### PR TITLE
Fix output shape of resample_bilinear()

### DIFF
--- a/pyresample/bilinear/__init__.py
+++ b/pyresample/bilinear/__init__.py
@@ -98,6 +98,12 @@ def resample_bilinear(data, source_geo_def, target_area_def, radius=50e3,
     else:
         result[np.isnan(result)] = fill_value
 
+    # Reshape to target area shape
+    shp = target_area_def.shape
+    result = result.reshape((shp[0], shp[1], data.shape[1]))
+    # Remove extra dimensions
+    result = np.squeeze(result)
+
     return result
 
 

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -207,7 +207,7 @@ class Test(unittest.TestCase):
         res = bil.resample_bilinear(self.data1,
                                     self.swath_def,
                                     self.target_def)
-        self.assertEqual(res.size, self.target_def.size)
+        self.assertEqual(res.shape, self.target_def.shape)
         # There should be only one pixel with value 1, all others are 0
         self.assertEqual(res.sum(), 1)
 
@@ -225,8 +225,8 @@ class Test(unittest.TestCase):
                                     self.swath_def,
                                     self.target_def)
         shp = res.shape
-        self.assertEqual(shp[0], self.target_def.size)
-        self.assertEqual(shp[1], 2)
+        self.assertEqual(shp[0:2], self.target_def.shape)
+        self.assertEqual(shp[-1], 2)
 
 
 def suite():


### PR DESCRIPTION
This PR reshapes the output data to correspond to target area definition and the number of "channels"/datasets that are resampled.

Fixes #72