### PR TITLE
Allow chunk size in dask methods to be 2D

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1235,9 +1235,8 @@ class AreaDefinition(BaseDefinition):
             # XXX: does pyproj copy arrays? What can we do so it doesn't?
             return np.dstack(target_proj(data1, data2, inverse=True))
 
-        res = map_blocks(invproj, target_x, target_y, chunks=(target_x.chunks[0],
-                                                              target_x.chunks[1],
-                                                              2),
+        res = map_blocks(invproj, target_x, target_y,
+                         chunks=(target_x.chunks[0], target_x.chunks[1], 2),
                          new_axis=[2])
 
         return res[:, :, 0], res[:, :, 1]

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -1091,6 +1091,7 @@ class XArrayResamplerNN(object):
         mask_2d_added = False
         coords = {}
         try:
+            # FIXME: Use same chunk size as input data
             coord_x, coord_y = self.target_geo_def.get_proj_vectors_dask()
         except AttributeError:
             coord_x, coord_y = None, None


### PR DESCRIPTION
This PR allows the dask methods to specify a 2D chunk size. This should allow for the best performance when chunk size is shared across arrays.

 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)

