### PR TITLE
Make azimuth angle for omerc dynamic areas more robust

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -535,14 +535,14 @@ class SwathDefinition(CoordinateDefinition):
 
         # return proj_dict2points
         # We need to compute alpha-based omerc for geotiff support
-
         lonc, lat0 = Proj(**proj_dict2points)(0, 0, inverse=True)
         az1, az2, dist = Geod(**proj_dict2points).inv(lonc, lat0, lon2, lat2)
         azimuth = az1
         az1, az2, dist = Geod(**proj_dict2points).inv(lonc, lat0, lon1, lat1)
         azimuth += az1
         azimuth /= 2
-        azimuth = 180 + azimuth
+        if abs(azimuth) > 90:
+            azimuth = 180 + azimuth
 
         return {'proj': 'omerc', 'alpha': float(azimuth),
                 'lat_0': float(lat0),  'lonc': float(lonc),

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -531,15 +531,19 @@ class SwathDefinition(CoordinateDefinition):
 
         proj_dict2points = {'proj': 'omerc', 'lat_0': lat, 'ellps': ellipsoid,
                             'lat_1': lat1, 'lon_1': lon1,
-                            'lat_2': lat2, 'lon_2': lon2}
+                            'lat_2': lat2, 'lon_2': lon2, 'no_rot': True}
+
+        # return proj_dict2points
+        # We need to compute alpha-based omerc for geotiff support
 
         lonc, lat0 = Proj(**proj_dict2points)(0, 0, inverse=True)
-        az1, az2, dist = Geod(**proj_dict2points).inv(lon1, lat1, lon2, lat2)
-        if abs(lat1) > abs(lat2):
-            azimuth = az2
-        else:
-            azimuth = az1
-        del az1, az2, dist
+        az1, az2, dist = Geod(**proj_dict2points).inv(lonc, lat0, lon2, lat2)
+        azimuth = az1
+        az1, az2, dist = Geod(**proj_dict2points).inv(lonc, lat0, lon1, lat1)
+        azimuth += az1
+        azimuth /= 2
+        azimuth = 180 + azimuth
+
         return {'proj': 'omerc', 'alpha': float(azimuth),
                 'lat_0': float(lat0),  'lonc': float(lonc),
                 'no_rot': True, 'ellps': ellipsoid}

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -534,9 +534,13 @@ class SwathDefinition(CoordinateDefinition):
                             'lat_2': lat2, 'lon_2': lon2}
 
         lonc, lat0 = Proj(**proj_dict2points)(0, 0, inverse=True)
-        az1, az2, dist = Geod(**proj_dict2points).inv(lonc, lat0, lon1, lat1)
-        del az2, dist
-        return {'proj': 'omerc', 'alpha': float(az1),
+        az1, az2, dist = Geod(**proj_dict2points).inv(lon1, lat1, lon2, lat2)
+        if abs(lat1) > abs(lat2):
+            azimuth = az2
+        else:
+            azimuth = az1
+        del az1, az2, dist
+        return {'proj': 'omerc', 'alpha': float(azimuth),
                 'lat_0': float(lat0),  'lonc': float(lonc),
                 'no_rot': True, 'ellps': ellipsoid}
 

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -539,14 +539,24 @@ class SwathDefinition(CoordinateDefinition):
         az1, az2, dist = Geod(**proj_dict2points).inv(lonc, lat0, lon2, lat2)
         azimuth = az1
         az1, az2, dist = Geod(**proj_dict2points).inv(lonc, lat0, lon1, lat1)
-        azimuth += az1
-        azimuth /= 2
+        if abs(az1 - azimuth) > 1:
+            if abs(az2 - azimuth) > 1:
+                logger.warning("Can't find appropriate azimuth.")
+            else:
+                azimuth += az2
+                azimuth /= 2
+        else:
+            azimuth += az1
+            azimuth /= 2
+
         if abs(azimuth) > 90:
             azimuth = 180 + azimuth
 
-        return {'proj': 'omerc', 'alpha': float(azimuth),
-                'lat_0': float(lat0),  'lonc': float(lonc),
-                'no_rot': True, 'ellps': ellipsoid}
+        prj_params = {'proj': 'omerc', 'alpha': float(azimuth),
+                      'lat_0': float(lat0),  'lonc': float(lonc),
+                      'no_rot': True, 'ellps': ellipsoid}
+
+        return prj_params
 
     def _compute_generic_parameters(self, projection, ellipsoid):
         """Compute the projection bb parameters for most projections."""

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -844,9 +844,9 @@ class TestSwathDefinition(unittest.TestCase):
                          [81.26400756835938, 29.672000885009766, 10.260000228881836]]).T
 
         area = geometry.SwathDefinition(lons, lats)
-        proj_dict = {'no_rot': True, 'lonc': 5.340645620216994,
+        proj_dict = {'no_rot': True, 'lonc': -11.391744043133668,
                      'ellps': 'WGS84', 'proj': 'omerc',
-                     'alpha': 19.022450179020247, 'lat_0': 60.7420043944989}
+                     'alpha': 9.185764390923012, 'lat_0': -0.2821013754097188}
         assert_np_dict_allclose(area._compute_omerc_parameters('WGS84'),
                                 proj_dict)
 
@@ -902,13 +902,13 @@ class TestSwathDefinition(unittest.TestCase):
 
         res = area.compute_optimal_bb_area({'proj': 'omerc', 'ellps': 'WGS84'})
 
-        np.testing.assert_allclose(res.area_extent, (2286629.731529,
-                                                     -2359693.817959,
-                                                     11729881.856072,
-                                                     2437001.523925))
-        proj_dict = {'no_rot': True, 'lonc': 5.340645620216994,
+        np.testing.assert_allclose(res.area_extent, [2253027.149539,
+                                                     -2348379.728104,
+                                                     11687636.846985,
+                                                     2432121.058435])
+        proj_dict = {'no_rot': True, 'lonc': -11.391744043133668,
                      'ellps': 'WGS84', 'proj': 'omerc',
-                     'alpha': 19.022450179020247, 'lat_0': 60.7420043944989}
+                     'alpha': 9.185764390923012, 'lat_0': -0.2821013754097188}
         assert_np_dict_allclose(res.proj_dict, proj_dict)
         self.assertEqual(res.shape, (3, 3))
 
@@ -1095,25 +1095,6 @@ class TestDynamicAreaDefinition(unittest.TestCase):
 
     def test_freeze_with_bb(self):
         """Test freezing the area with bounding box computation."""
-        # area = geometry.DynamicAreaDefinition('test_area', 'A test area',
-        #                                       {'proj': 'omerc'},
-        #                                       optimize_projection=False)
-        # lons = [[10, 12.1, 14.2, 16.3],
-        #         [10, 12, 14, 16],
-        #         [10, 11.9, 13.8, 15.7]]
-        # lats = [[66, 67, 68, 69.],
-        #         [58, 59, 60, 61],
-        #         [50, 51, 52, 53]]
-        # sdef = geometry.SwathDefinition(lons, lats)
-        # result = area.freeze(sdef,
-        #                      resolution=1000)
-        # self.assertTupleEqual(result.area_extent, (5578795.1654752363,
-        #                                            -270848.61872542271,
-        #                                            7694893.3964453982,
-        #                                            126974.877141819))
-        # self.assertEqual(result.x_size, 2116)
-        # self.assertEqual(result.y_size, 398)
-
         area = geometry.DynamicAreaDefinition('test_area', 'A test area',
                                               {'proj': 'omerc'},
                                               optimize_projection=True)
@@ -1126,10 +1107,10 @@ class TestDynamicAreaDefinition(unittest.TestCase):
         sdef = geometry.SwathDefinition(lons, lats)
         result = area.freeze(sdef,
                              resolution=1000)
-        np.testing.assert_allclose(result.area_extent, (5050520.6077326955,
-                                                        -336485.86803662963,
-                                                        8223167.9541879389,
-                                                        192612.12645302597))
+        np.testing.assert_allclose(result.area_extent, [5016583.682258,
+                                                        -336277.698941,
+                                                        8184964.697984,
+                                                        192456.651909])
         self.assertEqual(result.x_size, 3)
         self.assertEqual(result.y_size, 4)
 


### PR DESCRIPTION
Fix omerc dynamic area computation to choose the best angle.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)
