### PR TITLE
Fix attributes copy after resampling to be a deepcopy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,21 +8,6 @@ environment:
     CONDA_CHANNEL_PRIORITY: "True"
 
   matrix:
-    - PYTHON: "C:\\Python27_32"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-      NUMPY_VERSION: "stable"
-
-    - PYTHON: "C:\\Python27_64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      NUMPY_VERSION: "stable"
-
-    - PYTHON: "C:\\Python36_32"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
-      NUMPY_VERSION: "stable"
-
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
@@ -33,10 +18,6 @@ install:
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
-    # HACK: Copy tiff.dll to libtiff.dll
-    - "cd %PYTHON%\\envs\\test\\Library\\bin"
-    - "copy tiff.dll libtiff.dll"
-    - "cd C:\\projects\\pyresample"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -117,9 +117,9 @@ def _read_yaml_area_file_content(area_file_name):
         if (isinstance(area_file_obj, (str, six.text_type)) and
                 os.path.isfile(area_file_obj)):
             with open(area_file_obj) as area_file_obj:
-                tmp_dict = yaml.load(area_file_obj)
+                tmp_dict = yaml.safe_load(area_file_obj)
         else:
-            tmp_dict = yaml.load(area_file_obj)
+            tmp_dict = yaml.safe_load(area_file_obj)
         area_dict = recursive_dict_update(area_dict, tmp_dict)
 
     return area_dict

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -23,12 +23,13 @@ from __future__ import absolute_import
 import sys
 import types
 import warnings
+from copy import deepcopy
 from logging import getLogger
 
 import numpy as np
+
 from pykdtree.kdtree import KDTree
-from pyresample import _spatial_mp, data_reduce, geometry
-from pyresample import CHUNK_SIZE
+from pyresample import CHUNK_SIZE, _spatial_mp, data_reduce, geometry
 
 logger = getLogger(__name__)
 
@@ -1203,7 +1204,7 @@ class XArrayResamplerNN(object):
                       fill_value=fill_value,
                       dtype=new_data.dtype, concatenate=True)
         res = DataArray(res, dims=dst_dims, coords=coords,
-                        attrs=data.attrs.copy())
+                        attrs=deepcopy(data.attrs))
 
         return res
 


### PR DESCRIPTION
This PR also include other small fixes:
- remove appveyor on python 2.7
- fix the pyyaml deprecation warnings
- replace da.atop with da.blockwise

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
