### PR TITLE
Add 'proj4_radius_parameters' to calculate 'a' and 'b' from ellps

### DIFF
--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -137,6 +137,31 @@ class TestMisc(unittest.TestCase):
                            u'+proj=stere +a=6378273 +b=6356889.44891 +lat_0=90 +lat_ts=70 +lon_0=-45',
                            1000, 1000, (-1000, -1000, 1000, 1000))
 
+    def test_proj4_radius_parameters_provided(self):
+        from pyresample import utils
+        a, b = utils.proj4_radius_parameters(
+            '+proj=stere +a=6378273 +b=6356889.44891',
+        )
+        np.testing.assert_almost_equal(a, 6378273)
+        np.testing.assert_almost_equal(b, 6356889.44891)
+
+    def test_proj4_radius_parameters_ellps(self):
+        from pyresample import utils
+        a, b = utils.proj4_radius_parameters(
+            '+proj=stere +ellps=WGS84',
+        )
+        np.testing.assert_almost_equal(a, 6378137.)
+        np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
+
+    def test_proj4_radius_parameters_default(self):
+        from pyresample import utils
+        a, b = utils.proj4_radius_parameters(
+            '+proj=lcc',
+        )
+        # WGS84
+        np.testing.assert_almost_equal(a, 6378137.)
+        np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
+
 
 def suite():
     """The test suite.

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -407,21 +407,24 @@ def proj4_str_to_dict(proj4_str):
     return dict((x[0], (x[1] if len(x) == 2 else True)) for x in pairs)
 
 
-def proj4_radius_parameters(proj4_dict_or_str):
+def proj4_radius_parameters(proj4_dict):
     """Calculate 'a' and 'b' radius parameters.
+
+    Arguments:
+        proj4_dict (str or dict): PROJ.4 parameters
 
     Returns:
         a (float), b (float): equatorial and polar radius
     """
-    if isinstance(proj4_dict_or_str, str):
-        new_info = proj4_str_to_dict(proj4_dict_or_str)
+    if isinstance(proj4_dict, str):
+        new_info = proj4_str_to_dict(proj4_dict)
     else:
-        new_info = proj4_dict_or_str.copy()
+        new_info = proj4_dict.copy()
 
     # load information from PROJ.4 about the ellipsis if possible
-    if '+ellps' in new_info and '+a' not in new_info or '+b' not in new_info:
+    if '+a' not in new_info or '+b' not in new_info:
         import pyproj
-        ellps = pyproj.pj_ellps[new_info['+ellps']]
+        ellps = pyproj.pj_ellps[new_info.get('+ellps', 'WGS84')]
         new_info['+a'] = ellps['a']
         if 'b' not in ellps and 'rf' in ellps:
             new_info['+f'] = 1. / ellps['rf']

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -414,7 +414,7 @@ def proj4_radius_parameters(proj4_dict_or_str):
         a (float), b (float): equatorial and polar radius
     """
     if isinstance(proj4_dict_or_str, str):
-        new_info = proj4_dict_or_str(proj4_dict_or_str)
+        new_info = proj4_str_to_dict(proj4_dict_or_str)
     else:
         new_info = proj4_dict_or_str.copy()
 


### PR DESCRIPTION
In my SCMI NetCDF4 writer that I'm making for satpy (https://github.com/pytroll/satpy/pull/67) I need access to the PROJ.4 `a` and `b` parameters (equatorial and polar radius) of the dataset being remapped. However, if a PROJ.4 string/dict is specified using a datum and ellps the `a` and `b` parameters are not easily accessible. This PR adds a utility function for checking pyproj for the ellipsoid parameters and computed `a` and `b` from them if needed.