### PR TITLE
Fix 'typing' import with 'collections' for python 2 compatibility

### DIFF
--- a/pyresample/utils/__init__.py
+++ b/pyresample/utils/__init__.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Miscellaneous utility functions for pyresample."""
-from typing import Mapping
+from collections import Mapping
 import numpy as np
 import warnings
 


### PR DESCRIPTION
The 'typing' module was used to import the `Mapping` class for a small utility function. This was causing compatibility issues for environments with python <3.5. The `Mapping` object should be available from the `collections` module in all supported versions of python.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
