### PR TITLE
Remove warning about cartopy 0.17

### DIFF
--- a/pyresample/_cartopy.py
+++ b/pyresample/_cartopy.py
@@ -33,8 +33,6 @@ import shapely.geometry as sgeom
 try:
     from cartopy.crs import from_proj
 except ImportError:
-    warnings.warn("'cartopy' >= 0.17 required for better 'from_proj' "
-                  "functionality.")
     from_proj = None
 
 logger = getLogger(__name__)


### PR DESCRIPTION
The warning was supposed to show that a recent version of cartopy should have the PROJ.4 -> CRS functionality, but this still hasn't been added to cartopy so the warning is confusing.

 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
