### PR TITLE
Fix log message not to rely on the proj key

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1344,7 +1344,8 @@ class AreaDefinition(BaseDefinition):
         # Intersection only required for two different projections
         if area_to_cover.proj_str == self.proj_str:
             logger.debug('Projections for data and slice areas are'
-                         ' identical: %s', area_to_cover.proj_dict['proj'])
+                         ' identical: %s',
+                         area_to_cover.proj_dict.get('proj', area_to_cover.proj_dict.get('init')))
             # Get xy coordinates
             llx, lly, urx, ury = area_to_cover.area_extent
             x, y = self.get_xy_from_proj_coords([llx, urx], [lly, ury])


### PR DESCRIPTION

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
