### PR TITLE
Refactor and deprecate geometry "*_dask" methods

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,13 @@ install:
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
+    # HACK: Copy tiff.dll to libtiff.dll
+    - "cd %PYTHON%\\envs\\test\\Library\\bin"
+    - "dir"
+    - "dir tiff.dll"
+    - "echo %cd%"
+    - "copy tiff.dll libtiff.dll"
+    - "cd C:\\projects\\satpy"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,9 +35,6 @@ install:
     - "activate test"
     # HACK: Copy tiff.dll to libtiff.dll
     - "cd %PYTHON%\\envs\\test\\Library\\bin"
-    - "dir"
-    - "dir tiff.dll"
-    - "echo %cd%"
     - "copy tiff.dll libtiff.dll"
     - "cd C:\\projects\\pyresample"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
     - "dir tiff.dll"
     - "echo %cd%"
     - "copy tiff.dll libtiff.dll"
-    - "cd C:\\projects\\satpy"
+    - "cd C:\\projects\\pyresample"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1116,12 +1116,13 @@ class AreaDefinition(BaseDefinition):
         """Helper method to apply a rotation factor to a matrix of points."""
         if hasattr(xspan, 'chunks'):
             # we were given dask arrays, use dask functions
-            import dask.array as np
-        rot_rad = np.radians(rot_deg)
-        rot_mat = np.array([[np.cos(rot_rad),  np.sin(rot_rad)],
-                            [-np.sin(rot_rad), np.cos(rot_rad)]])
-        x, y = np.meshgrid(xspan, yspan)
-        return np.einsum('ji, mni -> jmn', rot_mat, np.dstack([x, y]))
+            import dask.array as numpy
+        else:
+            numpy = np
+        rot_rad = numpy.radians(rot_deg)
+        rot_mat = numpy.array([[np.cos(rot_rad),  np.sin(rot_rad)], [-np.sin(rot_rad), np.cos(rot_rad)]])
+        x, y = numpy.meshgrid(xspan, yspan)
+        return numpy.einsum('ji, mni -> jmn', rot_mat, numpy.dstack([x, y]))
 
     def get_proj_vectors_dask(self, chunks=None, dtype=None):
         if chunks is None:
@@ -1192,7 +1193,7 @@ class AreaDefinition(BaseDefinition):
         (target_x, target_y) : tuple of numpy arrays
             Grids of area x- and y-coordinates in projection units
 
-        .. versionchanged:: 1.10.2
+        .. versionchanged:: 1.11.0
 
             Removed 'cache' keyword argument and add 'chunks' for creating
             dask arrays.
@@ -1206,7 +1207,7 @@ class AreaDefinition(BaseDefinition):
             target_x = target_x[data_slice[1]]
 
         if self.rotation != 0:
-            res = self.do_rotation(target_x, target_y, self.rotation)
+            res = self._do_rotation(target_x, target_y, self.rotation)
             target_x, target_y = res[0, :, :], res[1, :, :]
         elif chunks is not None:
             import dask.array as da

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1255,16 +1255,6 @@ class AreaDefinition(BaseDefinition):
             return self.get_proj_vectors()[1]
 
     @property
-    def proj_x_coords(self):
-        warnings.warn("Deprecated, use 'projection_x_coords' instead", DeprecationWarning)
-        return self.projection_x_coords
-
-    @property
-    def proj_y_coords(self):
-        warnings.warn("Deprecated, use 'projection_y_coords' instead", DeprecationWarning)
-        return self.projection_y_coords
-
-    @property
     def outer_boundary_corners(self):
         """Return the lon,lat of the outer edges of the corner points."""
         from pyresample.spherical_geometry import Coordinate

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1125,9 +1125,11 @@ class AreaDefinition(BaseDefinition):
         return numpy.einsum('ji, mni -> jmn', rot_mat, numpy.dstack([x, y]))
 
     def get_proj_vectors_dask(self, chunks=None, dtype=None):
+        warnings.warn("'get_proj_vectors_dask' is deprecated, please use "
+                      "'get_proj_vectors' with the 'chunks' keyword argument specified.")
         if chunks is None:
             chunks = CHUNK_SIZE  # FUTURE: Use a global config object instead
-        return self._get_proj_vectors(dtype=dtype, chunks=chunks)
+        return self.get_proj_vectors(dtype=dtype, chunks=chunks)
 
     def _get_proj_vectors(self, dtype=None, check_rotation=True, chunks=None):
         """Helper for getting 1D projection coordinates."""
@@ -1158,18 +1160,28 @@ class AreaDefinition(BaseDefinition):
         target_y = arange(self.y_size, **y_kwargs) * -self.pixel_size_y + self.pixel_upper_left[1]
         return target_x, target_y
 
-    def get_proj_vectors(self, dtype=None):
+    def get_proj_vectors(self, dtype=None, chunks=None):
         """Calculate 1D projection coordinates for the X and Y dimension.
+
+        Parameters
+        ----------
+        dtype : numpy.dtype
+            Numpy data type for the returned arrays
+        chunks : int or tuple
+            Return dask arrays with the chunk size specified. If this is a
+            tuple then the first element is the Y array's chunk size and the
+            second is the X array's chunk size.
 
         Returns
         -------
         tuple: (X, Y) where X and Y are 1-dimensional numpy arrays
 
         The data type of the returned arrays can be controlled with the
-        `dtype` keyword argument.
+        `dtype` keyword argument. If `chunks` is provided then dask arrays
+        are returned instead.
 
         """
-        return self._get_proj_vectors(dtype=dtype)
+        return self._get_proj_vectors(dtype=dtype, chunks=chunks)
 
     def get_proj_coords_dask(self, chunks=None, dtype=None):
         if chunks is None:

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -251,6 +251,9 @@ class BaseDefinition(object):
         -------
         cartesian_coords : numpy array
         """
+        if cache:
+            warnings.warn("'cache' keyword argument will be removed in the "
+                          "future and data will not be cached.", PendingDeprecationWarning)
 
         if self.cartesian_coords is None:
             # Coordinates are not cached
@@ -1307,6 +1310,9 @@ class AreaDefinition(BaseDefinition):
             Grids of area lons and and lats
         """
 
+        if cache:
+            warnings.warn("'cache' keyword argument will be removed in the "
+                          "future and data will not be cached.", PendingDeprecationWarning)
         if dtype is None:
             dtype = self.dtype
 

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -688,7 +688,7 @@ class Test(unittest.TestCase):
         xcoord, ycoord = area_def.get_proj_coords()
         np.testing.assert_allclose(xcoord[0, :],
                                    np.array([742462.120246, 745997.654152, 749533.188058, 753068.721964,
-                                             756604.25587 , 760139.789776, 763675.323681, 767210.857587,
+                                             756604.25587, 760139.789776, 763675.323681, 767210.857587,
                                              770746.391493, 774281.925399]))
         np.testing.assert_allclose(ycoord[:, 0],
                                    np.array([-675286.976033, -678822.509939, -682358.043845, -685893.577751,
@@ -697,7 +697,7 @@ class Test(unittest.TestCase):
 
         xcoord, ycoord = area_def.get_proj_coords(data_slice=(slice(None, None, 2), slice(None, None, 2)))
         np.testing.assert_allclose(xcoord[0, :],
-                                   np.array([742462.120246, 749533.188058, 756604.25587 , 763675.323681,
+                                   np.array([742462.120246, 749533.188058, 756604.25587, 763675.323681,
                                              770746.391493]))
         np.testing.assert_allclose(ycoord[:, 0],
                                    np.array([-675286.976033, -682358.043845, -689429.111657, -696500.179469,

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -640,7 +640,8 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(lon__, lon_expect, rtol=0, atol=1e-7))
         self.assertTrue(np.allclose(lat__, lat_expect, rtol=0, atol=1e-7))
 
-    def test_get_proj_coords(self):
+    def test_get_proj_coords_basic(self):
+        """Test basic get_proj_coords usage."""
         from pyresample import utils
         area_id = 'test'
         area_name = 'Test area with 2x2 pixels'
@@ -648,16 +649,8 @@ class Test(unittest.TestCase):
         x_size = 10
         y_size = 10
         area_extent = [1000000, 0, 1050000, 50000]
-        proj_dict = {"proj": 'laea',
-                     'lat_0': '60',
-                     'lon_0': '0',
-                     'a': '6371228.0', 'units': 'm'}
-        area_def = utils.get_area_def(area_id,
-                                      area_name,
-                                      proj_id,
-                                      proj_dict,
-                                      x_size, y_size,
-                                      area_extent)
+        proj_dict = {"proj": 'laea', 'lat_0': '60', 'lon_0': '0', 'a': '6371228.0', 'units': 'm'}
+        area_def = utils.get_area_def(area_id, area_name, proj_id, proj_dict, x_size, y_size, area_extent)
 
         xcoord, ycoord = area_def.get_proj_coords()
         self.assertTrue(np.allclose(xcoord[0, :],
@@ -673,6 +666,74 @@ class Test(unittest.TestCase):
         xcoord, ycoord = area_def.get_proj_coords(data_slice=(slice(None, None, 2),
                                                               slice(None, None, 2)))
 
+        self.assertTrue(np.allclose(xcoord[0, :],
+                                    np.array([1002500., 1012500., 1022500.,
+                                              1032500., 1042500.])))
+        self.assertTrue(np.allclose(ycoord[:, 0],
+                                    np.array([47500., 37500., 27500., 17500.,
+                                              7500.])))
+
+    def test_get_proj_coords_rotation(self):
+        """Test basic get_proj_coords usage with rotation specified."""
+        from pyresample.geometry import AreaDefinition
+        area_id = 'test'
+        area_name = 'Test area with 2x2 pixels'
+        proj_id = 'test'
+        x_size = 10
+        y_size = 10
+        area_extent = [1000000, 0, 1050000, 50000]
+        proj_dict = {"proj": 'laea', 'lat_0': '60', 'lon_0': '0', 'a': '6371228.0', 'units': 'm'}
+        area_def = AreaDefinition(area_id, area_name, proj_id, proj_dict, x_size, y_size, area_extent, rotation=45)
+
+        xcoord, ycoord = area_def.get_proj_coords()
+        np.testing.assert_allclose(xcoord[0, :],
+                                   np.array([742462.120246, 745997.654152, 749533.188058, 753068.721964,
+                                             756604.25587 , 760139.789776, 763675.323681, 767210.857587,
+                                             770746.391493, 774281.925399]))
+        np.testing.assert_allclose(ycoord[:, 0],
+                                   np.array([-675286.976033, -678822.509939, -682358.043845, -685893.577751,
+                                             -689429.111657, -692964.645563, -696500.179469, -700035.713375,
+                                             -703571.247281, -707106.781187]))
+
+        xcoord, ycoord = area_def.get_proj_coords(data_slice=(slice(None, None, 2), slice(None, None, 2)))
+        np.testing.assert_allclose(xcoord[0, :],
+                                   np.array([742462.120246, 749533.188058, 756604.25587 , 763675.323681,
+                                             770746.391493]))
+        np.testing.assert_allclose(ycoord[:, 0],
+                                   np.array([-675286.976033, -682358.043845, -689429.111657, -696500.179469,
+                                             -703571.247281]))
+
+    def test_get_proj_coords_dask(self):
+        """Test get_proj_coords usage with dask arrays."""
+        from pyresample import utils
+        area_id = 'test'
+        area_name = 'Test area with 2x2 pixels'
+        proj_id = 'test'
+        x_size = 10
+        y_size = 10
+        area_extent = [1000000, 0, 1050000, 50000]
+        proj_dict = {"proj": 'laea', 'lat_0': '60', 'lon_0': '0', 'a': '6371228.0', 'units': 'm'}
+        area_def = utils.get_area_def(area_id, area_name, proj_id, proj_dict, x_size, y_size, area_extent)
+
+        xcoord, ycoord = area_def.get_proj_coords_dask()
+        xcoord = xcoord.compute()
+        ycoord = ycoord.compute()
+        self.assertTrue(np.allclose(xcoord[0, :],
+                                    np.array([1002500., 1007500., 1012500.,
+                                              1017500., 1022500., 1027500.,
+                                              1032500., 1037500., 1042500.,
+                                              1047500.])))
+        self.assertTrue(np.allclose(ycoord[:, 0],
+                                    np.array([47500., 42500., 37500., 32500.,
+                                              27500., 22500., 17500., 12500.,
+                                              7500.,  2500.])))
+
+        # use the shared method and provide chunks and slices
+        xcoord, ycoord = area_def.get_proj_coords(data_slice=(slice(None, None, 2),
+                                                              slice(None, None, 2)),
+                                                  chunks=4096)
+        xcoord = xcoord.compute()
+        ycoord = ycoord.compute()
         self.assertTrue(np.allclose(xcoord[0, :],
                                     np.array([1002500., 1012500., 1022500.,
                                               1032500., 1042500.])))

--- a/pyresample/test/test_swath.py
+++ b/pyresample/test/test_swath.py
@@ -42,7 +42,11 @@ class Test(unittest.TestCase):
             self.assertFalse(('Possible more' not in str(
                 w[0].message)), 'Failed to create correct neighbour radius warning')
 
-        truth_value = 668848.082208
+        if sys.platform == 'darwin':
+            # OSX seems to get slightly different results for `_spatial_mp.Cartesian`
+            truth_value = 668848.144817
+        else:
+            truth_value = 668848.082208
         self.assertAlmostEqual(res.sum() / 100., truth_value, 1,
                                msg='Failed self mapping swath for 1 channel')
 
@@ -58,7 +62,11 @@ class Test(unittest.TestCase):
             self.assertFalse(('Possible more' not in str(
                 w[0].message)), 'Failed to create correct neighbour radius warning')
 
-        truth_value = 668848.082208
+        if sys.platform == 'darwin':
+            # OSX seems to get slightly different results for `_spatial_mp.Cartesian`
+            truth_value = 668848.144817
+        else:
+            truth_value = 668848.082208
         self.assertAlmostEqual(res[:, 0].sum() / 100., truth_value, 1,
                                msg='Failed self mapping swath multi for channel 1')
         self.assertAlmostEqual(res[:, 1].sum() / 100., truth_value, 1,

--- a/pyresample/test/test_swath.py
+++ b/pyresample/test/test_swath.py
@@ -42,11 +42,7 @@ class Test(unittest.TestCase):
             self.assertFalse(('Possible more' not in str(
                 w[0].message)), 'Failed to create correct neighbour radius warning')
 
-        if sys.platform == 'darwin':
-            # OSX seems to get slightly different results for `_spatial_mp.Cartesian`
-            truth_value = 668848.144817
-        else:
-            truth_value = 668848.082208
+        truth_value = 668848.082208
         self.assertAlmostEqual(res.sum() / 100., truth_value, 1,
                                msg='Failed self mapping swath for 1 channel')
 
@@ -62,11 +58,7 @@ class Test(unittest.TestCase):
             self.assertFalse(('Possible more' not in str(
                 w[0].message)), 'Failed to create correct neighbour radius warning')
 
-        if sys.platform == 'darwin':
-            # OSX seems to get slightly different results for `_spatial_mp.Cartesian`
-            truth_value = 668848.144817
-        else:
-            truth_value = 668848.082208
+        truth_value = 668848.082208
         self.assertAlmostEqual(res[:, 0].sum() / 100., truth_value, 1,
                                msg='Failed self mapping swath multi for channel 1')
         self.assertAlmostEqual(res[:, 1].sum() / 100., truth_value, 1,


### PR DESCRIPTION
There was currently only a `get_proj_vectors_dask` method, but since we typically use dask arrays with xarray and xarray coordinates *have* to be computed and proj vectors are typically used as xarray DataArray coordinates it makes more sense to me to just provide a numpy array version of the method. Also if using dask's ProgressBar context manager using dask arrays as coordinates results in multiple progress bars for each coordinate that has to be computed. This can be confusing to some users.

Additionally this PR includes a refactor of all of these associated methods (coords/vectors) to reuse as much code as they can. This includes deprecating the `_dask` versions of the few methods that exist or at least adding a deprecation warning for them.

This PR also includes adding rotation functionality back in for the `get_proj_coords_dask` function which was previously not implemented.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
