### PR TITLE
Non-contiguous area definitions are now not concatenable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ env:
   - PYTHON_VERSION=$PYTHON_VERSION
   - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='xarray dask toolz Cython pykdtree sphinx cartopy rasterio kealib pillow matplotlib
+  - CONDA_DEPENDENCIES='xarray dask toolz Cython pykdtree sphinx cartopy rasterio pillow matplotlib
     pyyaml pyproj coveralls configobj coverage codecov'
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request'
   - SETUP_CMD='test'
   - CONDA_CHANNELS='conda-forge'
+  - CONDA_CHANNEL_PRIORITY='True'
 matrix:
   include:
   - env: PYTHON_VERSION=2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
     CONDA_DEPENDENCIES: "xarray dask toolz Cython pykdtree sphinx cartopy rasterio pillow matplotlib pyyaml pyproj coveralls configobj coverage"
     CONDA_CHANNELS: "conda-forge"
+    CONDA_CHANNEL_PRIORITY: "True"
 
   matrix:
     - PYTHON: "C:\\Python27_32"

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1449,13 +1449,17 @@ def get_geostationary_bounding_box(geos_area, nb_points=50):
 
 def combine_area_extents_vertical(area1, area2):
     """Combine the area extents of areas 1 and 2."""
-    if (area1.area_extent[0] == area2.area_extent[0] and
-            area1.area_extent[2] == area2.area_extent[2]):
+    if (area1.area_extent[0] == area2.area_extent[0]
+            and area1.area_extent[2] == area2.area_extent[2]):
         current_extent = list(area1.area_extent)
         if np.isclose(area1.area_extent[1], area2.area_extent[3]):
             current_extent[1] = area2.area_extent[1]
         elif np.isclose(area1.area_extent[3], area2.area_extent[1]):
             current_extent[3] = area2.area_extent[3]
+        else:
+            raise IncompatibleAreas(
+                "Can't concatenate non-contiguous area definitions: "
+                "{0} and {1}".format(area1, area2))
     else:
         raise IncompatibleAreas(
             "Can't concatenate area definitions with "

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1266,6 +1266,14 @@ class TestStackedAreaDefinition(unittest.TestCase):
         res = combine_area_extents_vertical(area1, area2)
         self.assertListEqual(res, [1, 2, 3, 6])
 
+        # Non contiguous area extends shouldn't be combinable
+        area1 = MagicMock()
+        area1.area_extent = (1, 2, 3, 4)
+        area2 = MagicMock()
+        area2.area_extent = (1, 5, 3, 7)
+        self.assertRaises(IncompatibleAreas,
+                          combine_area_extents_vertical, area1, area2)
+
     def test_append_area_defs_fail(self):
         """Fail appending areas."""
         area1 = MagicMock()


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

 - [x] Closes pytroll/satpy#491 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
