### PR TITLE
Fix _PROJ4Projection threshold

### DIFF
--- a/pyresample/_cartopy.py
+++ b/pyresample/_cartopy.py
@@ -18,7 +18,6 @@
 """Classes for geometry operations"""
 
 from logging import getLogger
-import warnings
 import numpy as np
 
 try:
@@ -93,7 +92,7 @@ class _PROJ4Projection(ccrs.Projection):
     @property
     def threshold(self):
         x0, x1, y0, y1 = self.bounds
-        return min(np.fabs(x1 - x0), np.fabs(y1 - y0)) / 100.
+        return min(abs(x1 - x0), abs(y1 - y0)) / 100.
 
 
 def _lesser_from_proj(proj4_terms, globe=None, bounds=None):

--- a/pyresample/_cartopy.py
+++ b/pyresample/_cartopy.py
@@ -93,7 +93,7 @@ class _PROJ4Projection(ccrs.Projection):
     @property
     def threshold(self):
         x0, x1, y0, y1 = self.bounds
-        return min(x1 - x0, y1 - y0) / 100.
+        return min(np.fabs(x1 - x0), np.fabs(y1 - y0)) / 100.
 
 
 def _lesser_from_proj(proj4_terms, globe=None, bounds=None):

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -69,26 +69,47 @@ class Test(unittest.TestCase):
                         msg='Calculation of cartesian coordinates failed')
 
     def test_cartopy_crs(self):
-        area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)',
-                                           'areaD',
-                                           {'a': '6378144.0',
-                                            'b': '6356759.0',
-                                            'lat_0': '50.00',
-                                            'lat_ts': '50.00',
-                                            'lon_0': '8.00',
-                                            'proj': 'stere'},
-                                           800,
-                                           800,
-                                           [-1370912.72,
-                                            -909968.64000000001,
-                                            1029087.28,
-                                            1490031.3600000001])
-        crs = area_def.to_cartopy_crs()
-        self.assertEqual(crs.bounds,
-                         (area_def.area_extent[0],
-                          area_def.area_extent[2],
-                          area_def.area_extent[1],
-                          area_def.area_extent[3]))
+        """Test conversion from area definition to cartopy crs"""
+        europe = geometry.AreaDefinition(area_id='areaD',
+                                         description='Europe (3km, HRV, VTC)',
+                                         proj_id='areaD',
+                                         projection={'a': '6378144.0',
+                                                     'b': '6356759.0',
+                                                     'lat_0': '50.00',
+                                                     'lat_ts': '50.00',
+                                                     'lon_0': '8.00',
+                                                     'proj': 'stere'},
+                                         width=800, height=800,
+                                         area_extent=[-1370912.72,
+                                                      -909968.64000000001,
+                                                      1029087.28,
+                                                      1490031.3600000001])
+        seviri = geometry.AreaDefinition(area_id='seviri',
+                                         description='SEVIRI HRIT like (flipped, south up)',
+                                         proj_id='seviri',
+                                         projection={'proj': 'geos',
+                                                     'lon_0': 0.0,
+                                                     'a': 6378169.00,
+                                                     'b': 6356583.80,
+                                                     'h': 35785831.00,
+                                                     'units': 'm'},
+                                         width=123, height=123,
+                                         area_extent=[5500000, 5500000, -5500000, -5500000])
+
+        for area_def in [europe, seviri]:
+            crs = area_def.to_cartopy_crs()
+
+            # Bounds
+            self.assertEqual(crs.bounds,
+                             (area_def.area_extent[0],
+                              area_def.area_extent[2],
+                              area_def.area_extent[1],
+                              area_def.area_extent[3]))
+
+            # Threshold
+            thresh_exp = min(np.fabs(area_def.area_extent[2] - area_def.area_extent[0]),
+                             np.fabs(area_def.area_extent[3] - area_def.area_extent[1])) / 100.
+            self.assertEqual(crs.threshold, thresh_exp)
 
     def test_create_areas_def(self):
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)',


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

 - [x] Closes #160 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

When computing the ``threshold`` property in class ``_PROJ4Projection``, take into account that lower left x/y can be larger than upper right x/y if the area is flipped N-S and/or E-W.

@djhoese I don't know what this threshold is actually used for by cartopy, but it solves the coastlines issue. Can you please check which of the other properties using ``self.bounds`` need to be adapted?
