### PR TITLE
Fix bil mask deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'
@@ -13,8 +12,6 @@ before_install:
 install:
 - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install "matplotlib>=1.5.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install "sphinx>=1.5.0"; fi
-- if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install "matplotlib<1.5.0"; fi
-- if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install "sphinx<1.5.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "3.4" ]]; then pip install "matplotlib>=1.5.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "3.4" ]]; then pip install "sphinx>=1.5.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install "matplotlib>=1.5.0"; fi

--- a/pyresample/bilinear/__init__.py
+++ b/pyresample/bilinear/__init__.py
@@ -30,6 +30,7 @@ http://www.ahinson.com/algorithms_general/Sections/InterpolationRegression/Inter
 
 import numpy as np
 from pyproj import Proj
+import warnings
 
 from pyresample import kd_tree
 
@@ -210,11 +211,13 @@ def get_bil_info(source_geo_def, target_area_def, radius=50e3, neighbours=32,
     #     source_geo_def = SwathDefinition(lons, lats)
 
     # Calculate neighbour information
-    (input_idxs, output_idxs, idx_ref, dists) = \
-        kd_tree.get_neighbour_info(source_geo_def, target_area_def,
-                                   radius, neighbours=neighbours,
-                                   nprocs=nprocs, reduce_data=reduce_data,
-                                   segments=segments, epsilon=epsilon)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        (input_idxs, output_idxs, idx_ref, dists) = \
+            kd_tree.get_neighbour_info(source_geo_def, target_area_def,
+                                       radius, neighbours=neighbours,
+                                       nprocs=nprocs, reduce_data=reduce_data,
+                                       segments=segments, epsilon=epsilon)
 
     del output_idxs, dists
 

--- a/pyresample/bilinear/__init__.py
+++ b/pyresample/bilinear/__init__.py
@@ -389,8 +389,14 @@ def _mask_coordinates(lons, lats):
     lats = lats.ravel()
     idxs = ((lons < -180.) | (lons > 180.) |
             (lats < -90.) | (lats > 90.))
-    lons[idxs] = np.nan
-    lats[idxs] = np.nan
+    if hasattr(lons, 'mask'):
+        lons = np.ma.masked_where(idxs | lons.mask, lons)
+    else:
+        lons[idxs] = np.nan
+    if hasattr(lats, 'mask'):
+        lats = np.ma.masked_where(idxs | lats.mask, lats)
+    else:
+        lats[idxs] = np.nan
 
     return lons, lats
 


### PR DESCRIPTION
This PR fixes how the invalid coordinates were handled in bilinear interpolation, indicated by deprecation warning raised by Numpy. If there's a better way of doing this (compare to the original version), I'm happy to update the PR.

Also UserWarning about possible extra neighbours inside search radius is now suppressed, as the number of retrieved neighbours is more or less static.
