### PR TITLE
Fix possible type mismatch with pykdtree.

### DIFF
--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -541,6 +541,10 @@ def _query_resample_kdtree(resample_kdtree, source_geo_def, target_geo_def,
     output_coords = cartesian.transform_lonlats(
         target_lons_valid, target_lats_valid)
 
+    # pykdtree requires query points have same data type as kdtree.
+    dt = resample_kdtree.data_pts.dtype
+    output_coords = np.asarray(output_coords, dtype=dt)
+
     # Query kd-tree
     distance_array, index_array = resample_kdtree.query(output_coords,
                                                         k=neighbours,

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -786,6 +786,18 @@ class Test(unittest.TestCase):
         self.assertTrue(numpy.array_equal(fill_mask, expected_fill_mask),
                         msg='Failed to create fill mask on masked data')
 
+    def test_dtype(self):
+        lons = numpy.fromfunction(lambda y, x: 3 + x, (50, 10))
+        lats = numpy.fromfunction(lambda y, x: 75 - y, (50, 10))
+        grid_def = geometry.GridDefinition(lons, lats)
+        lons = numpy.asarray(lons, dtype='f4')
+        lats  = numpy.asarray(lats, dtype='f4')
+        swath_def = geometry.SwathDefinition(lons=lons, lats=lats)
+        valid_input_index, valid_output_index, index_array, distance_array = \
+            kd_tree.get_neighbour_info(swath_def,
+                                       grid_def,
+                                       50000, neighbours=1, segments=1)
+
     def test_nearest_from_sample(self):
         data = numpy.fromfunction(lambda y, x: y * x, (50, 10))
         lons = numpy.fromfunction(lambda y, x: 3 + x, (50, 10))


### PR DESCRIPTION
I have a program that worked okay until I installed pykdtree.  It seems to be more picky about data types, so I added this one-line change to work around the problem.

Here's an example of a traceback I got illustrating the issue:

```
  File "/usr/local/lib/python2.7/site-packages/pyresample-1.1.5-py2.7.egg/pyresample/image.py", line 279, in resample
    segments=self.segments)
  File "/usr/local/lib/python2.7/site-packages/pyresample-1.1.5-py2.7.egg/pyresample/kd_tree.py", line 101, in resample_nearest
    reduce_data=reduce_data, nprocs=nprocs, segments=segments)
  File "/usr/local/lib/python2.7/site-packages/pyresample-1.1.5-py2.7.egg/pyresample/kd_tree.py", line 259, in _resample
    segments=segments)
  File "/usr/local/lib/python2.7/site-packages/pyresample-1.1.5-py2.7.egg/pyresample/kd_tree.py", line 350, in get_neighbour_info
    nprocs=nprocs)
  File "/usr/local/lib/python2.7/site-packages/pyresample-1.1.5-py2.7.egg/pyresample/kd_tree.py", line 548, in _query_resample_kdtree
    distance_upper_bound=radius_of_influence)
  File "kdtree.pyx", line 168, in pykdtree.kdtree.KDTree.query (pykdtree/kdtree.c:2137)
TypeError: Type mismatch. query points must be of type float32 when data points are of type float32
```