### PR TITLE
Fix numpy 1.13 compatibility

### DIFF
--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -807,11 +807,22 @@ def get_sample_from_neighbour_info(resample_type, output_shape, data,
 
             # Calculate final stddev
             new_valid_index = (count > 1)
-            v1 = norm[new_valid_index]
-            v2 = norm_sqr[new_valid_index]
-            stddev[new_valid_index] = np.sqrt(
-                (v1 / (v1 ** 2 - v2)) * stddev[new_valid_index])
-            stddev[~new_valid_index] = np.NaN
+            if stddev.ndim >= 2:
+                # If given more than 1 input data array
+                new_valid_index = new_valid_index[:, 0]
+                for i in range(stddev.shape[-1]):
+                    v1 = norm[new_valid_index, i]
+                    v2 = norm_sqr[new_valid_index, i]
+                    stddev[new_valid_index, i] = np.sqrt(
+                        (v1 / (v1 ** 2 - v2)) * stddev[new_valid_index, i])
+                    stddev[~new_valid_index, i] = np.NaN
+            else:
+                # If given single input data array
+                v1 = norm[new_valid_index]
+                v2 = norm_sqr[new_valid_index]
+                stddev[new_valid_index] = np.sqrt(
+                    (v1 / (v1 ** 2 - v2)) * stddev[new_valid_index])
+                stddev[~new_valid_index] = np.NaN
 
         # Add fill values
         result[np.invert(result_valid_index)] = fill_value

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -4,13 +4,18 @@ import random
 import sys
 
 import numpy as np
-from mock import MagicMock, patch
 
 from pyresample import geo_filter, geometry
 from pyresample.geometry import (IncompatibleAreas,
                                  combine_area_extents_vertical,
                                  concatenate_area_defs)
 from pyresample.test.utils import catch_warnings
+
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    # separate mock package py<3.3
+    from mock import MagicMock, patch
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -345,17 +345,19 @@ class Test(unittest.TestCase):
             self.assertTrue(any(['Possible more' in str(
                 x.message) for x in w]), 'Failed to create correct neighbour radius warning')
         cross_sum = res.sum()
-        cross_sum_stddev = stddev.sum()
         cross_sum_counts = counts.sum()
         expected = 1461.84313918
-        expected_stddev = 0.446204424799
+        expected_stddev = [0.446193170875, 0.443606880035, 0.438586349519]
         expected_counts = 4934802.0
         self.assertTrue(res.shape == stddev.shape and stddev.shape ==
                         counts.shape and counts.shape == (800, 800, 3))
         self.assertAlmostEqual(cross_sum, expected,
                                msg='Swath multi channel resampling gauss failed on data')
-        self.assertAlmostEqual(cross_sum_stddev, expected_stddev,
-                               msg='Swath multi channel resampling gauss failed on stddev')
+        for i, e_stddev in enumerate(expected_stddev):
+            cross_sum_stddev = stddev[:, :, i].sum()
+            print(cross_sum_stddev, e_stddev)
+            self.assertAlmostEqual(cross_sum_stddev, e_stddev,
+                                   msg='Swath multi channel resampling gauss failed on stddev (channel {})'.format(i))
         self.assertAlmostEqual(cross_sum_counts, expected_counts,
                                msg='Swath multi channel resampling gauss failed on counts')
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ extras_require = {'pykdtree': ['pykdtree>=1.1.1'],
                   'numexpr': ['numexpr'],
                   'quicklook': ['matplotlib', 'basemap', 'pillow']}
 
+test_requires = []
+if sys.version_info < (3, 3):
+    test_requires.append('mock')
 if sys.version_info < (2, 6):
     # multiprocessing is not in the standard library
     requirements.append('multiprocessing')
@@ -110,6 +113,7 @@ if __name__ == "__main__":
           setup_requires=['numpy'],
           install_requires=requirements,
           extras_require=extras_require,
+          test_requires=test_requires,
           cmdclass={'build_ext': build_ext},
           ext_modules=cythonize(extensions),
           test_suite='pyresample.test.suite',


### PR DESCRIPTION
In numpy 1.13 it is illegal to index an array with a boolean array of a different size. In `kd_tree.py:get_sample_from_neighbour_info` there is a count array of shape `(N * M, 1)`. When resampling is passed multiple channel arrays `(N, M, 3)` the standard deviation and other related arrays have shape `(N * M, 3)`. When passed a single channel they are `(N * M,)`. The count array is used to index in to these stddev and other arrays. In 1.13 this causes an error.

Previously the indexing looked like `v1 = norm[new_valid_index]` which converted a `(N * M, 3)` array in to a `(N * M,)` array by taking only the first channel. This is equivalent to `v1 = norm[new_valid_index, 0]` and is reflected in these fixes.

This PR should fix all of these issues. It also does additional testing on the stddev results in the `test_gauss_multi_uncert` test. NOTE: The standard deviation in early versions of numpy would have very small values for the second and third channels. This fix changes the result of the `stddev.sum()` of the first channel by a little bit because it is not including the small values from those other channels.