### PR TITLE
Added another possible error in parse_area_file

### DIFF
--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -91,7 +91,7 @@ def parse_area_file(area_file_name, *regions):
 
     try:
         return _parse_yaml_area_file(area_file_name, *regions)
-    except yaml.scanner.ScannerError:
+    except (yaml.scanner.ScannerError, yaml.parser.ParserError):
         return _parse_legacy_area_file(area_file_name, *regions)
 
 


### PR DESCRIPTION
In some cases, parsing an areas.def file in the old format raises a yaml.parser.ParserError, which has therefore been added to the yaml.scanner.ScannerError.