### PR TITLE
Fix yaml area loading when projection is latlong (units degrees)

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -423,7 +423,7 @@ def create_area_def(area_id, projection, width=None, height=None, area_extent=No
 
     # If no units are provided, try to get units used in proj_dict. If still none are provided, use meters.
     if units is None:
-        units = proj_dict.get('units', 'm')
+        units = proj_dict.get('units', 'm' if not p.is_latlong() else 'degrees')
 
     # Allow height and width to be provided for more consistency across functions in pyresample.
     if height is not None or width is not None:

--- a/pyresample/test/test_files/areas.yaml
+++ b/pyresample/test/test_files/areas.yaml
@@ -235,3 +235,17 @@ ease_nh:
     lower_left_xy: [-5326849.0625, -5326849.0625]
     upper_right_xy: [5326849.0625, 5326849.0625]
     units: m
+
+test_latlong:
+  description: Basic latlong grid
+  projection:
+    proj: longlat
+    lat_0: 27.12
+    lon_0: -81.36
+    ellps: WGS84
+  shape:
+    height: 4058
+    width: 3473
+  area_extent:
+    lower_left_xy: [-0.08115781021773638, 0.4038691889114878]
+    upper_right_xy: [0.08115781021773638, 0.5427973973702365]

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -78,8 +78,10 @@ class TestYAMLAreaParser(unittest.TestCase):
     def test_area_parser_yaml(self):
         """Test YAML area parser."""
         from pyresample import parse_area_file
-        ease_nh, ease_sh, test_m, test_deg, test_rad = parse_area_file(os.path.join(os.path.dirname(
-            __file__), 'test_files', 'areas.yaml'), 'ease_nh', 'ease_sh', 'test_meters', 'test_degrees', 'test_radians')
+        test_area_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
+        test_areas = parse_area_file(test_area_file, 'ease_nh', 'ease_sh', 'test_meters', 'test_degrees',
+                                     'test_radians', 'test_latlong')
+        ease_nh, ease_sh, test_m, test_deg, test_rad, test_latlong = test_areas
 
         nh_str = """Area ID: ease_nh
 Description: Arctic EASE grid
@@ -121,6 +123,14 @@ Number of rows: 425
 Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)"""
         self.assertEqual(test_rad.rotation, 45)
         self.assertEqual(test_rad.__str__(), rad_str)
+
+        latlong_str = """Area ID: test_latlong
+Description: Basic latlong grid
+Projection: {'ellps': 'WGS84', 'lat_0': '27.12', 'lon_0': '-81.36', 'proj': 'longlat'}
+Number of columns: 3473
+Number of rows: 4058
+Area extent: (1.4186, 0.007, 1.4214, 0.0095)"""
+        self.assertEqual(test_latlong.__str__(), latlong_str)
 
     def test_multiple_file_content(self):
         from pyresample import parse_area_file
@@ -290,8 +300,7 @@ class TestMisc(unittest.TestCase):
     def test_def2yaml_converter(self):
         from pyresample import parse_area_file, convert_def_to_yaml
         import tempfile
-        def_file = os.path.join(os.path.dirname(__file__), 'test_files',
-                                'areas.cfg')
+        def_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.cfg')
         filehandle, yaml_file = tempfile.mkstemp()
         os.close(filehandle)
         try:


### PR DESCRIPTION
YAML parsing was assuming meters for units even for latlong projections.

@pnuu @wroberts4 Can you verify that this fixes the issue brought up on slack.