### PR TITLE
Fix build issue with g++ 5.4

### DIFF
--- a/pyresample/ewa/_fornav_templates.cpp
+++ b/pyresample/ewa/_fornav_templates.cpp
@@ -1,6 +1,6 @@
 #include "Python.h"
 #include <stddef.h>
-#include "math.h"
+#include <cmath>
 #include "numpy/arrayobject.h"
 #include "_fornav_templates.h"
 


### PR DESCRIPTION
Fixes a build failure on linux with g++ 5.4
```
pyresample/ewa/_fornav_templates.cpp:238:15: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if (iu2 >= grid_cols) {
               ^
pyresample/ewa/_fornav_templates.cpp:244:15: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if (iv2 >= grid_rows) {
               ^
pyresample/ewa/_fornav_templates.cpp:248:15: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if (iu1 < grid_cols && iu2 >= 0 && iv1 < grid_rows && iv2 >= 0) {
               ^
pyresample/ewa/_fornav_templates.cpp:248:46: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if (iu1 < grid_cols && iu2 >= 0 && iv1 < grid_rows && iv2 >= 0) {
                                              ^
In file included from /usr/include/python3.5m/pyport.h:328:0,
                 from /usr/include/python3.5m/Python.h:50,
                 from pyresample/ewa/_fornav_templates.cpp:1:
pyresample/ewa/_fornav_templates.cpp:275:52: error: non-floating-point argument in call to function '__builtin_isnan'
                     if ((this_val == img_fill) || (isnan(this_val))) {
                                                    ^
pyresample/ewa/_fornav_templates.cpp:282:51: error: non-floating-point argument in call to function '__builtin_isnan'
                   if ((this_val != img_fill) && !(isnan(this_val))) {
                                                   ^
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```