### PR TITLE
Fix area parsing code to convert PROJ.4 parameters to float if possible

### DIFF
--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -22,20 +22,22 @@ class TestLegacyAreaParser(unittest.TestCase):
         nh_str = """Area ID: ease_nh
 Description: Arctic EASE grid
 Projection ID: ease_nh
-Projection: {'a': '6371228.0', 'lat_0': '90', 'lon_0': '0', 'proj': 'laea', 'units': 'm'}
+Projection: {'a': '6371228.0', 'lat_0': '90.0', 'lon_0': '0.0', 'proj': 'laea', 'units': 'm'}
 Number of columns: 425
 Number of rows: 425
 Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)"""
         self.assertEquals(ease_nh.__str__(), nh_str)
+        self.assertIsInstance(ease_nh.proj_dict['lat_0'], float)
 
         sh_str = """Area ID: ease_sh
 Description: Antarctic EASE grid
 Projection ID: ease_sh
-Projection: {'a': '6371228.0', 'lat_0': '-90', 'lon_0': '0', 'proj': 'laea', 'units': 'm'}
+Projection: {'a': '6371228.0', 'lat_0': '-90.0', 'lon_0': '0.0', 'proj': 'laea', 'units': 'm'}
 Number of columns: 425
 Number of rows: 425
 Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)"""
         self.assertEquals(ease_sh.__str__(), sh_str)
+        self.assertIsInstance(ease_sh.proj_dict['lat_0'], float)
 
     def test_load_area(self):
         from pyresample import utils
@@ -45,7 +47,7 @@ Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)"""
         nh_str = """Area ID: ease_nh
 Description: Arctic EASE grid
 Projection ID: ease_nh
-Projection: {'a': '6371228.0', 'lat_0': '90', 'lon_0': '0', 'proj': 'laea', 'units': 'm'}
+Projection: {'a': '6371228.0', 'lat_0': '90.0', 'lon_0': '0.0', 'proj': 'laea', 'units': 'm'}
 Number of columns: 425
 Number of rows: 425
 Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)"""
@@ -246,6 +248,8 @@ class TestMisc(unittest.TestCase):
         proj_str2 = utils.proj4_dict_to_str(proj_dict)
         proj_dict2 = utils.proj4_str_to_dict(proj_str2)
         self.assertDictEqual(proj_dict, proj_dict2)
+        self.assertIsInstance(proj_dict['lon_0'], float)
+        self.assertIsInstance(proj_dict2['lon_0'], float)
 
 
 def suite():

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -408,6 +408,22 @@ def fwhm2sigma(fwhm):
     return fwhm / (2 * np.sqrt(np.log(2)))
 
 
+def _convert_proj_floats(proj_pairs):
+    """Convert PROJ.4 parameters to floats if possible."""
+    proj_dict = {}
+    for x in proj_pairs:
+        if len(x) == 1:
+            proj_dict[x[0]] = True
+            continue
+
+        try:
+            proj_dict[x[0]] = float(x[1])
+        except ValueError:
+            proj_dict[x[0]] = x[1]
+
+    return proj_dict
+
+
 def _get_proj4_args(proj4_args):
     """Create dict from proj4 args
     """
@@ -416,7 +432,7 @@ def _get_proj4_args(proj4_args):
         proj_config = ConfigObj(str(proj4_args).replace('+', '').split())
     else:
         proj_config = ConfigObj(proj4_args)
-    return proj_config.dict()
+    return _convert_proj_floats(proj_config.dict().items())
 
 
 def proj4_str_to_dict(proj4_str):
@@ -425,7 +441,7 @@ def proj4_str_to_dict(proj4_str):
     Note: Key only parameters will be assigned a value of `True`.
     """
     pairs = (x.split('=', 1) for x in proj4_str.replace('+', '').split(" "))
-    return dict((x[0], (x[1] if len(x) == 2 else True)) for x in pairs)
+    return _convert_proj_floats(pairs)
 
 
 def proj4_dict_to_str(proj4_dict, sort=False):


### PR DESCRIPTION
Legacy file format was producing area definition objects where PROJ.4 dictionaries had numeric values (lon_0, lat_0, etc) that were being stored as strings in the AreaDefinition. This is undesired in 99% of the use cases that I can think of. This PR makes it so any time (at least in the utility functions) a PROJ.4 string is converted to a dictionary the parameters are converted to floats when possible.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

This was pointed out by @yufeizhu600 and @goodsonr as an issue in some satpy use cases.