### PR TITLE
Fix GridDefinition as permitted definition in preprocessing utils

### DIFF
--- a/pyresample/test/test_ewa_ll2cr.py
+++ b/pyresample/test/test_ewa_ll2cr.py
@@ -24,34 +24,13 @@
 import sys
 import logging
 import numpy as np
+from pyresample.test.utils import create_test_longitude, create_test_latitude
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
 
 LOG = logging.getLogger(__name__)
-
-
-def create_test_longitude(start, stop, shape, twist_factor=0.0, dtype=np.float32):
-    if start > stop:
-        stop += 360.0
-
-    lon_row = np.linspace(start, stop, num=shape[1]).astype(dtype)
-    twist_array = np.arange(shape[0]).reshape((shape[0], 1)) * twist_factor
-    lon_array = np.repeat([lon_row], shape[0], axis=0)
-    lon_array += twist_array
-
-    if stop > 360.0:
-        lon_array[lon_array > 360.0] -= 360
-    return lon_array
-
-
-def create_test_latitude(start, stop, shape, twist_factor=0.0, dtype=np.float32):
-    lat_col = np.linspace(start, stop, num=shape[0]).astype(dtype).reshape((shape[0], 1))
-    twist_array = np.arange(shape[1]) * twist_factor
-    lat_array = np.repeat(lat_col, shape[1], axis=1)
-    lat_array += twist_array
-    return lat_array
 
 
 dynamic_wgs84 = {

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -131,11 +131,11 @@ class TestPreprocessing(unittest.TestCase):
         proj_dict = utils.proj4_str_to_dict(proj_str)
         extents = [0, 0, 1000. * 5000, 1000. * 5000]
         area_def = geometry.AreaDefinition('CONUS', 'CONUS', 'CONUS',
-                                           proj_dict, 500, 500, extents)
+                                           proj_dict, 400, 500, extents)
 
         extents2 = [-1000, -1000, 1000. * 4000, 1000. * 4000]
         area_def2 = geometry.AreaDefinition('CONUS', 'CONUS', 'CONUS',
-                                           proj_dict, 700, 700, extents2)
+                                           proj_dict, 600, 700, extents2)
         rows, cols = utils.generate_nearest_neighbour_linesample_arrays(area_def, area_def2, 12000.)
 
     def test_nearest_neighbor_area_grid(self):
@@ -148,30 +148,30 @@ class TestPreprocessing(unittest.TestCase):
         proj_dict = utils.proj4_str_to_dict(proj_str)
         extents = [0, 0, 1000. * 5000, 1000. * 5000]
         area_def = geometry.AreaDefinition('CONUS', 'CONUS', 'CONUS',
-                                           proj_dict, 500, 500, extents)
+                                           proj_dict, 400, 500, extents)
         rows, cols = utils.generate_nearest_neighbour_linesample_arrays(area_def, grid, 12000.)
 
     def test_nearest_neighbor_grid_area(self):
         from pyresample import utils, geometry
         proj_str = "+proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs"
         proj_dict = utils.proj4_str_to_dict(proj_str)
-        extents = [0, 0, 1000., 1000.]
+        extents = [0, 0, 1000. * 2500., 1000. * 2000.]
         area_def = geometry.AreaDefinition('CONUS', 'CONUS', 'CONUS',
-                                           proj_dict, 50, 50, extents)
+                                           proj_dict, 40, 50, extents)
 
-        lon_arr = create_test_longitude(-100.0, -80.0, (500, 500), dtype=np.float64)
-        lat_arr = create_test_latitude(20.0, 40.0, (500, 500), dtype=np.float64)
+        lon_arr = create_test_longitude(-100.0, -60.0, (550, 500), dtype=np.float64)
+        lat_arr = create_test_latitude(20.0, 45.0, (550, 500), dtype=np.float64)
         grid = geometry.GridDefinition(lons=lon_arr, lats=lat_arr)
         rows, cols = utils.generate_nearest_neighbour_linesample_arrays(grid, area_def, 12000.)
 
     def test_nearest_neighbor_grid_grid(self):
         from pyresample import utils, geometry
-        lon_arr = create_test_longitude(-95.0, -85.0, (50, 50), dtype=np.float64)
-        lat_arr = create_test_latitude(25.0, 35.0, (50, 50), dtype=np.float64)
+        lon_arr = create_test_longitude(-95.0, -85.0, (40, 50), dtype=np.float64)
+        lat_arr = create_test_latitude(25.0, 35.0, (40, 50), dtype=np.float64)
         grid_dst = geometry.GridDefinition(lons=lon_arr, lats=lat_arr)
 
-        lon_arr = create_test_longitude(-100.0, -80.0, (500, 500), dtype=np.float64)
-        lat_arr = create_test_latitude(20.0, 40.0, (500, 500), dtype=np.float64)
+        lon_arr = create_test_longitude(-100.0, -80.0, (400, 500), dtype=np.float64)
+        lat_arr = create_test_latitude(20.0, 40.0, (400, 500), dtype=np.float64)
         grid = geometry.GridDefinition(lons=lon_arr, lats=lat_arr)
         rows, cols = utils.generate_nearest_neighbour_linesample_arrays(grid, grid_dst, 12000.)
 

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -140,8 +140,8 @@ class TestPreprocessing(unittest.TestCase):
 
     def test_nearest_neighbor_area_grid(self):
         from pyresample import utils, geometry
-        lon_arr = create_test_longitude(-94.9, -94.0, (50, 100), dtype=np.float64)
-        lat_arr = create_test_latitude(25.1, 26.0, (50, 100), dtype=np.float64)
+        lon_arr = create_test_longitude(-94.9, -90.0, (50, 100), dtype=np.float64)
+        lat_arr = create_test_latitude(25.1, 30.0, (50, 100), dtype=np.float64)
         grid = geometry.GridDefinition(lons=lon_arr, lats=lat_arr)
 
         proj_str = "+proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs"
@@ -150,6 +150,30 @@ class TestPreprocessing(unittest.TestCase):
         area_def = geometry.AreaDefinition('CONUS', 'CONUS', 'CONUS',
                                            proj_dict, 500, 500, extents)
         rows, cols = utils.generate_nearest_neighbour_linesample_arrays(area_def, grid, 12000.)
+
+    def test_nearest_neighbor_grid_area(self):
+        from pyresample import utils, geometry
+        proj_str = "+proj=lcc +datum=WGS84 +ellps=WGS84 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs"
+        proj_dict = utils.proj4_str_to_dict(proj_str)
+        extents = [0, 0, 1000., 1000.]
+        area_def = geometry.AreaDefinition('CONUS', 'CONUS', 'CONUS',
+                                           proj_dict, 50, 50, extents)
+
+        lon_arr = create_test_longitude(-100.0, -80.0, (500, 500), dtype=np.float64)
+        lat_arr = create_test_latitude(20.0, 40.0, (500, 500), dtype=np.float64)
+        grid = geometry.GridDefinition(lons=lon_arr, lats=lat_arr)
+        rows, cols = utils.generate_nearest_neighbour_linesample_arrays(grid, area_def, 12000.)
+
+    def test_nearest_neighbor_grid_grid(self):
+        from pyresample import utils, geometry
+        lon_arr = create_test_longitude(-95.0, -85.0, (50, 50), dtype=np.float64)
+        lat_arr = create_test_latitude(25.0, 35.0, (50, 50), dtype=np.float64)
+        grid_dst = geometry.GridDefinition(lons=lon_arr, lats=lat_arr)
+
+        lon_arr = create_test_longitude(-100.0, -80.0, (500, 500), dtype=np.float64)
+        lat_arr = create_test_latitude(20.0, 40.0, (500, 500), dtype=np.float64)
+        grid = geometry.GridDefinition(lons=lon_arr, lats=lat_arr)
+        rows, cols = utils.generate_nearest_neighbour_linesample_arrays(grid, grid_dst, 12000.)
 
 
 class TestMisc(unittest.TestCase):

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -25,6 +25,7 @@ import six
 import types
 import warnings
 
+import numpy as np
 
 _deprecations_as_exceptions = False
 _include_astropy_deprecations = False
@@ -150,4 +151,25 @@ class catch_warnings(warnings.catch_warnings):
     def __exit__(self, type, value, traceback):
         treat_deprecations_as_exceptions()
 
+
+def create_test_longitude(start, stop, shape, twist_factor=0.0, dtype=np.float32):
+    if start > stop:
+        stop += 360.0
+
+    lon_row = np.linspace(start, stop, num=shape[1]).astype(dtype)
+    twist_array = np.arange(shape[0]).reshape((shape[0], 1)) * twist_factor
+    lon_array = np.repeat([lon_row], shape[0], axis=0)
+    lon_array += twist_array
+
+    if stop > 360.0:
+        lon_array[lon_array > 360.0] -= 360
+    return lon_array
+
+
+def create_test_latitude(start, stop, shape, twist_factor=0.0, dtype=np.float32):
+    lat_col = np.linspace(start, stop, num=shape[0]).astype(dtype).reshape((shape[0], 1))
+    twist_array = np.arange(shape[1]) * twist_factor
+    lat_array = np.repeat(lat_col, shape[1], axis=1)
+    lat_array += twist_array
+    return lat_array
 

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -278,9 +278,9 @@ def generate_quick_linesample_arrays(source_area_def, target_area_def, nprocs=1)
     Parameters
     -----------
     source_area_def : object
-        Source area definition as AreaDefinition object
+        Source area definition as geometry definition object
     target_area_def : object
-        Target area definition as AreaDefinition object
+        Target area definition as geometry definition object
     nprocs : int, optional
         Number of processor cores to be used
 
@@ -288,12 +288,6 @@ def generate_quick_linesample_arrays(source_area_def, target_area_def, nprocs=1)
     -------
     (row_indices, col_indices) : tuple of numpy arrays
     """
-    geo_def_cls = (pr.geometry.GridDefinition, pr.geometry.AreaDefinition)
-    if not (isinstance(source_area_def, geo_def_cls) and
-            isinstance(target_area_def, geo_def_cls)):
-        raise TypeError('source_area_def and target_area_def must be of type '
-                        'geometry.AreaDefinition or geometry.GridDefinition')
-
     lons, lats = target_area_def.get_lonlats(nprocs)
 
     source_pixel_y, source_pixel_x = pr.grid.get_linesample(lons, lats,
@@ -315,9 +309,9 @@ def generate_nearest_neighbour_linesample_arrays(source_area_def, target_area_de
     Parameters
     -----------
     source_area_def : object
-        Source area definition as AreaDefinition object
+        Source area definition as geometry definition object
     target_area_def : object
-        Target area definition as AreaDefinition object
+        Target area definition as geometry definition object
     radius_of_influence : float
         Cut off distance in meters
     nprocs : int, optional
@@ -327,12 +321,6 @@ def generate_nearest_neighbour_linesample_arrays(source_area_def, target_area_de
     -------
     (row_indices, col_indices) : tuple of numpy arrays
     """
-
-    geo_def_cls = (pr.geometry.GridDefinition, pr.geometry.AreaDefinition)
-    if not (isinstance(source_area_def, geo_def_cls) and
-                isinstance(target_area_def, geo_def_cls)):
-        raise TypeError('source_area_def and target_area_def must be of type '
-                        'geometry.AreaDefinition or geometry.GridDefinition')
 
     valid_input_index, valid_output_index, index_array, distance_array = \
         pr.kd_tree.get_neighbour_info(source_area_def,

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -288,10 +288,11 @@ def generate_quick_linesample_arrays(source_area_def, target_area_def, nprocs=1)
     -------
     (row_indices, col_indices) : tuple of numpy arrays
     """
-    if not (isinstance(source_area_def, pr.geometry.AreaDefinition) and
-            isinstance(target_area_def, pr.geometry.AreaDefinition)):
+    geo_def_cls = (pr.geometry.GridDefinition, pr.geometry.AreaDefinition)
+    if not (isinstance(source_area_def, geo_def_cls) and
+            isinstance(target_area_def, geo_def_cls)):
         raise TypeError('source_area_def and target_area_def must be of type '
-                        'geometry.AreaDefinition')
+                        'geometry.AreaDefinition or geometry.GridDefinition')
 
     lons, lats = target_area_def.get_lonlats(nprocs)
 
@@ -327,10 +328,11 @@ def generate_nearest_neighbour_linesample_arrays(source_area_def, target_area_de
     (row_indices, col_indices) : tuple of numpy arrays
     """
 
-    if not (isinstance(source_area_def, pr.geometry.AreaDefinition) and
-            isinstance(target_area_def, pr.geometry.AreaDefinition)):
+    geo_def_cls = (pr.geometry.GridDefinition, pr.geometry.AreaDefinition)
+    if not (isinstance(source_area_def, geo_def_cls) and
+                isinstance(target_area_def, geo_def_cls)):
         raise TypeError('source_area_def and target_area_def must be of type '
-                        'geometry.AreaDefinition')
+                        'geometry.AreaDefinition or geometry.GridDefinition')
 
     valid_input_index, valid_output_index, index_array, distance_array = \
         pr.kd_tree.get_neighbour_info(source_area_def,


### PR DESCRIPTION
Fix #56.

Questions:

1. Should `SwathDefinition` be allowed too?
2. See #56 for my questions about what the expected use of these functions is. Does the target have to be a subset of the source?

TODO:

1. Fix docstring in functions
