### PR TITLE
Add parse_area_file wrapper function to pyresample.utils

### DIFF
--- a/pyresample/utils/__init__.py
+++ b/pyresample/utils/__init__.py
@@ -48,6 +48,12 @@ def convert_def_to_yaml(*args, **kwargs):
     return convert_def_to_yaml(*args, **kwargs)
 
 
+def parse_area_file(*args, **kwargs):
+    from pyresample.area_config import parse_area_file
+    warnings.warn("'parse_area_file' has moved, import it with 'from pyresample import parse_area_file'")
+    return parse_area_file(*args, **kwargs)
+
+
 def generate_quick_linesample_arrays(source_area_def, target_area_def, nprocs=1):
     """Generate linesample arrays for quick grid resampling
 


### PR DESCRIPTION
In #156 I forgot to add `parse_area_file` as one of the deprecated/moved functions. This is breaking satpy and other pytroll packages. This adds the wrapper function to fix this.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
