### PR TITLE
Fix TestArc failure on some architectures.

### DIFF
--- a/pyresample/test/test_spherical.py
+++ b/pyresample/test/test_spherical.py
@@ -185,7 +185,7 @@ class TestArc(unittest.TestCase):
         lon, lat = arc1.intersection(arc2)
 
         self.assertTrue(np.allclose(np.rad2deg(lon), 5))
-        self.assertEquals(np.rad2deg(lat), 5.0575148968282093)
+        self.assertEquals(np.rad2deg(lat).round(7), round(5.0575148968282093, 7))
 
         arc1 = Arc(SCoordinate(0, 0),
                    SCoordinate(np.deg2rad(10), np.deg2rad(10)))


### PR DESCRIPTION
The pyresample 1.9.3 Debian package failed to build on some architectures ([arm64](https://buildd.debian.org/status/fetch.php?pkg=pyresample&arch=arm64&ver=1.9.3-1&stamp=1528790874&raw=0), [i386](https://buildd.debian.org/status/fetch.php?pkg=pyresample&arch=i386&ver=1.9.3-1&stamp=1528790751&raw=0), [ppc64el](https://buildd.debian.org/status/fetch.php?pkg=pyresample&arch=ppc64el&ver=1.9.3-1&stamp=1528790956&raw=0), [s390x](https://buildd.debian.org/status/fetch.php?pkg=pyresample&arch=s390x&ver=1.9.3-1&stamp=1528790549&raw=0), [powerpc](https://buildd.debian.org/status/fetch.php?pkg=pyresample&arch=powerpc&ver=1.9.3-1&stamp=1528790853&raw=0), [ppc64](https://buildd.debian.org/status/fetch.php?pkg=pyresample&arch=ppc64&ver=1.9.3-1&stamp=1528791735&raw=0), [riscv64](https://buildd.debian.org/status/fetch.php?pkg=pyresample&arch=riscv64&ver=1.9.3-1&stamp=1528797680&raw=0)) due to `test_intersection` failure:
```
======================================================================
FAIL: test_intersection (pyresample.test.test_spherical.TestArc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/pyresample/test/test_spherical.py", line 188, in test_intersection
    self.assertEquals(np.rad2deg(lat), 5.0575148968282093)
AssertionError: array([5.0575149]) != 5.057514896828209

----------------------------------------------------------------------
```

This is fixed by rounding the values to seven decimals.

 - [x] Tests passed
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff``
