### PR TITLE
Allow create_area_def to work with incomplete proj dicts to create DynamicAreas

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -472,11 +472,10 @@ def _make_area(area_id, description, proj_id, proj_dict, shape, area_extent, **k
         height, width = shape
     if None not in (area_extent, shape):
         return AreaDefinition(area_id, description, proj_id, proj_dict, width, height, area_extent, **kwargs)
-    else:
-        return DynamicAreaDefinition(area_id=area_id, description=description, projection=proj_dict, width=width,
-                                     height=height, area_extent=area_extent, rotation=kwargs.get('rotation'),
-                                     optimize_projection=optimize_projection)
-    raise ValueError('Not enough information provided to create an area definition')
+
+    return DynamicAreaDefinition(area_id=area_id, description=description, projection=proj_dict, width=width,
+                                 height=height, area_extent=area_extent, rotation=kwargs.get('rotation'),
+                                 optimize_projection=optimize_projection)
 
 
 def _get_proj_data(projection):

--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -419,7 +419,10 @@ def create_area_def(area_id, projection, width=None, height=None, area_extent=No
 
     # Get a proj4_dict from either a proj4_dict or a proj4_string.
     proj_dict = _get_proj_data(projection)
-    p = Proj(proj_dict, preserve_units=True)
+    try:
+        p = Proj(proj_dict, preserve_units=True)
+    except RuntimeError:
+        return _make_area(area_id, description, proj_id, proj_dict, shape, area_extent, **kwargs)
 
     # If no units are provided, try to get units used in proj_dict. If still none are provided, use meters.
     if units is None:
@@ -469,7 +472,7 @@ def _make_area(area_id, description, proj_id, proj_dict, shape, area_extent, **k
         height, width = shape
     if None not in (area_extent, shape):
         return AreaDefinition(area_id, description, proj_id, proj_dict, width, height, area_extent, **kwargs)
-    elif area_extent is not None or shape is not None:
+    else:
         return DynamicAreaDefinition(area_id=area_id, description=description, projection=proj_dict, width=width,
                                      height=height, area_extent=area_extent, rotation=kwargs.get('rotation'),
                                      optimize_projection=optimize_projection)

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1461,6 +1461,9 @@ class TestStackedAreaDefinition(unittest.TestCase):
         self.assertTrue(isinstance(cad(area_id, projection_list[1], shape=shape), DynamicAreaDefinition))
         self.assertTrue(isinstance(cad(area_id, projection_list[1], area_extent=area_extent), DynamicAreaDefinition))
 
+        area_def = cad('omerc_bb', {'ellps': 'WGS84', 'proj': 'omerc'})
+        self.assertTrue(isinstance(area_def, DynamicAreaDefinition))
+
 
 class TestDynamicAreaDefinition(unittest.TestCase):
 


### PR DESCRIPTION
Allow create_area_def to work with incomplete proj dicts to create DynamicAreas

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

