### PR TITLE
Add dask extra to setup.py to specify minimum dask version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = ['setuptools>=3.2', 'pyproj', 'numpy', 'configobj',
 extras_require = {'pykdtree': ['pykdtree>=1.1.1'],
                   'numexpr': ['numexpr'],
                   'quicklook': ['matplotlib', 'basemap', 'pillow'],
-                  'dask': ['dask>=1.9']}
+                  'dask': ['dask>=0.16.1']}
 
 test_requires = []
 if sys.version_info < (3, 3):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ requirements = ['setuptools>=3.2', 'pyproj', 'numpy', 'configobj',
                 'pykdtree>=1.1.1', 'pyyaml', 'six']
 extras_require = {'pykdtree': ['pykdtree>=1.1.1'],
                   'numexpr': ['numexpr'],
-                  'quicklook': ['matplotlib', 'basemap', 'pillow']}
+                  'quicklook': ['matplotlib', 'basemap', 'pillow'],
+                  'dask': ['dask>=1.9']}
 
 test_requires = []
 if sys.version_info < (3, 3):


### PR DESCRIPTION
pyresample uses dask meshgrid which came in version 1.9. This PR adds that to setup.py even though it is only an 'extra'.