### PR TITLE
Fix typos in README and index page

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include LICENSE.txt
 include pyresample/ewa/*.h
 include versioneer.py
 include pyresample/version.py
+include README.md

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ reprojection is the process of mapping input geolocated data points to a
 new target geographic projection and area.
 
 Pyresample can operate on both fixed grids of data and geolocated swath data.
-To describe these data Pyresample use various "geometry" objects include the
-`AreaDefinition` and `SwathDefinition` classes.
+To describe these data Pyresample uses various "geometry" objects including
+the `AreaDefinition` and `SwathDefinition` classes.
 
 Pyresample offers multiple resampling algorithms including:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,8 +8,8 @@ reprojection is the process of mapping input geolocated data points to a
 new target geographic projection and area.
 
 Pyresample can operate on both fixed grids of data and geolocated swath data.
-To describe these data Pyresample use various "geometry" objects include the
-`AreaDefinition` and `SwathDefinition` classes.
+To describe these data Pyresample uses various "geometry" objects including
+the `AreaDefinition` and `SwathDefinition` classes.
 
 Pyresample offers multiple resampling algorithms including:
 


### PR DESCRIPTION
Small typos in the README and index page descriptions