### PR TITLE
Delete unused requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/matplotlib/basemap.git


### PR DESCRIPTION
Not used and only references basemap which is deprecated. @pytroll/core let me know if I'm missing something.