### PR TITLE
[tests] Skip deprecation warnings in test_gauss_multi_uncert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ before_install:
 - sudo apt-get install libfreetype6-dev
 - sudo apt-get install libgeos-3.3.8 libgeos-c1 libgeos-dev
 install:
+- if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install "matplotlib<1.5.0"; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install "matplotlib>=1.5.0"; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install "matplotlib<1.5.0"; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "3.4" ]]; then pip install "matplotlib>=1.5.0"; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install "matplotlib>=1.5.0"; fi
 - pip install -r requirements.txt
 - pip install -e ".[pykdtree]"
 - pip install coveralls

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -400,6 +400,13 @@ class Test(unittest.TestCase):
                                                          segments=1, with_uncert=True)
         else:
             with warnings.catch_warnings(record=True) as w:
+                # The assertion below checks if there is only one warning raised
+                # and whether it contains a specific message from pyresample
+                # On python 2.7.9+ the resample_gauss method raises multiple deprecation warnings
+                # that cause to fail, so we ignore the unrelated warnings.
+                # TODO: better way would be to filter UserWarning correctly
+                from numpy import VisibleDeprecationWarning
+                warnings.simplefilter('ignore', (DeprecationWarning, VisibleDeprecationWarning))
                 res, stddev, counts = kd_tree.resample_gauss(swath_def, data_multi,
                                                              self.area_def, 50000, [
                                                                  25000, 15000, 10000],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-git+https://github.com/matplotlib/matplotlib.git
 git+https://github.com/matplotlib/basemap.git


### PR DESCRIPTION
And catch the rest of the warnings. Check if there is only one warning collected, and
whether it contains the relevant message ('possible more than 8 neighbours found'). This patch is necessary for python 2.7.9 and newer