### PR TITLE
Fix masks in grid.get_resampled_image

### DIFF
--- a/pyresample/grid.py
+++ b/pyresample/grid.py
@@ -236,7 +236,7 @@ def get_resampled_image(target_area_def, source_area_def, source_image_data,
                 # First iteration
                 result = next_result
             else:
-                result = np.row_stack((result, next_result))
+                result = np.ma.row_stack((result, next_result))
 
         return result
     else:

--- a/pyresample/grid.py
+++ b/pyresample/grid.py
@@ -236,7 +236,11 @@ def get_resampled_image(target_area_def, source_area_def, source_image_data,
                 # First iteration
                 result = next_result
             else:
-                result = np.ma.row_stack((result, next_result))
+                if isinstance(next_result, np.ma.core.MaskedArray):
+                    stack = np.ma.row_stack
+                else:
+                    stack = np.row_stack
+                result = stack((result, next_result))
 
         return result
     else:

--- a/pyresample/test/test_grid.py
+++ b/pyresample/test/test_grid.py
@@ -152,6 +152,22 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(
             cross_sum, expected, msg='Resampling of image failed')
 
+    def test_resampled_image_masked(self):
+        # Generate test image with masked elements
+        data = np.ma.ones(self.msg_area.shape)
+        data.mask = np.zeros(data.shape)
+        data.mask[253:400, 1970:2211] = 1
+
+        # Resample image using multiple segments
+        target_def = self.area_def
+        source_def = self.msg_area
+        res = grid.get_resampled_image(
+            target_def, source_def, data, segments=4, fill_value=None)
+
+        # Make sure the mask has been preserved
+        self.assertGreater(res.mask.sum(), 0,
+                           msg='Resampling did not preserve the mask')
+
     @tmp
     def test_generate_linesample(self):
         data = np.fromfunction(lambda y, x: y * x * 10 ** -6, (3712, 3712))


### PR DESCRIPTION
Fix #87 

Use numpy.ma version of row_stack to prevent loosing the mask of large images (rows > cut_off).

