### PR TITLE
Specify minimum version of setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 version = imp.load_source('pyresample.version', 'pyresample/version.py')
 
-requirements = ['pyproj', 'numpy', 'configobj', 'pykdtree>=1.1.1']
+requirements = ['setuptools>=3.2', 'pyproj', 'numpy', 'configobj', 'pykdtree>=1.1.1']
 extras_require = {'pykdtree': ['pykdtree>=1.1.1'],
                   'numexpr': ['numexpr'],
                   'quicklook': ['matplotlib', 'basemap', 'pillow']}


### PR DESCRIPTION
Prior to version 3.2 setuptools would not recognize correctly the language of `*.cpp` extensions and would assume it's `*.c` no matter what. Version 3.2 of setuptools fixes that.