### PR TITLE
Revert "Fix data reduction when poles are within area"

### DIFF
--- a/pyresample/data_reduce.py
+++ b/pyresample/data_reduce.py
@@ -289,7 +289,7 @@ def _get_valid_index(lons_side1, lons_side2, lons_side3, lons_side4,
 
     # From the winding number theorem follows:
     # angle_sum possiblilities:
-    #-360: area covers north pole
+    # -360: area covers north pole
     # 360: area covers south pole
     #   0: area covers no poles
     # else: area covers both poles

--- a/pyresample/data_reduce.py
+++ b/pyresample/data_reduce.py
@@ -289,14 +289,14 @@ def _get_valid_index(lons_side1, lons_side2, lons_side3, lons_side4,
 
     # From the winding number theorem follows:
     # angle_sum possiblilities:
-    # 360: area covers north pole
-    #-360: area covers south pole
+    #-360: area covers north pole
+    # 360: area covers south pole
     #   0: area covers no poles
     # else: area covers both poles
-    if round(angle_sum) == 360:
+    if round(angle_sum) == -360:
         # Covers NP
         valid_index = (lats >= lat_min_buffered)
-    elif round(angle_sum) == -360:
+    elif round(angle_sum) == 360:
         # Covers SP
         valid_index = (lats <= lat_max_buffered)
     elif round(angle_sum) == 0:

--- a/pyresample/test/__init__.py
+++ b/pyresample/test/__init__.py
@@ -36,6 +36,7 @@ from pyresample.test import (
     test_ewa_ll2cr,
     test_ewa_fornav,
     test_bilinear,
+    test_data_reduce,
 )
 
 import unittest
@@ -57,7 +58,7 @@ def suite():
     mysuite.addTests(test_ewa_ll2cr.suite())
     mysuite.addTests(test_ewa_fornav.suite())
     mysuite.addTests(test_bilinear.suite())
-
+    mysuite.addTests(test_data_reduce.suite())
     return mysuite
 
 

--- a/pyresample/test/test_data_reduce.py
+++ b/pyresample/test/test_data_reduce.py
@@ -1,0 +1,172 @@
+# pyresample, Resampling of remote sensing image data in python
+#
+# Copyright (C) 2018  Pytroll Developers
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Testing the data_reduce module."""
+
+import unittest
+import numpy as np
+from pyresample import geometry
+from pyresample.data_reduce import (get_valid_index_from_cartesian_grid,
+                                    swath_from_lonlat_grid,
+                                    swath_from_lonlat_boundaries,
+                                    swath_from_cartesian_grid,
+                                    get_valid_index_from_lonlat_grid)
+
+
+class Test(unittest.TestCase):
+    """Unit testing the data_reduce module."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Get ready for testing."""
+        cls.area_def = geometry.AreaDefinition('areaD',
+                                               'Europe (3km, HRV, VTC)',
+                                               'areaD',
+                                               {'a': '6378144.0',
+                                                'b': '6356759.0',
+                                                'lat_0': '50.00',
+                                                'lat_ts': '50.00',
+                                                'lon_0': '8.00',
+                                                'proj': 'stere'},
+                                               800,
+                                               800,
+                                               [-1370912.72,
+                                                   -909968.64000000001,
+                                                   1029087.28,
+                                                   1490031.3600000001])
+
+    def test_reduce(self):
+        data = np.fromfunction(lambda y, x: (y + x), (1000, 1000))
+        lons = np.fromfunction(
+            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
+        lats = np.fromfunction(
+            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
+        grid_lons, grid_lats = self.area_def.get_lonlats()
+        lons, lats, data = swath_from_lonlat_grid(grid_lons, grid_lats,
+                                                  lons, lats, data,
+                                                  7000)
+        cross_sum = data.sum()
+        expected = 20514375.0
+        self.assertAlmostEqual(cross_sum, expected, msg='Reduce data failed')
+
+    def test_reduce_boundary(self):
+        data = np.fromfunction(lambda y, x: (y + x), (1000, 1000))
+        lons = np.fromfunction(
+            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
+        lats = np.fromfunction(
+            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
+        boundary_lonlats = self.area_def.get_boundary_lonlats()
+        lons, lats, data = swath_from_lonlat_boundaries(boundary_lonlats[0],
+                                                        boundary_lonlats[1],
+                                                        lons, lats, data, 7000)
+        cross_sum = data.sum()
+        expected = 20514375.0
+        self.assertAlmostEqual(cross_sum, expected, msg='Reduce data failed')
+
+    def test_cartesian_reduce(self):
+        data = np.fromfunction(lambda y, x: (y + x), (1000, 1000))
+        lons = np.fromfunction(
+            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
+        lats = np.fromfunction(
+            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
+        grid = self.area_def.get_cartesian_coords()
+        lons, lats, data = swath_from_cartesian_grid(grid, lons, lats, data,
+                                                     7000)
+        cross_sum = data.sum()
+        expected = 20514375.0
+        self.assertAlmostEqual(
+            cross_sum, expected, msg='Cartesian reduce data failed')
+
+    def test_area_con_reduce(self):
+        data = np.fromfunction(lambda y, x: (y + x), (1000, 1000))
+        lons = np.fromfunction(
+            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
+        lats = np.fromfunction(
+            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
+        grid_lons, grid_lats = self.area_def.get_lonlats()
+        valid_index = get_valid_index_from_lonlat_grid(grid_lons, grid_lats,
+                                                       lons, lats, 7000)
+        data = data[valid_index]
+        cross_sum = data.sum()
+        expected = 20514375.0
+        self.assertAlmostEqual(cross_sum, expected, msg='Reduce data failed')
+
+    def test_area_con_cartesian_reduce(self):
+        data = np.fromfunction(lambda y, x: (y + x), (1000, 1000))
+        lons = np.fromfunction(
+            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
+        lats = np.fromfunction(
+            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
+        cart_grid = self.area_def.get_cartesian_coords()
+        valid_index = get_valid_index_from_cartesian_grid(cart_grid,
+                                                          lons, lats, 7000)
+        data = data[valid_index]
+        cross_sum = data.sum()
+        expected = 20514375.0
+        self.assertAlmostEqual(
+            cross_sum, expected, msg='Cartesian reduce data failed')
+
+    def test_reduce_north_pole(self):
+        """Test reducing around the poles."""
+
+        from pyresample import utils
+        area_id = 'ease_sh'
+        description = 'Antarctic EASE grid'
+        proj_id = 'ease_sh'
+        projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+        x_size = 425
+        y_size = 425
+        area_extent = (-5326849.0625, -5326849.0625,
+                       5326849.0625, 5326849.0625)
+        area_def = utils.get_area_def(area_id, description, proj_id,
+                                      projection, x_size, y_size, area_extent)
+
+        grid_lons, grid_lats = area_def.get_lonlats()
+
+        area_id = 'ease_sh'
+        description = 'Antarctic EASE grid'
+        proj_id = 'ease_sh'
+        projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+        x_size = 1000
+        y_size = 1000
+        area_extent = (-532684.0625, -532684.0625, 532684.0625, 532684.0625)
+        smaller_area_def = utils.get_area_def(area_id, description, proj_id,
+                                              projection, x_size, y_size,
+                                              area_extent)
+
+        data = np.fromfunction(lambda y, x: (y + x), (1000, 1000))
+        lons, lats = smaller_area_def.get_lonlats()
+
+        lons, lats, data = swath_from_lonlat_grid(grid_lons, grid_lats,
+                                                  lons, lats, data, 7000)
+
+        cross_sum = data.sum()
+        expected = 999000000.0
+        self.assertAlmostEqual(cross_sum, expected, msg='Reduce data failed')
+
+
+def suite():
+    """The test suite.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(Test))
+
+    return mysuite
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -5,7 +5,7 @@ import sys
 
 import numpy
 
-from pyresample import data_reduce, geometry, kd_tree, utils
+from pyresample import geometry, kd_tree, utils
 from pyresample.test.utils import catch_warnings
 
 if sys.version_info < (2, 7):
@@ -135,7 +135,7 @@ class Test(unittest.TestCase):
         mask = numpy.ones_like(lons, dtype=numpy.bool)
         mask[::2, ::2] = False
         swath_def = geometry.SwathDefinition(
-            lons=numpy.ma.masked_array(lons, mask=mask), # numpy.ones_like(lons, dtype=numpy.bool)),
+            lons=numpy.ma.masked_array(lons, mask=mask),
             lats=numpy.ma.masked_array(lats, mask=False)
         )
         res = kd_tree.resample_nearest(swath_def, data.ravel(),
@@ -501,80 +501,6 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(cross_sum, expected,
                                msg='Swath multi channel custom resampling failed')
 
-    def test_reduce(self):
-        data = numpy.fromfunction(lambda y, x: (y + x), (1000, 1000))
-        lons = numpy.fromfunction(
-            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
-        lats = numpy.fromfunction(
-            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
-        grid_lons, grid_lats = self.area_def.get_lonlats()
-        lons, lats, data = data_reduce.swath_from_lonlat_grid(grid_lons, grid_lats,
-                                                              lons, lats, data,
-                                                              7000)
-        cross_sum = data.sum()
-        expected = 20514375.0
-        self.assertAlmostEqual(cross_sum, expected, msg='Reduce data failed')
-
-    def test_reduce_boundary(self):
-        data = numpy.fromfunction(lambda y, x: (y + x), (1000, 1000))
-        lons = numpy.fromfunction(
-            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
-        lats = numpy.fromfunction(
-            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
-        boundary_lonlats = self.area_def.get_boundary_lonlats()
-        lons, lats, data = data_reduce.swath_from_lonlat_boundaries(boundary_lonlats[0],
-                                                                    boundary_lonlats[
-                                                                        1],
-                                                                    lons, lats, data,
-                                                                    7000)
-        cross_sum = data.sum()
-        expected = 20514375.0
-        self.assertAlmostEqual(cross_sum, expected, msg='Reduce data failed')
-
-    def test_cartesian_reduce(self):
-        data = numpy.fromfunction(lambda y, x: (y + x), (1000, 1000))
-        lons = numpy.fromfunction(
-            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
-        lats = numpy.fromfunction(
-            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
-        #grid = utils.generate_cartesian_grid(self.area_def)
-        grid = self.area_def.get_cartesian_coords()
-        lons, lats, data = data_reduce.swath_from_cartesian_grid(grid, lons, lats, data,
-                                                                 7000)
-        cross_sum = data.sum()
-        expected = 20514375.0
-        self.assertAlmostEqual(
-            cross_sum, expected, msg='Cartesian reduce data failed')
-
-    def test_area_con_reduce(self):
-        data = numpy.fromfunction(lambda y, x: (y + x), (1000, 1000))
-        lons = numpy.fromfunction(
-            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
-        lats = numpy.fromfunction(
-            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
-        grid_lons, grid_lats = self.area_def.get_lonlats()
-        valid_index = data_reduce.get_valid_index_from_lonlat_grid(grid_lons, grid_lats,
-                                                                   lons, lats, 7000)
-        data = data[valid_index]
-        cross_sum = data.sum()
-        expected = 20514375.0
-        self.assertAlmostEqual(cross_sum, expected, msg='Reduce data failed')
-
-    def test_area_con_cartesian_reduce(self):
-        data = numpy.fromfunction(lambda y, x: (y + x), (1000, 1000))
-        lons = numpy.fromfunction(
-            lambda y, x: -180 + (360.0 / 1000) * x, (1000, 1000))
-        lats = numpy.fromfunction(
-            lambda y, x: -90 + (180.0 / 1000) * y, (1000, 1000))
-        cart_grid = self.area_def.get_cartesian_coords()
-        valid_index = data_reduce.get_valid_index_from_cartesian_grid(cart_grid,
-                                                                      lons, lats, 7000)
-        data = data[valid_index]
-        cross_sum = data.sum()
-        expected = 20514375.0
-        self.assertAlmostEqual(
-            cross_sum, expected, msg='Cartesian reduce data failed')
-
     def test_masked_nearest(self):
         data = numpy.ones((50, 10))
         data[:, 5:] = 2
@@ -848,6 +774,7 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(Test))
 
     return mysuite
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes the gap appearing at the poles for areas containing a pole

 - [x] Closes #61
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)

