### PR TITLE
Optimize xarray

### DIFF
--- a/docs/source/plot.rst
+++ b/docs/source/plot.rst
@@ -14,16 +14,17 @@ The function **plot.save_quicklook** saves the Basemap image directly to file.
 
 .. doctest::
 
- >>> import numpy as np	
- >>> import pyresample as pr
+ >>> import numpy as np
+ >>> from pyresample import load_area, save_quicklook, SwathDefinition
+ >>> from pyresample.kd_tree import resample_nearest
  >>> lons = np.zeros(1000)
  >>> lats = np.arange(-80, -90, -0.01)
  >>> tb37v = np.arange(1000)
- >>> area_def = pr.utils.load_area('areas.cfg', 'ease_sh')
- >>> swath_def = pr.geometry.SwathDefinition(lons, lats)
- >>> result = pr.kd_tree.resample_nearest(swath_def, tb37v, area_def,
- ...                                      radius_of_influence=20000, fill_value=None)
- >>> pr.plot.save_quicklook('tb37v_quick.png', area_def, result, label='Tb 37v (K)')
+ >>> area_def = load_area('areas.cfg', 'ease_sh')
+ >>> swath_def = SwathDefinition(lons, lats)
+ >>> result = resample_nearest(swath_def, tb37v, area_def,
+ ...                           radius_of_influence=20000, fill_value=None)
+ >>> save_quicklook('tb37v_quick.png', area_def, result, label='Tb 37v (K)')
 
 Assuming **lons**, **lats** and **tb37v** are initialized with real data the result might look something like this:
   .. image:: _static/images/tb37v_quick.png
@@ -49,14 +50,15 @@ Assuming the file **areas.cfg** has the following area definition:
 **Example usage:**
 
  >>> import numpy as np 
- >>> import pyresample as pr
+ >>> from pyresample import load_area, save_quicklook, SwathDefinition
+ >>> from pyresample.kd_tree import resample_nearest
  >>> lons = np.zeros(1000)
  >>> lats = np.arange(-80, -90, -0.01)
  >>> tb37v = np.arange(1000)
- >>> area_def = pr.utils.load_area('areas.cfg', 'pc_world')
- >>> swath_def = pr.geometry.SwathDefinition(lons, lats)
- >>> result = pr.kd_tree.resample_nearest(swath_def, tb37v, area_def, radius_of_influence=20000, fill_value=None)
- >>> pr.plot.save_quicklook('tb37v_pc.png', area_def, result, num_meridians=0, num_parallels=0, label='Tb 37v (K)')
+ >>> area_def = load_area('areas.cfg', 'pc_world')
+ >>> swath_def = SwathDefinition(lons, lats)
+ >>> result = resample_nearest(swath_def, tb37v, area_def, radius_of_influence=20000, fill_value=None)
+ >>> save_quicklook('tb37v_pc.png', area_def, result, num_meridians=0, num_parallels=0, label='Tb 37v (K)')
 
 Assuming **lons**, **lats** and **tb37v** are initialized with real data the result might look something like this:
   .. image:: _static/images/tb37v_pc.png
@@ -81,14 +83,15 @@ Assuming the file **areas.cfg** has the following area definition for an ortho p
 **Example usage:**
 
  >>> import numpy as np 
- >>> import pyresample as pr
+ >>> from pyresample import load_area, save_quicklook, SwathDefinition
+ >>> from pyresample.kd_tree import resample_nearest
  >>> lons = np.zeros(1000)
  >>> lats = np.arange(-80, -90, -0.01)
  >>> tb37v = np.arange(1000)
- >>> area_def = pr.utils.load_area('areas.cfg', 'ortho')
- >>> swath_def = pr.geometry.SwathDefinition(lons, lats)
- >>> result = pr.kd_tree.resample_nearest(swath_def, tb37v, area_def, radius_of_influence=20000, fill_value=None)
- >>> pr.plot.save_quicklook('tb37v_ortho.png', area_def, result, num_meridians=0, num_parallels=0, label='Tb 37v (K)')
+ >>> area_def = load_area('areas.cfg', 'ortho')
+ >>> swath_def = SwathDefinition(lons, lats)
+ >>> result = resample_nearest(swath_def, tb37v, area_def, radius_of_influence=20000, fill_value=None)
+ >>> save_quicklook('tb37v_ortho.png', area_def, result, num_meridians=0, num_parallels=0, label='Tb 37v (K)')
 
 Assuming **lons**, **lats** and **tb37v** are initialized with real data the result might look something like this:
   .. image:: _static/images/tb37v_ortho.png
@@ -105,15 +108,16 @@ AreaDefintion using the **plot.area_def2basemap(area_def, **kwargs)** function.
 
  >>> import numpy as np	
  >>> import matplotlib.pyplot as plt
- >>> import pyresample as pr
+ >>> from pyresample import load_area, save_quicklook, area_def2basemap, SwathDefinition
+ >>> from pyresample.kd_tree import resample_nearest
  >>> lons = np.zeros(1000)
  >>> lats = np.arange(-80, -90, -0.01)
  >>> tb37v = np.arange(1000)
- >>> area_def = pr.utils.load_area('areas.cfg', 'ease_sh')
- >>> swath_def = pr.geometry.SwathDefinition(lons, lats)
- >>> result = pr.kd_tree.resample_nearest(swath_def, tb37v, area_def,
- ...                                      radius_of_influence=20000, fill_value=None)
- >>> bmap = pr.plot.area_def2basemap(area_def)
+ >>> area_def = load_area('areas.cfg', 'ease_sh')
+ >>> swath_def = SwathDefinition(lons, lats)
+ >>> result = resample_nearest(swath_def, tb37v, area_def,
+ ...                           radius_of_influence=20000, fill_value=None)
+ >>> bmap = area_def2basemap(area_def)
  >>> bmng = bmap.bluemarble()
  >>> col = bmap.imshow(result, origin='upper')
  >>> plt.savefig('tb37v_bmng.png', bbox_inches='tight')

--- a/docs/source/swath.rst
+++ b/docs/source/swath.rst
@@ -6,6 +6,14 @@ Resampling of swath data
 Pyresample can be used to resample a swath dataset to a grid, a grid to a swath or a swath to another swath. 
 Resampling can be done using nearest neighbour method, Guassian weighting, weighting with an arbitrary radial function.
 
+.. versionchanged:: 1.8.0
+
+    `SwathDefinition` no longer checks the validity of the provided longitude
+    and latitude coordinates to improve performance. Longitude arrays are
+    expected to be between -180 and 180 degrees, latitude -90 to 90 degrees.
+    This also applies to all geometry definitions that are provided longitude
+    and latitude arrays on initialization.
+
 pyresample.image
 ----------------
 The ImageContainerNearest and ImageContanerBilinear classes can be used for resampling of swaths as well as grids.  Below is an example using nearest neighbour resampling.

--- a/docs/source/swath.rst
+++ b/docs/source/swath.rst
@@ -12,7 +12,8 @@ Resampling can be done using nearest neighbour method, Guassian weighting, weigh
     and latitude coordinates to improve performance. Longitude arrays are
     expected to be between -180 and 180 degrees, latitude -90 to 90 degrees.
     This also applies to all geometry definitions that are provided longitude
-    and latitude arrays on initialization.
+    and latitude arrays on initialization. Use
+    `pyresample.utils.check_and_wrap` to preprocess your arrays.
 
 pyresample.image
 ----------------

--- a/pyresample/__init__.py
+++ b/pyresample/__init__.py
@@ -16,6 +16,9 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
+CHUNK_SIZE = os.getenv('PYTROLL_CHUNKSIZE', 4096)
+
 from pyresample.version import __version__
 # Backwards compatibility
 from pyresample import geometry
@@ -34,8 +37,6 @@ from pyresample.plot import save_quicklook, area_def2basemap
 
 __all__ = ['grid', 'image', 'kd_tree',
            'utils', 'plot', 'geo_filter', 'geometry', 'CHUNK_SIZE']
-
-CHUNK_SIZE = os.getenv('PYTROLL_CHUNKSIZE', 4096)
 
 
 def get_capabilities():

--- a/pyresample/__init__.py
+++ b/pyresample/__init__.py
@@ -15,18 +15,13 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-
+import os
 from pyresample.version import __version__
-from pyresample import geometry
-from pyresample import grid
-from pyresample import image
-from pyresample import kd_tree
-from pyresample import utils
-from pyresample import plot
 
 __all__ = ['grid', 'image', 'kd_tree',
-           'utils', 'plot', 'geo_filter', 'geometry']
+           'utils', 'plot', 'geo_filter', 'geometry', 'CHUNK_SIZE']
+
+CHUNK_SIZE = os.getenv('PYTROLL_CHUNKSIZE', 4096)
 
 
 def get_capabilities():

--- a/pyresample/__init__.py
+++ b/pyresample/__init__.py
@@ -17,7 +17,7 @@
 
 import os
 
-CHUNK_SIZE = os.getenv('PYTROLL_CHUNKSIZE', 4096)
+CHUNK_SIZE = os.getenv('PYTROLL_CHUNK_SIZE', 4096)
 
 from pyresample.version import __version__
 # Backwards compatibility

--- a/pyresample/__init__.py
+++ b/pyresample/__init__.py
@@ -17,6 +17,20 @@
 
 import os
 from pyresample.version import __version__
+# Backwards compatibility
+from pyresample import geometry
+from pyresample import grid
+from pyresample import image
+from pyresample import kd_tree
+from pyresample import utils
+from pyresample import plot
+# Easy access
+from pyresample.geometry import (SwathDefinition,
+                                 AreaDefinition,
+                                 DynamicAreaDefinition)
+from pyresample.utils import load_area
+from pyresample.kd_tree import XArrayResamplerNN
+from pyresample.plot import save_quicklook, area_def2basemap
 
 __all__ = ['grid', 'image', 'kd_tree',
            'utils', 'plot', 'geo_filter', 'geometry', 'CHUNK_SIZE']

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -41,11 +41,11 @@ except ImportError:
 logger = getLogger(__name__)
 
 
-class DimensionError(Exception):
+class DimensionError(ValueError):
     pass
 
 
-class IncompatibleAreas(Exception):
+class IncompatibleAreas(ValueError):
     """Error when the areas to combine are not compatible."""
 
 

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -63,7 +63,15 @@ class Boundary(object):
 
 class BaseDefinition(object):
 
-    """Base class for geometry definitions"""
+    """Base class for geometry definitions
+
+    .. versionchanged:: 1.8.0
+
+        `BaseDefinition` no longer checks the validity of the provided longitude
+        and latitude coordinates to improve performance. Longitude arrays are
+        expected to be between -180 and 180 degrees, latitude -90 to 90 degrees.
+
+    """
 
     def __init__(self, lons=None, lats=None, nprocs=1):
         if type(lons) != type(lats):
@@ -76,30 +84,8 @@ class BaseDefinition(object):
                 raise ValueError('lons and lats must have same shape')
 
         self.nprocs = nprocs
-
-        # check the latitutes
-        if lats is not None:
-            if isinstance(lats, np.ndarray) and (lats.min() < -90. or lats.max() > 90.):
-                raise ValueError(
-                    'Some latitudes are outside the [-90.;+90] validity range')
-            elif not isinstance(lats, np.ndarray):
-                # assume we have to mask an xarray
-                lats = lats.where((lats >= -90.) & (lats <= 90.))
         self.lats = lats
-
-        # check the longitudes
-        if lons is not None:
-            if (lons.min() < -180. or lons.max() >= +180.):
-                # issue warning
-                warnings.warn('All geometry objects expect longitudes in the [-180:+180[ range. ' +
-                              'We will now automatically wrap your longitudes into [-180:+180[, and continue. ' +
-                              'To avoid this warning next time, use routine utils.wrap_longitudes().')
-                # assume we have to mask an xarray
-                # wrap longitudes to [-180;+180[
-                lons = utils.wrap_longitudes(lons)
-
         self.lons = lons
-
         self.ndim = None
         self.cartesian_coords = None
 

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -55,7 +55,7 @@ except ImportError:
         raise ImportError('Either pykdtree or scipy must be available')
 
 
-class EmptyResult(Exception):
+class EmptyResult(ValueError):
     pass
 
 

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -27,7 +27,7 @@ from logging import getLogger
 
 import numpy as np
 
-from pyresample import _spatial_mp, data_reduce, geometry
+from pyresample import _spatial_mp, data_reduce, geometry, CHUNK_SIZE
 
 logger = getLogger(__name__)
 
@@ -1123,7 +1123,7 @@ class XArrayResamplerNN(object):
 
         res = data.values[slices]
         res[mask_slices] = fill_value
-        res = DataArray(da.from_array(res, chunks=5000), dims=data.dims, coords=coords)
+        res = DataArray(da.from_array(res, chunks=CHUNK_SIZE), dims=data.dims, coords=coords)
         return res
 
 

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -960,39 +960,29 @@ class XArrayResamplerNN(object):
         y_coords = R * da.cos(da.deg2rad(lats)) * da.sin(da.deg2rad(lons))
         z_coords = R * da.sin(da.deg2rad(lats))
 
-        return da.stack((x_coords, y_coords, z_coords), axis=-1)
+        return da.stack((x_coords.ravel(), y_coords.ravel(), z_coords.ravel()), axis=-1)
 
-    def _create_resample_kdtree(self, source_lons, source_lats, valid_input_index):
+    def _create_resample_kdtree(self):
         """Set up kd tree on input"""
+        source_lons, source_lats = self.source_geo_def.get_lonlats_dask(blocksize=2048)
+        valid_input_idx = ((source_lons >= -180) & (source_lons <= 180) &
+                           (source_lats <= 90) & (source_lats >= -90))
 
-        """
-        if not isinstance(source_geo_def, geometry.BaseDefinition):
-            raise TypeError('source_geo_def must be of geometry type')
-
-        #Get reduced cartesian coordinates and flatten them
-        source_cartesian_coords = source_geo_def.get_cartesian_coords(nprocs=nprocs)
-        input_coords = geometry._flatten_cartesian_coords(source_cartesian_coords)
-        input_coords = input_coords[valid_input_index]
-        """
-
-        vii = valid_input_index.compute().ravel()
-        source_lons_valid = source_lons.ravel()[vii]
-        source_lats_valid = source_lats.ravel()[vii]
-
-        input_coords = self.transform_lonlats(source_lons_valid,
-                                              source_lats_valid)
-
-        if input_coords.size == 0:
-            raise EmptyResult('No valid data points in input data')
+        # FIXME: Is dask smart enough to only compute the pixels we end up
+        #        using even with this complicated indexing
+        input_coords = self.transform_lonlats(source_lons,
+                                              source_lats)
+        input_coords = input_coords[valid_input_idx.ravel(), :]
 
         # Build kd-tree on input
         input_coords = input_coords.astype(np.float)
+        valid_input_idx, input_coords = da.compute(valid_input_idx, input_coords)
         if kd_tree_name == 'pykdtree':
-            resample_kdtree = KDTree(input_coords.compute())
+            resample_kdtree = KDTree(input_coords)
         else:
-            resample_kdtree = sp.cKDTree(input_coords.compute())
+            resample_kdtree = sp.cKDTree(input_coords)
 
-        return resample_kdtree
+        return valid_input_idx, resample_kdtree
 
     def _query_resample_kdtree(self,
                                resample_kdtree,
@@ -1016,8 +1006,17 @@ class XArrayResamplerNN(object):
                 eps=self.epsilon,
                 distance_upper_bound=self.radius_of_influence)
 
+            # KDTree query returns out-of-bounds neighbors as `len(arr)`
+            # which is an invalid index, we mask those out so -1 represents
+            # invalid values
+            # voi is 2D, index_array is 1D
+            bad_mask = index_array >= resample_kdtree.n
+            voi[bad_mask.reshape(shape)] = False
             res_ia = np.full(shape, fill_value=-1, dtype=np.int)
-            res_ia[voi] = index_array
+            res_ia[voi] = index_array[~bad_mask]
+            # res_ia[voi >= resample_kdtree.n] = -1
+            # res_ia[voi] = index_array
+            # res_ia[voi >= resample_kdtree.n] = -1
             return res_ia
 
         res = da.map_blocks(query_no_distance, target_lons, target_lats,
@@ -1038,16 +1037,9 @@ class XArrayResamplerNN(object):
             warnings.warn('Searching for %s neighbours in %s data points' %
                           (self.neighbours, self.source_geo_def.size))
 
-        source_lons, source_lats = self.source_geo_def.get_lonlats_dask()
-        valid_input_idx = ((source_lons >= -180) & (source_lons <= 180) &
-                           (source_lats <= 90) & (source_lats >= -90))
-
         # Create kd-tree
-        try:
-            resample_kdtree = self._create_resample_kdtree(
-                source_lons, source_lats, valid_input_idx)
-
-        except EmptyResult:
+        valid_input_idx, resample_kdtree = self._create_resample_kdtree()
+        if resample_kdtree.n == 0:
             # Handle if all input data is reduced away
             valid_output_idx, index_arr, distance_arr = \
                 _create_empty_info(self.source_geo_def,
@@ -1056,24 +1048,20 @@ class XArrayResamplerNN(object):
             self.valid_output_index = valid_output_idx
             self.index_array = index_arr
             self.distance_array = distance_arr
-            return (valid_input_idx, valid_output_idx, index_arr, distance_arr)
+            return valid_input_idx, valid_output_idx, index_arr, distance_arr
 
-        target_lons, target_lats = self.target_geo_def.get_lonlats_dask()
+        target_lons, target_lats = self.target_geo_def.get_lonlats_dask(blocksize=2048)
         valid_output_idx = ((target_lons >= -180) & (target_lons <= 180) &
                             (target_lats <= 90) & (target_lats >= -90))
 
         index_arr, distance_arr = self._query_resample_kdtree(
             resample_kdtree, target_lons, target_lats, valid_output_idx)
-        # Fix invalid values
-        index_arr[index_arr < 0] = -1
-        index_arr[index_arr >= valid_input_idx.sum()] = -1
 
+        self.valid_output_index, self.index_array = da.compute(valid_output_idx, index_arr)
         self.valid_input_index = valid_input_idx
-        self.valid_output_index = valid_output_idx
-        self.index_array = index_arr
         self.distance_array = distance_arr
 
-        return valid_input_idx, valid_output_idx, index_arr, distance_arr
+        return self.valid_input_index, self.valid_output_index, self.index_array, self.distance_array
 
     def get_sample_from_neighbour_info(self, data, fill_value=np.nan):
         # FIXME: can be this made into a dask construct ?

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -836,12 +836,12 @@ class TestSwathDefinition(unittest.TestCase):
 
         lons = np.array([[-45., 0., 45.],
                          [-90, 0., 90.],
-                         [-135., 180., 135.]]).T
+                         [-135., -180., 135.]]).T
 
         area = geometry.SwathDefinition(lons, lats)
         lons, lats = area.get_edge_lonlats()
 
-        np.testing.assert_allclose(lons, [-45., -90., -135., -135., 180., 135.,
+        np.testing.assert_allclose(lons, [-45., -90., -135., -135., -180., 135.,
                                           135., 90., 45., 45., 0., -45.])
         np.testing.assert_allclose(lats, [80., 80., 80., 80., 80., 80., 80.,
                                           80., 80., 80., 80., 80.])

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -91,43 +91,6 @@ class Test(unittest.TestCase):
         self.assertTrue((cart_coords.sum() - exp) < 1e-7 * exp,
                         msg='Calculation of cartesian coordinates failed')
 
-    def test_base_lat_invalid(self):
-
-        lons = np.arange(-135., +135, 20.)
-        lats = np.ones_like(lons) * 70.
-        lats[0] = -95
-        lats[1] = +95
-        self.assertRaises(
-            ValueError, geometry.BaseDefinition, lons=lons, lats=lats)
-
-    def test_base_lon_wrapping(self):
-
-        lons1 = np.arange(-135., +135, 50.)
-        lats = np.ones_like(lons1) * 70.
-
-        with catch_warnings() as w1:
-            base_def1 = geometry.BaseDefinition(lons1, lats)
-            self.assertFalse(
-                len(w1) != 0, 'Got warning <%s>, but was not expecting one' % w1)
-
-        lons2 = np.where(lons1 < 0, lons1 + 360, lons1)
-        with catch_warnings() as w2:
-            base_def2 = geometry.BaseDefinition(lons2, lats)
-            self.assertFalse(
-                len(w2) != 1, 'Failed to trigger a warning on longitude wrapping')
-            self.assertFalse(('-180:+180' not in str(w2[0].message)),
-                             'Failed to trigger correct warning about longitude wrapping')
-
-        self.assertFalse(
-            base_def1 != base_def2, 'longitude wrapping to [-180:+180] did not work')
-
-        with catch_warnings() as w3:
-            base_def3 = geometry.BaseDefinition(None, None)
-            self.assertFalse(
-                len(w3) != 0, 'Got warning <%s>, but was not expecting one' % w3)
-
-        self.assert_raises(ValueError, base_def3.get_lonlats)
-
     def test_base_type(self):
         lons1 = np.arange(-135., +135, 50.)
         lats = np.ones_like(lons1) * 70.
@@ -755,27 +718,6 @@ class TestSwathDefinition(unittest.TestCase):
         self.assertFalse(id(lons1) != id(lons2) or id(lats1) != id(lats2),
                          msg='Caching of swath coordinates failed')
 
-    def test_swath_wrap(self):
-        lons1 = np.fromfunction(lambda y, x: 3 + (10.0 / 100) * x, (5000, 100))
-        lats1 = np.fromfunction(
-            lambda y, x: 75 - (50.0 / 5000) * y, (5000, 100))
-
-        lons1 += 180.
-        with catch_warnings() as w1:
-            swath_def = geometry.BaseDefinition(lons1, lats1)
-            self.assertFalse(
-                len(w1) != 1, 'Failed to trigger a warning on longitude wrapping')
-            self.assertFalse(('-180:+180' not in str(w1[0].message)),
-                             'Failed to trigger correct warning about longitude wrapping')
-
-        lons2, lats2 = swath_def.get_lonlats()
-
-        self.assertTrue(id(lons1) != id(lons2),
-                        msg='Caching of swath coordinates failed with longitude wrapping')
-
-        self.assertTrue(lons2.min() > -180 and lons2.max() < 180,
-                        'Wrapping of longitudes failed for SwathDefinition')
-
     def test_concat_1d(self):
         lons1 = np.array([1, 2, 3])
         lats1 = np.array([1, 2, 3])
@@ -899,7 +841,7 @@ class TestSwathDefinition(unittest.TestCase):
         area = geometry.SwathDefinition(lons, lats)
         lons, lats = area.get_edge_lonlats()
 
-        np.testing.assert_allclose(lons, [-45., -90., -135., -135., -180., 135.,
+        np.testing.assert_allclose(lons, [-45., -90., -135., -135., 180., 135.,
                                           135., 90., 45., 45., 0., -45.])
         np.testing.assert_allclose(lats, [80., 80., 80., 80., 80., 80., 80.,
                                           80., 80., 80., 80., 80.])

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -188,6 +188,24 @@ class TestMisc(unittest.TestCase):
         self.assertFalse(
             (wlons.min() < -180) or (wlons.max() >= 180) or (+180 in wlons))
 
+    def test_wrap_and_check(self):
+        from pyresample import utils
+
+        lons1 = np.arange(-135., +135, 50.)
+        lats = np.ones_like(lons1) * 70.
+        new_lons, new_lats = utils.check_and_wrap(lons1, lats)
+        self.assertIs(lats, new_lats)
+        self.assertTrue(np.isclose(lons1, new_lons).all())
+
+        lons2 = np.where(lons1 < 0, lons1 + 360, lons1)
+        new_lons, new_lats = utils.check_and_wrap(lons2, lats)
+        self.assertIs(lats, new_lats)
+        # after wrapping lons2 should look like lons1
+        self.assertTrue(np.isclose(lons1, new_lons).all())
+
+        lats2 = lats + 25.
+        self.assertRaises(ValueError, utils.check_and_wrap, lons1, lats2)
+
     def test_unicode_proj4_string(self):
         """Test that unicode is accepted for area creation.
         """

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -513,6 +513,34 @@ def wrap_longitudes(lons):
     return (lons + 180) % 360 - 180
 
 
+def check_and_wrap(lons, lats):
+    """Wrap longitude to [-180:+180[ and check latitude for validity.
+
+    Args:
+        lons (ndarray): Longitude degrees
+        lats (ndarray): Latitude degrees
+
+    Returns:
+        lons, lats: Longitude degrees in the range [-180:180[ and the original
+                    latitude array
+
+    Raises:
+        ValueError: If latitude array is not between -90 and 90
+
+    """
+    # check the latitutes
+    if lats.min() < -90. or lats.max() > 90.:
+        raise ValueError(
+            'Some latitudes are outside the [-90.:+90] validity range')
+
+    # check the longitudes
+    if lons.min() < -180. or lons.max() >= 180.:
+        # wrap longitudes to [-180;+180[
+        lons = wrap_longitudes(lons)
+
+    return lons, lats
+
+
 def recursive_dict_update(d, u):
     """Recursive dictionary update using
 

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -30,10 +30,8 @@ import yaml
 from configobj import ConfigObj
 from collections import Mapping
 
-import pyresample as pr
 
-
-class AreaNotFound(Exception):
+class AreaNotFound(KeyError):
 
     """Exception raised when specified are is no found in file"""
     pass
@@ -126,6 +124,7 @@ def _parse_yaml_area_file(area_file_name, *regions):
     the files, using the first file as the "base", replacing things after
     that.
     """
+    from pyresample.geometry import DynamicAreaDefinition
     area_dict = _read_yaml_area_file_content(area_file_name)
     area_list = regions or area_dict.keys()
 
@@ -154,11 +153,11 @@ def _parse_yaml_area_file(area_file_name, *regions):
             rotation = params['rotation']
         except KeyError:
             rotation = 0
-        area = pr.geometry.DynamicAreaDefinition(area_name, description,
-                                                 projection, xsize, ysize,
-                                                 area_extent,
-                                                 optimize_projection,
-                                                 rotation)
+        area = DynamicAreaDefinition(area_name, description,
+                                     projection, xsize, ysize,
+                                     area_extent,
+                                     optimize_projection,
+                                     rotation)
         try:
             area = area.freeze()
         except (TypeError, AttributeError):
@@ -230,6 +229,7 @@ def _parse_legacy_area_file(area_file_name, *regions):
 
 def _create_area(area_id, area_content):
     """Parse area configuration"""
+    from pyresample.geometry import AreaDefinition
 
     config_obj = area_content.replace('{', '').replace('};', '')
     config_obj = ConfigObj([line.replace(':', '=', 1)
@@ -257,10 +257,10 @@ def _create_area(area_id, area_content):
         config['AREA_EXTENT'][i] = float(val)
 
     config['PCS_DEF'] = _get_proj4_args(config['PCS_DEF'])
-    return pr.geometry.AreaDefinition(config['REGION'], config['NAME'],
-                                      config['PCS_ID'], config['PCS_DEF'],
-                                      config['XSIZE'], config['YSIZE'],
-                                      config['AREA_EXTENT'], config['ROTATION'])
+    return AreaDefinition(config['REGION'], config['NAME'],
+                          config['PCS_ID'], config['PCS_DEF'],
+                          config['XSIZE'], config['YSIZE'],
+                          config['AREA_EXTENT'], config['ROTATION'])
 
 
 def get_area_def(area_id, area_name, proj_id, proj4_args, x_size, y_size,
@@ -292,9 +292,10 @@ def get_area_def(area_id, area_name, proj_id, proj4_args, x_size, y_size,
         AreaDefinition object
     """
 
+    from pyresample.geometry import AreaDefinition
     proj_dict = _get_proj4_args(proj4_args)
-    return pr.geometry.AreaDefinition(area_id, area_name, proj_id, proj_dict,
-                                      x_size, y_size, area_extent)
+    return AreaDefinition(area_id, area_name, proj_id, proj_dict,
+                          x_size, y_size, area_extent)
 
 
 def generate_quick_linesample_arrays(source_area_def, target_area_def,
@@ -314,11 +315,12 @@ def generate_quick_linesample_arrays(source_area_def, target_area_def,
     -------
     (row_indices, col_indices) : tuple of numpy arrays
     """
+    from pyresample.grid import get_linesample
     lons, lats = target_area_def.get_lonlats(nprocs)
 
-    source_pixel_y, source_pixel_x = pr.grid.get_linesample(lons, lats,
-                                                            source_area_def,
-                                                            nprocs=nprocs)
+    source_pixel_y, source_pixel_x = get_linesample(lons, lats,
+                                                    source_area_def,
+                                                    nprocs=nprocs)
 
     source_pixel_x = _downcast_index_array(source_pixel_x,
                                            source_area_def.shape[1])
@@ -350,12 +352,13 @@ def generate_nearest_neighbour_linesample_arrays(source_area_def,
     (row_indices, col_indices) : tuple of numpy arrays
     """
 
+    from pyresample.kd_tree import get_neighbour_info
     valid_input_index, valid_output_index, index_array, distance_array = \
-        pr.kd_tree.get_neighbour_info(source_area_def,
-                                      target_area_def,
-                                      radius_of_influence,
-                                      neighbours=1,
-                                      nprocs=nprocs)
+        get_neighbour_info(source_area_def,
+                           target_area_def,
+                           radius_of_influence,
+                           neighbours=1,
+                           nprocs=nprocs)
     # Enumerate rows and cols
     rows = np.fromfunction(lambda i, j: i, source_area_def.shape,
                            dtype=np.int32).ravel()

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = ['setuptools>=3.2', 'pyproj', 'numpy', 'configobj',
 extras_require = {'pykdtree': ['pykdtree>=1.1.1'],
                   'numexpr': ['numexpr'],
                   'quicklook': ['matplotlib', 'basemap', 'pillow'],
-                  'dask': ['dask>=1.9']}
+                  'dask': ['dask>=0.16.1']}
 
 test_requires = []
 if sys.version_info < (3, 3):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ requirements = ['setuptools>=3.2', 'pyproj', 'numpy', 'configobj',
                 'pykdtree>=1.1.1', 'pyyaml', 'six']
 extras_require = {'pykdtree': ['pykdtree>=1.1.1'],
                   'numexpr': ['numexpr'],
-                  'quicklook': ['matplotlib', 'basemap', 'pillow']}
+                  'quicklook': ['matplotlib', 'basemap', 'pillow'],
+                  'dask': ['dask>=1.9']}
 
 test_requires = []
 if sys.version_info < (3, 3):


### PR DESCRIPTION
This optimizes how dask arrays are computed and used in the nearest neighbor resampling. It reduces the usage so that dask arrays *should* only be computed once and when possible should share as many calculations as possible. Two things that should be looked at:

- [ ] I added a FIXME to line 971 in `kd_tree.py` to double check that dask doesn't compute things for pixels that we don't use. We use some complicated indexing so I could see how it might not be able to. I had trouble producing a test case that matched what is done here.
- [ ] The `get_sample_from_neighbour_info` method is still not using dask arrays and should be changed to do that at some point. As discussed on slack there is a new method being added to xarray that should help with this (https://github.com/pydata/xarray/pull/1751), but from the simple tests I did I got terrible performance. Perhaps our use case is too large or perhaps I was just doing it wrong.

Note the backwards compatibility breaking change this PR includes where `BaseDefinition` no longer checks lon/lat input arrays for -180/180,-90/90 validity since doing that with dask arrays would be a huge waste of time and it is a huge waste of computation time even for normal numpy arrays. The usual use case is a user who already has valid inputs.

 - [ ] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

