### PR TITLE
Update installation instructions to match current best practices

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,8 +37,7 @@ class Mock(object):
 
 # If we are on read the docs then just mock external packages
 if os.environ.get("READTHEDOCS") == "True":
-    MOCK_MODULES = ['numpy', 'pykdtree', 'configobj', 'pyproj',
-                    'scipy', 'scipy.spatial', 'pyresample.ewa']
+    MOCK_MODULES = ['numpy', 'pykdtree', 'configobj', 'pyproj', 'pyresample.ewa']
     for mod_name in MOCK_MODULES:
         sys.modules[mod_name] = Mock()
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,69 +1,73 @@
 Installing Pyresample
 =====================
-Pyresample depends on pyproj, numpy(>= 1.3), scipy(>= 0.7), multiprocessing 
-(builtin package for Python > 2.5) and configobj. Optionally pykdtree can be used instead of scipy from v0.8.0.
 
-The correct version of the packages should be installed on your system 
-(refer to numpy and scipy installation instructions) or use easy_install to handle dependencies automatically.
+Pyresample depends on pyproj, numpy(>= 1.10), pyyaml, configobj, six, and pykdtree (>= 1.1.1).
 
-In order to use the pyresample plotting functionality Basemap and matplotlib (>= 0.98) must be installed. 
-These packages are not a prerequisite for using any other pyresample functionality. 
+In order to use the pyresample plotting functionality Cartopy and matplotlib (>= 1.0) must be installed.
+These packages are not a prerequisite for using any other pyresample functionality.
+
+Optionally, for dask and xarray support these libraries must also be installed.
+Some utilities like converting from rasterio objects to pyresample objects
+will require rasterio or other libraries to be installed. The older
+multiprocessing interfaces (Proj_MP) use the ``scipy`` KDTree implementation.
+Newer xarray/dask interfaces are recommended if possible.
 
 Package test
 ************
-Test the package (requires nose):
+
+Testing pyresample requires all optional packages to be installed including
+rasterio, dask, xarray, cartopy, pillow, and matplotlib. Without all of these
+dependencies some tests may fail.
+To run tests from a source tarball:
 
 .. code-block:: bash
 
-	$ tar -zxvf pyresample-<version>.tar.gz
-	$ cd pyresample-<version>
-	$ nosetests
-	
+    tar -zxf pyresample-<version>.tar.gz
+    cd pyresample-<version>
+    python setup.py test
+
 If all the tests passes the functionality of all pyresample functions on the system has been verified.
 
 Package installation
 ********************
-A sandbox environment can be created for pyresample using `Virtualenv <http://pypi.python.org/pypi/virtualenv>`_
 
-Pyresample is available from pypi.
-  
-Install Pyresample using pip:
+Pyresample is available from PyPI and can be installed with pip:
 
 .. code-block:: bash
 
-	$ pip install pyresample
+    pip install pyresample
 
-Alternatively install from tarball:
+Pyresample can also be installed with conda via the conda-forge channel:
 
 .. code-block:: bash
 
-	$ tar -zxvf pyresample-<version>.tar.gz
-	$ cd pyresample-<version>
-	$ python setup.py install
+    conda install -c conda-forge pyresample
 
-Using pykdtree
-**************
+Or directly from a source tarball:
 
-As of pyresample v0.8.0 pykdtree can be used as backend instead of scipy. 
-This enables significant speedups for large datasets.
+.. code-block:: bash
 
-pykdtree is used as a drop-in replacement for scipy. If it's available it will be used otherwise scipy will be used.
-To check which backend is active for your pyresample installation do:
+    tar -zxvf pyresample-<version>.tar.gz
+    cd pyresample-<version>
+    pip install .
 
- >>> import pyresample as pr
- >>> pr.kd_tree.which_kdtree()
+To install in a "development" mode where source file changes are immediately
+reflected in your python environment run the following instead of the above
+pip command:
 
-which returns either 'pykdtree' or 'scipy.spatial'.
+    pip install -e .
 
-Please refere to pykdtree_ for installation description.
 
-If pykdtree is built with OpenMP support the number of threads is controlled with the standard OpenMP environment variable OMP_NUM_THREADS.
-The *nprocs* argument has no effect on pykdtree.
+pykdtree and numexpr
+********************
 
-Using numexpr
-*************
+Pyresample uses the ``pykdtree`` package which can be built with
+multi-threaded support. If it is built with this support the environment
+variable ``OMP_NUM_THREADS`` can be used to control the number of threads.
+Please refer to the pykdtree_ repository for more information.
 
-As of pyresample v1.0.0 numexpr_ will be used for minor bottleneck optimization if available
+As of pyresample v1.0.0 numexpr_ will be used for minor bottleneck
+optimization if available.
 
 .. _pykdtree: https://github.com/storpipfugl/pykdtree
 .. _numexpr: https://code.google.com/p/numexpr/

--- a/docs/source/swath.rst
+++ b/docs/source/swath.rst
@@ -245,11 +245,6 @@ grid point (the nearest neighbour). Also note **distance_array** is not a requir
 Segmented resampling
 ********************
 Whenever a resampling function takes the keyword argument **segments** the number of segments to split the resampling process in can be specified. This affects the memory footprint of pyresample. If the value of **segments** is left to default pyresample will estimate the number of segments to use. 
-    
-Speedup using pykdtree
-**********************
-
-pykdtree can be used instead of scipy to gain significant speedup for large datasets. See :ref:`multi`. 
 
 pyresample.bilinear
 -------------------

--- a/pyresample/_spatial_mp.py
+++ b/pyresample/_spatial_mp.py
@@ -21,7 +21,6 @@ import ctypes
 
 import numpy as np
 import pyproj
-#import scipy.spatial as sp
 import multiprocessing as mp
 
 try:

--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -12,16 +12,7 @@ import numpy as np
 
 from pyproj import Proj
 
-try:
-    from pykdtree.kdtree import KDTree
-    kd_tree_name = 'pykdtree'
-except ImportError:
-    try:
-        import scipy.spatial as sp
-        kd_tree_name = 'scipy.spatial'
-    except ImportError:
-        raise ImportError('Either pykdtree or scipy must be available')
-
+from pykdtree.kdtree import KDTree
 from pyresample import data_reduce, geometry, CHUNK_SIZE
 
 
@@ -266,12 +257,7 @@ class XArrayResamplerBilinear(object):
         input_coords = input_coords.astype(np.float)
         valid_input_index, input_coords = da.compute(valid_input_index,
                                                      input_coords)
-        if kd_tree_name == 'pykdtree':
-            resample_kdtree = KDTree(input_coords)
-        else:
-            resample_kdtree = sp.cKDTree(input_coords)
-
-        return valid_input_index, resample_kdtree
+        return valid_input_index, KDTree(input_coords)
 
     def _query_resample_kdtree(self,
                                resample_kdtree,

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # workaround python bug: http://bugs.python.org/issue15881#msg170215
+# remove when python 2 support is dropped
 import multiprocessing  # noqa: F401
 import versioneer
 import os
@@ -32,12 +33,9 @@ extras_require = {'pykdtree': ['pykdtree>=1.1.1'],
                   'rasterio': ['rasterio'],
                   'dask': ['dask>=0.16.1']}
 
-test_requires = ['rasterio']
+test_requires = ['rasterio', 'dask', 'xarray', 'cartopy', 'pillow', 'matplotlib', 'scipy']
 if sys.version_info < (3, 3):
     test_requires.append('mock')
-if sys.version_info < (2, 6):
-    # multiprocessing is not in the standard library
-    requirements.append('multiprocessing')
 
 if sys.platform.startswith("win"):
     extra_compile_args = []


### PR DESCRIPTION
I updated the installation instructions to remove some of the older parts, typos, and update the dependencies. One thing that I didn't realize before making #136 is that the scipy KDTree is still being used in the `MP` code (`_spatial_mp.py`). @pnuu @mraspaud Any idea if this can be removed in favor of pykdtree or would you expect OpenMP to have some issues with the shared memory arrays that are being passed (doubt it)? If there wouldn't be any issues then we can completely drop scipy as a dependency.

 - [x] Closes #136 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
