### PR TITLE
Provide the minimum version of pyproj needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 version = imp.load_source('pyresample.version', 'pyresample/version.py')
 
-requirements = ['setuptools>=3.2', 'pyproj', 'numpy', 'configobj',
+requirements = ['setuptools>=3.2', 'pyproj>=1.9.5.1', 'numpy', 'configobj',
                 'pykdtree>=1.1.1', 'pyyaml', 'six']
 extras_require = {'pykdtree': ['pykdtree>=1.1.1'],
                   'numexpr': ['numexpr'],


### PR DESCRIPTION
This fixes the minimum version of pyproj needed by pyresample

 - [x] Tests passed (for all non-documentation changes)
