### PR TITLE
Fix Windows CI import Error

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   # target Python version and architecture
   - "conda update --yes conda"
   - "conda config --add channels https://conda.anaconda.org/ioos"
-  - "conda create -q --yes -n test python=%PYTHON_VERSION% basemap sphinx pyproj"
+  - "conda create -q --yes -n test python=%PYTHON_VERSION% basemap sphinx pyproj scipy"
   - "activate test"
   - "pip install coveralls"
   - "where python"


### PR DESCRIPTION
@davidh-ssec This fixes the import error. Scipy was not installed and the `ImportError: Either pykdtree or scipy must be available` was hidden in shell output.

The tests start to run now but a few still ERROR. See https://ci.appveyor.com/project/cpaulik/pyresample/build/1.0.8/job/hnuud6mc9yftxld2 or the build of this PR.