### PR TITLE
Add comparison methods to area definitions

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -119,6 +119,41 @@ class BaseDefinition(object):
 
         return not self.__eq__(other)
 
+    def _comparable(self):
+        return self.shape
+
+    def __lt__(self, other):
+        """Which area is higher resolution (larger size)."""
+        if not isinstance(other, self.__class__):
+            raise TypeError("{0} can only be compared with {0}".format(
+                self.__class__))
+
+        return self._comparable() < other._comparable()
+
+    def __le__(self, other):
+        """Which area is higher resolution (larger size)."""
+        if not isinstance(other, self.__class__):
+            raise TypeError("{0} can only be compared with {0}".format(
+                self.__class__))
+
+        return self._comparable() <= other._comparable()
+
+    def __gt__(self, other):
+        """Which area is higher resolution (larger size)."""
+        if not isinstance(other, self.__class__):
+            raise TypeError("{0} can only be compared with {0}".format(
+                self.__class__))
+
+        return self._comparable() > other._comparable()
+
+    def __ge__(self, other):
+        """Which area is higher resolution (larger size)."""
+        if not isinstance(other, self.__class__):
+            raise TypeError("{0} can only be compared with {0}".format(
+                self.__class__))
+
+        return self._comparable() >= other._comparable()
+
     def get_area_extent_for_subset(self, row_LR, col_LR, row_UL, col_UL):
         """Calculate extent for a subdomain of this area
 
@@ -898,6 +933,10 @@ class AreaDefinition(BaseDefinition):
 
         return not self.__eq__(other)
 
+    def _comparable(self):
+        """Used by comparison methods for sorting"""
+        return self.pixel_size_x
+
     def __hash__(self):
         return hash((
             self.proj_str,
@@ -1044,9 +1083,16 @@ class AreaDefinition(BaseDefinition):
         if dtype is None:
             dtype = self.dtype
 
-        target_x = da.arange(self.x_size, chunks=chunks, dtype=dtype) * \
+        if not isinstance(chunks, int):
+            y_chunks = chunks[0]
+            x_chunks = chunks[1]
+        else:
+            y_chunks = chunks
+            x_chunks = chunks
+
+        target_x = da.arange(self.x_size, chunks=x_chunks, dtype=dtype) * \
             self.pixel_size_x + self.pixel_upper_left[0]
-        target_y = da.arange(self.y_size, chunks=chunks, dtype=dtype) * - \
+        target_y = da.arange(self.y_size, chunks=y_chunks, dtype=dtype) * - \
             self.pixel_size_y + self.pixel_upper_left[1]
         return target_x, target_y
 

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -939,6 +939,50 @@ class AreaDefinition(BaseDefinition):
         # small pixel size means big shape
         return 1. / self.pixel_size_x
 
+    def __lt__(self, other):
+        """Which area is higher resolution (larger size)."""
+        if not isinstance(other, self.__class__):
+            raise TypeError("{0} can only be compared with {0}".format(
+                self.__class__))
+        if self.proj4_string != other.proj4_string:
+            raise ValueError("Can't compare AreaDefinitions with different "
+                             "projections.")
+
+        return self._comparable() < other._comparable()
+
+    def __le__(self, other):
+        """Which area is higher resolution (larger size)."""
+        if not isinstance(other, self.__class__):
+            raise TypeError("{0} can only be compared with {0}".format(
+                self.__class__))
+        if self.proj4_string != other.proj4_string:
+            raise ValueError("Can't compare AreaDefinitions with different "
+                             "projections.")
+
+        return self._comparable() <= other._comparable()
+
+    def __gt__(self, other):
+        """Which area is higher resolution (larger size)."""
+        if not isinstance(other, self.__class__):
+            raise TypeError("{0} can only be compared with {0}".format(
+                self.__class__))
+        if self.proj4_string != other.proj4_string:
+            raise ValueError("Can't compare AreaDefinitions with different "
+                             "projections.")
+
+        return self._comparable() > other._comparable()
+
+    def __ge__(self, other):
+        """Which area is higher resolution (larger size)."""
+        if not isinstance(other, self.__class__):
+            raise TypeError("{0} can only be compared with {0}".format(
+                self.__class__))
+        if self.proj4_string != other.proj4_string:
+            raise ValueError("Can't compare AreaDefinitions with different "
+                             "projections.")
+
+        return self._comparable() >= other._comparable()
+
     def __hash__(self):
         return hash((
             self.proj_str,

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -935,7 +935,9 @@ class AreaDefinition(BaseDefinition):
 
     def _comparable(self):
         """Used by comparison methods for sorting"""
-        return self.pixel_size_x
+        # BaseDefinition uses shape, pixel size is the inverse
+        # small pixel size means big shape
+        return 1. / self.pixel_size_x
 
     def __hash__(self):
         return hash((
@@ -1271,6 +1273,7 @@ class AreaDefinition(BaseDefinition):
         target_proj = Proj(**self.proj_dict)
 
         def invproj(data1, data2):
+            # XXX: does pyproj copy arrays? What can we do so it doesn't?
             return np.dstack(target_proj(data1, data2, inverse=True))
 
         res = map_blocks(invproj, target_x, target_y, chunks=(target_x.chunks[0],

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -1091,6 +1091,7 @@ class XArrayResamplerNN(object):
         mask_2d_added = False
         coords = {}
         try:
+            # FIXME: Use same chunk size as input data
             coord_x, coord_y = self.target_geo_def.get_proj_vectors_dask()
         except AttributeError:
             coord_x, coord_y = None, None

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -212,7 +212,6 @@ class Test(unittest.TestCase):
             self.assertEqual(geometry.get_array_hashable(xrarr),
                              xrarr.attrs['hash'])
 
-
     def test_swath_hash(self):
         lons = np.array([1.2, 1.3, 1.4, 1.5])
         lats = np.array([65.9, 65.86, 65.82, 65.78])
@@ -254,13 +253,11 @@ class Test(unittest.TestCase):
 
             self.assertIsInstance(hash(swath_def), int)
 
-
         lons = np.ma.array([1.2, 1.3, 1.4, 1.5])
         lats = np.ma.array([65.9, 65.86, 65.82, 65.78])
         swath_def = geometry.SwathDefinition(lons, lats)
 
         self.assertIsInstance(hash(swath_def), int)
-
 
     def test_area_equal(self):
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
@@ -323,6 +320,72 @@ class Test(unittest.TestCase):
                                            )
         self.assertFalse(
             area_def == msg_area, 'area_defs are not expected to be equal')
+
+    def test_area_comparisons(self):
+        area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
+                                           {'a': '6378144.0',
+                                            'b': '6356759.0',
+                                            'lat_0': '50.00',
+                                            'lat_ts': '50.00',
+                                            'lon_0': '8.00',
+                                            'proj': 'stere'},
+                                           800,
+                                           800,
+                                           [-1370912.72,
+                                            -909968.64000000001,
+                                            1029087.28,
+                                            1490031.3600000001])
+
+        test_area = geometry.AreaDefinition('test', 'test',
+                                            'test',
+                                            {'a': '6378144.0',
+                                             'b': '6356759.0',
+                                             'lat_0': '50.00',
+                                             'lat_ts': '50.00',
+                                             'lon_0': '8.00',
+                                             'proj': 'stere'},
+                                            3712,
+                                            3712,
+                                            [-1370912.72,
+                                             -909968.64000000001,
+                                             1029087.28,
+                                             1490031.3600000001])
+        self.assertTrue(area_def < test_area)
+        self.assertTrue(area_def <= test_area)
+        self.assertFalse(area_def > test_area)
+        self.assertFalse(area_def >= test_area)
+
+    def test_area_comparisons_bad_proj(self):
+        area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
+                                           {'a': '6378144.0',
+                                            'b': '6356759.0',
+                                            'lat_0': '50.00',
+                                            'lat_ts': '50.00',
+                                            'lon_0': '8.00',
+                                            'proj': 'stere'},
+                                           800,
+                                           800,
+                                           [-1370912.72,
+                                            -909968.64000000001,
+                                            1029087.28,
+                                            1490031.3600000001])
+
+        test_area = geometry.AreaDefinition('test', 'test',
+                                            'test',
+                                            {'a': '6378144.0',
+                                             'lat_0': '50.00',
+                                             'lon_0': '8.00',
+                                             'proj': 'stere'},
+                                            3712,
+                                            3712,
+                                            [-1370912.72,
+                                             -909968.64000000001,
+                                             1029087.28,
+                                             1490031.3600000001])
+        self.assertRaises(ValueError, area_def.__lt__, test_area)
+        self.assertRaises(ValueError, area_def.__le__, test_area)
+        self.assertRaises(ValueError, area_def.__gt__, test_area)
+        self.assertRaises(ValueError, area_def.__ge__, test_area)
 
     def test_swath_equal_area(self):
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
@@ -399,6 +462,18 @@ class Test(unittest.TestCase):
 
         self.assertFalse(
             area_def == swath_def, "swath_def and area_def should be different")
+
+    def test_swath_comparisons(self):
+        lons = np.array([1.2, 1.3, 1.4, 1.5])
+        lats = np.array([65.9, 65.86, 65.82, 65.78])
+        swath_def1 = geometry.SwathDefinition(lons, lats)
+        lons = np.repeat(lons, 2)
+        lats = np.repeat(lats, 2)
+        swath_def2 = geometry.SwathDefinition(lons, lats)
+        self.assertTrue(swath_def1 < swath_def2)
+        self.assertTrue(swath_def1 <= swath_def2)
+        self.assertFalse(swath_def1 > swath_def2)
+        self.assertFalse(swath_def1 >= swath_def2)
 
     def test_grid_filter_valid(self):
         lons = np.array([-170, -30, 30, 170])


### PR DESCRIPTION
Based on the python docs I thought it would be better to implement each method separately since it sounds like there might be a small performance penalty to using the `total_ordering` decorator. 
This PR includes better chunk handling in AreaDefinitions so that you can ask for each dimension separately.

I should probably add some tests for this.

 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
