### PR TITLE
Fix example data for BIL, clarify text and add missing output_shape p…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,22 @@ before_install:
 - sudo apt-get install libfreetype6-dev
 - sudo apt-get install libgeos-dev
 install:
-- if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install "matplotlib>=1.5.0"; fi
+# matplotlib 2.1.0 has a bug that causes plotting masked arrays to fail
+# https://github.com/matplotlib/matplotlib/issues/9280
+- if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install "matplotlib>=1.5.0,!=2.1.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install "sphinx>=1.5.0"; fi
-- if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install "matplotlib<1.5.0"; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install "matplotlib<1.5.0,!=2.1.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install "sphinx<1.5.0"; fi
-- if [[ $TRAVIS_PYTHON_VERSION == "3.4" ]]; then pip install "matplotlib>=1.5.0"; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "3.4" ]]; then pip install "matplotlib>=1.5.0,!=2.1.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "3.4" ]]; then pip install "sphinx>=1.5.0"; fi
-- if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install "matplotlib>=1.5.0"; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install "matplotlib>=1.5.0,!=2.1.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install "sphinx>=1.5.0"; fi
-- if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install "matplotlib>=1.5.0"; fi
+- if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install "matplotlib>=1.5.0,!=2.1.0"; fi
 - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install "sphinx>=1.5.0"; fi
 - pip install -r requirements.txt
 - pip install -e ".[pykdtree,quicklook]"
 - pip install coveralls
 script:
-# Once doctests pass this should be uncommented to replace the other coverage run line
 - coverage run --source=pyresample setup.py test && cd docs && mkdir doctest && sphinx-build -E -n -b doctest ./source ./doctest && cd ..
 after_success: coveralls
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,13 +28,13 @@ environment:
       PYTHON_ARCH: "64"
       MINICONDA_VERSION: "3"
 
-    - PYTHON: "C:\\Python35_32"
-      PYTHON_VERSION: "3.5"
+    - PYTHON: "C:\\Python36_32"
+      PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "32"
       MINICONDA_VERSION: "3"
 
-    - PYTHON: "C:\\Python35_64"
-      PYTHON_VERSION: "3.5"
+    - PYTHON: "C:\\Python36_64"
+      PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       MINICONDA_VERSION: "3"
 
@@ -88,8 +88,3 @@ artifacts:
 #on_success:
 #  - TODO: upload the content of dist/*.whl to a public wheelhouse
 #
-
-notifications:
-  - provider: Slack
-    incoming_webhook:
-      secure: 7bEOYCIxHE5PkCF156zjxbJIeKkv7UpZulyn+Di09jqDlpvZjR0Qj3a1LK9AOjgwWgaQYbeI4BEYEdeq7pPxDs9snK8qvvbFDbuLAzg+HEQ=

--- a/docs/source/swath.rst
+++ b/docs/source/swath.rst
@@ -282,9 +282,9 @@ Function for resampling using bilinear interpolation for irregular source grids.
  ...                                      800, 800,
  ...                                      [-1370912.72, -909968.64,
  ...                                       1029087.28, 1490031.36])
- >>> data = np.fromfunction(lambda y, x: y*x, (50, 10))
- >>> lons = np.fromfunction(lambda y, x: 3 + x, (50, 10))
- >>> lats = np.fromfunction(lambda y, x: 75 - y, (50, 10))
+ >>> data = np.fromfunction(lambda y, x: y*x, (500, 100))
+ >>> lons = np.fromfunction(lambda y, x: 3 + x * 0.1, (500, 100))
+ >>> lats = np.fromfunction(lambda y, x: 75 - y * 0.1, (500, 100))
  >>> source_def = geometry.SwathDefinition(lons=lons, lats=lats)
  >>> result = bilinear.resample_bilinear(data, source_def, target_def,
  ...                                     radius=50e3, neighbours=32,
@@ -304,7 +304,8 @@ Keyword arguments which are passed to **kd_tree**:
 * **radius**: radius around each target pixel in meters to search for
   neighbours in the source data
 * **neighbours**: number of closest locations to consider when
-  selecting the four data points around the target pixel
+  selecting the four data points around the target location.  Note that this 
+  value needs to be large enough to ensure "surrounding" the target!
 * **nprocs**: number of processors to use for finding the closest pixels
 * **fill_value**: fill invalid pixel with this value.  If
   **fill_value=None** is used, masked arrays will be returned
@@ -332,7 +333,9 @@ significantly.  This is also done internally by the
 **resample_bilinear** function, but separating these steps makes it
 possible to cache the coefficients if the same transformation is done
 over and over again.  This is very typical in operational
-geostationary satellite image processing.
+geostationary satellite image processing.  Note that the output shape is now 
+defined so that the result is reshaped to correct shape.  This reshaping 
+is done internally in **resample_bilinear**.
 
 .. doctest::
 
@@ -353,7 +356,8 @@ geostationary satellite image processing.
  >>> t_params, s_params, input_idxs, idx_ref = \
  ...     bilinear.get_bil_info(source_def, target_def, radius=50e3, nprocs=1)
  >>> res = bilinear.get_sample_from_bil_info(data.ravel(), t_params, s_params,
- ...                                         input_idxs, idx_ref)
+ ...                                         input_idxs, idx_ref,
+ ...                                         output_shape=target_def.shape)
 
 
 pyresample.ewa

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -630,7 +630,7 @@ class DynamicAreaDefinition(object):
             domain = self.compute_domain(corners, resolution, size)
             self.area_extent, self.x_size, self.y_size = domain
 
-        return AreaDefinition(self.area_id, self.description, None,
+        return AreaDefinition(self.area_id, self.description, '',
                               self.proj_dict, self.x_size, self.y_size,
                               self.area_extent)
 
@@ -759,6 +759,10 @@ class AreaDefinition(BaseDefinition):
 
         self.dtype = dtype
 
+    @property
+    def proj_str(self):
+        return utils.proj4_dict_to_str(self.proj_dict, sort=True)
+
     def __str__(self):
         # We need a sorted dictionary for a unique hash of str(self)
         proj_dict = self.proj_dict
@@ -767,7 +771,7 @@ class AreaDefinition(BaseDefinition):
                                for k in sorted(proj_dict.keys())]) +
                     '}')
 
-        if self.proj_id is None:
+        if not self.proj_id:
             third_line = ""
         else:
             third_line = "Projection ID: {0}\n".format(self.proj_id)
@@ -1077,17 +1081,9 @@ class AreaDefinition(BaseDefinition):
                 cols = 1
 
         # Calculate coordinates
-        target_x = np.fromfunction(lambda i, j: (j + col_start) *
-                                   self.pixel_size_x +
-                                   self.pixel_upper_left[0],
-                                   (rows,
-                                    cols), dtype=dtype)
-
-        target_y = np.fromfunction(lambda i, j:
-                                   self.pixel_upper_left[1] -
-                                   (i + row_start) * self.pixel_size_y,
-                                   (rows,
-                                    cols), dtype=dtype)
+        target_x = np.arange(col_start, col_start + cols, dtype=dtype) * self.pixel_size_x + self.pixel_upper_left[0]
+        target_y = np.arange(row_start, row_start + rows, dtype=dtype) * -self.pixel_size_y + self.pixel_upper_left[1]
+        target_x, target_y = np.meshgrid(target_x, target_y)
 
         if is_single_value:
             # Return single values

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -221,6 +221,14 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(a, 6378137.)
         np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
 
+    def test_proj4_str_dict_conversion(self):
+        from pyresample import utils
+        proj_str = "+proj=lcc +ellps=WGS84 +lon_0=-95 +no_defs"
+        proj_dict = utils.proj4_str_to_dict(proj_str)
+        proj_str2 = utils.proj4_dict_to_str(proj_dict)
+        proj_dict2 = utils.proj4_str_to_dict(proj_str2)
+        self.assertDictEqual(proj_dict, proj_dict2)
+
 
 def suite():
     """The test suite.

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -415,6 +415,27 @@ def proj4_str_to_dict(proj4_str):
     return dict((x[0], (x[1] if len(x) == 2 else True)) for x in pairs)
 
 
+def proj4_dict_to_str(proj4_dict, sort=False):
+    """Convert a dictionary of PROJ.4 parameters to a valid PROJ.4 string"""
+    keys = proj4_dict.keys()
+    if sort:
+        keys = sorted(keys)
+    params = []
+    for key in keys:
+        val = proj4_dict[key]
+        key = str(key) if key.startswith('+') else '+' + str(key)
+        if str(val) in ['True', 'False']:
+            # could be string or boolean object
+            val = ''
+        if val:
+            param = '{}={}'.format(key, val)
+        else:
+            # example "+no_defs"
+            param = key
+        params.append(param)
+    return ' '.join(params)
+
+
 def proj4_radius_parameters(proj4_dict):
     """Calculate 'a' and 'b' radius parameters.
 


### PR DESCRIPTION
This PR fixes too sparse data in documentation examples for bilinear interpolation, and also clarifies the text and adds an unlisted `output_shape` parameter in `bilinear.get_sample_from_bil_info()`.