### PR TITLE
Fix get_area_slices edge case when target is larger than source

### DIFF
--- a/docs/source/swath.rst
+++ b/docs/source/swath.rst
@@ -301,7 +301,7 @@ Function for resampling using bilinear interpolation for irregular source grids.
  ...                                     reduce_data=True, segments=None,
  ...                                     epsilon=0)
 
-The **target_area** needs to be an area definition with **proj4_string**
+The **target_area** needs to be an area definition with **proj_str**
 attribute.
 
 ..

--- a/pyresample/bilinear/__init__.py
+++ b/pyresample/bilinear/__init__.py
@@ -235,7 +235,7 @@ def get_bil_info(source_geo_def, target_area_def, radius=50e3, neighbours=32,
     idx_ref = np.where(index_mask, 0, idx_ref)
 
     # Get output projection as pyproj object
-    proj = Proj(target_area_def.proj4_string)
+    proj = Proj(target_area_def.proj_str)
 
     # Get output x/y coordinates
     out_x, out_y = _get_output_xy(target_area_def, proj)

--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -126,7 +126,7 @@ class XArrayResamplerBilinear(object):
         index_array = da.where(index_mask, 0, index_array)
 
         # Get output projection as pyproj object
-        proj = Proj(self.target_geo_def.proj4_string)
+        proj = Proj(self.target_geo_def.proj_str)
 
         # Get output x/y coordinates
         out_x, out_y = _get_output_xy_dask(self.target_geo_def, proj)

--- a/pyresample/ewa/__init__.py
+++ b/pyresample/ewa/__init__.py
@@ -115,7 +115,7 @@ def ll2cr(swath_def, area_def, fill=np.nan, copy=True):
         lats = lats.astype(np.float64)
 
     # Break the input area up in to the expected parameters for ll2cr
-    p = area_def.proj4_string
+    p = area_def.proj_str
     cw = area_def.pixel_size_x
     # cell height must be negative for this to work as expected
     ch = -abs(area_def.pixel_size_y)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1375,16 +1375,7 @@ class AreaDefinition(BaseDefinition):
         return self[yslice, xslice]
 
     def __getitem__(self, key):
-        """Apply slices to the area_extent and size of the area.
-
-        .. note::
-
-            Slices are treated like normal numpy slices, meaning the start
-            index is inclusive and the stop index is exclusive. This differs
-            from pandas/xarray which treat a slice's stop as inclusive when
-            passed to 'isel'.
-
-        """
+        """Apply slices to the area_extent and size of the area."""
         yslice, xslice = key
         new_area_extent = ((self.pixel_upper_left[0] +
                             (xslice.start - 0.5) * self.pixel_size_x),

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1352,8 +1352,11 @@ class AreaDefinition(BaseDefinition):
             return slice(xstart, xstop), slice(ystart, ystop)
 
         data_boundary = Boundary(*get_geostationary_bounding_box(self))
+        if area_to_cover.proj_dict['proj'] == 'geos':
+            area_boundary = Boundary(*get_geostationary_bounding_box(area_to_cover))
+        else:
+            area_boundary = AreaDefBoundary(area_to_cover, 100)
 
-        area_boundary = AreaDefBoundary(area_to_cover, 100)
         intersection = data_boundary.contour_poly.intersection(
             area_boundary.contour_poly)
         if intersection is None:
@@ -1429,8 +1432,8 @@ def get_geostationary_bounding_box(geos_area, nb_points=50):
 
     # generate points around the north hemisphere in satellite projection
     # make it a bit smaller so that we stay inside the valid area
-    x = np.cos(np.linspace(-np.pi, 0, nb_points / 2)) * (xmax - 0.0001)
-    y = -np.sin(np.linspace(-np.pi, 0, nb_points / 2)) * (ymax - 0.0001)
+    x = np.cos(np.linspace(-np.pi, 0, int(nb_points / 2))) * (xmax - 0.0001)
+    y = -np.sin(np.linspace(-np.pi, 0, int(nb_points / 2))) * (ymax - 0.0001)
 
     ll_x, ll_y, ur_x, ur_y = geos_area.area_extent
 

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1353,7 +1353,8 @@ class AreaDefinition(BaseDefinition):
 
         data_boundary = Boundary(*get_geostationary_bounding_box(self))
         if area_to_cover.proj_dict['proj'] == 'geos':
-            area_boundary = Boundary(*get_geostationary_bounding_box(area_to_cover))
+            area_boundary = Boundary(
+                *get_geostationary_bounding_box(area_to_cover))
         else:
             area_boundary = AreaDefBoundary(area_to_cover, 100)
 
@@ -1365,7 +1366,8 @@ class AreaDefinition(BaseDefinition):
         x, y = self.get_xy_from_lonlat(np.rad2deg(intersection.lon),
                                        np.rad2deg(intersection.lat))
 
-        return slice(np.ma.min(x), np.ma.max(x) + 1), slice(np.ma.min(y), np.ma.max(y) + 1)
+        return (slice(np.ma.min(x), np.ma.max(x) + 1),
+                slice(np.ma.min(y), np.ma.max(y) + 1))
 
     def crop_around(self, other_area):
         """Crop this area around `other_area`."""

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -81,6 +81,15 @@ class BaseDefinition(object):
         self.cartesian_coords = None
         self.hash = None
 
+    def __getitem__(self, key):
+        """Slice a 2D geographic definition."""
+        y_slice, x_slice = key
+        return self.__class__(
+            lons=self.lons[y_slice, x_slice],
+            lats=self.lats[y_slice, x_slice],
+            nprocs=self.nprocs
+        )
+
     def __hash__(self):
         """Compute the hash of this object."""
         if self.hash is None:

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -154,19 +154,19 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(res[0], 0.5, 5)
 
     def test_get_output_xy(self):
-        proj = Proj(self.target_def.proj4_string)
+        proj = Proj(self.target_def.proj_str)
         out_x, out_y = bil._get_output_xy(self.target_def, proj)
         self.assertTrue(out_x.all())
         self.assertTrue(out_y.all())
 
     def test_get_input_xy(self):
-        proj = Proj(self.target_def.proj4_string)
+        proj = Proj(self.target_def.proj_str)
         in_x, in_y = bil._get_output_xy(self.swath_def, proj)
         self.assertTrue(in_x.all())
         self.assertTrue(in_y.all())
 
     def test_get_bounding_corners(self):
-        proj = Proj(self.target_def.proj4_string)
+        proj = Proj(self.target_def.proj_str)
         out_x, out_y = bil._get_output_xy(self.target_def, proj)
         in_x, in_y = bil._get_input_xy(self.swath_def, proj,
                                        self.input_idxs, self.idx_ref)

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -852,6 +852,17 @@ class TestSwathDefinition(unittest.TestCase):
         self.assertFalse(id(lons1) != id(lons2) or id(lats1) != id(lats2),
                          msg='Caching of swath coordinates failed')
 
+    def test_slice(self):
+        """Test that SwathDefinitions can be sliced."""
+        lons1 = np.fromfunction(lambda y, x: 3 + (10.0 / 100) * x, (5000, 100))
+        lats1 = np.fromfunction(
+            lambda y, x: 75 - (50.0 / 5000) * y, (5000, 100))
+
+        swath_def = geometry.SwathDefinition(lons1, lats1)
+        new_swath_def = swath_def[1000:4000, 20:40]
+        self.assertTupleEqual(new_swath_def.lons.shape, (3000, 20))
+        self.assertTupleEqual(new_swath_def.lats.shape, (3000, 20))
+
     def test_concat_1d(self):
         lons1 = np.array([1, 2, 3])
         lats1 = np.array([1, 2, 3])

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -743,8 +743,8 @@ class Test(unittest.TestCase):
         self.assertTrue((x__.data == x_expects).all())
         self.assertTrue((y__.data == y_expects).all())
 
-    def test_get_area_slices(self):
-        """Check area slicing."""
+    def test_get_area_slices_same_proj(self):
+        """Check area slicing with equal projections."""
         from pyresample import utils
         area_id = 'cover'
         area_name = 'Area to cover'
@@ -811,10 +811,10 @@ class Test(unittest.TestCase):
                                        proj_dict, 10, 10,
                                        [-1370912.72, -909968.64, 1029087.28,
                                         1490031.36])
-        self.assertEquals(area.proj4_string,
+        self.assertEquals(area.proj_str,
                           '+proj=stere +a=6378144.0 +b=6356759.0 +lat_0=50.0 +lat_ts=50.0 +lon_0=8.0')
         proj_dict['no_rot'] = ''
-        self.assertEquals(area.proj4_string,
+        self.assertEquals(area.proj_str,
                           '+proj=stere +a=6378144.0 +b=6356759.0 +lat_0=50.0 +lat_ts=50.0 +lon_0=8.0 +no_rot')
 
 

--- a/pyresample/test/test_grid.py
+++ b/pyresample/test/test_grid.py
@@ -201,7 +201,7 @@ class Test(unittest.TestCase):
             lat, 52.566998432390619, msg='Resampling of single lat failed')
 
     def test_proj4_string(self):
-        proj4_string = self.area_def.proj4_string
+        proj4_string = self.area_def.proj_str
         expected_string = '+a=6378144.0 +b=6356759.0 +lat_ts=50.00 +lon_0=8.00 +proj=stere +lat_0=50.00'
         self.assertEqual(
             frozenset(proj4_string.split()), frozenset(expected_string.split()))


### PR DESCRIPTION
There was a strange error I was getting when my destination (target) area for resampling in satpy was larger than the source area. During the resampling step of slicing away source data that wasn't needed I was running in to index errors. This PR fixes the two errors I encountered while fixing my use case and addresses one duplicate property in the area definition class.

First, it is possible for boundary intersections to be invalid in one of the projections so we have to make sure to take `np.ma.min(x)` instead of just `x.min()` where the latter could potentially returned masked values.

Second, the `get_xy_from_X` type methods had an off-by-one error where the index returned could be equal to the length of the array when that number is actually invalid (max index is length of array - 1). This was causing issues in the `get_area_slices` logic where it was adding `+ 1` to any valid indexes returned. This `+ 1` is needed  for the "stop" part of a slice which is exclusive (ex. `a[slice(5, 25)]` includes index 5 up to but not including index 25). So the end result was a slice being returned by `get_area_slices` that was 2 more than the highest valid index (size of array + 1).

Third, I noticed that in the past I apparently added a `proj_str` property when there was already a `proj4_string` property. After talking with @mraspaud we decided that it didn't really matter which one we used but that `proj_str` is probably more consistent with `proj_dict` which also exists.

I also changed the `get_area_slices` logic to make sure that source/target projects are exactly the same instead of just both being `geos`. I could probably now move the assertion that the source projection be `geos` to after the check if the projections are the same. @mraspaud Thoughts?

Lastly, there were a few cleanups I did in the tests including removing an old python 2.6 compatibility method for `assert_raises`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
