### PR TITLE
Fix create_area_def around poles

### DIFF
--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -176,7 +176,7 @@ def _capture_subarguments(params, arg_name, sub_arg_list):
           dx: 11
           dy: 22
           units: meters
-    returns DataArray((11, 22), attrs={'units': 'meters})
+        # returns DataArray((11, 22), attrs={'units': 'meters})
     """
     # Check if argument is in yaml.
     argument = params.get(arg_name)

--- a/pyresample/utils.py
+++ b/pyresample/utils.py
@@ -933,8 +933,8 @@ def _distance_from_center_forward(var, center, p, is_radians):
     # If on a pole, use northern/southern latitude for both height and width.
     if abs(abs(center_as_angle[1]) - pole) < 1e-8:
         direction_of_poles = _sign(center_as_angle[1])
-        var = (center[1] - p(_sign(center_as_angle[0]) * pole, center_as_angle[1] -
-                             direction_of_poles * abs(var[0]), radians=is_radians, errcheck=True)[0],
+        var = (center[1] - p(0, center_as_angle[1] - direction_of_poles * abs(var[0]),
+                             radians=is_radians, errcheck=True)[1],
                center[1] - p(0, center_as_angle[1] - direction_of_poles * abs(var[1]),
                              radians=is_radians, errcheck=True)[1])
     # Uses southern latitude and western longitude if radius is positive. Uses northern latitude and


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

 - [x] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Currently entering a radius or pixel_size in degrees when the center is at the poles (and normal lat/long is not the same as the center lat/long) does not yield the expected result. This change makes sure that the x direction is treated the same as the y direction and hence makes a square when both the x and y dimensions are equal.