### PR TITLE
Fix dynamic omerc parameter computation to survive nans

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -577,6 +577,7 @@ class SwathDefinition(CoordinateDefinition):
             thelats = self.lats[:, int(cols / 2)]
             thelats = thelats.where(thelats.notnull(), drop=True)
             lon1, lon2 = np.asanyarray(thelons[[0, -1]])
+            lines = len(thelats)
             lat1, lat, lat2 = np.asanyarray(thelats[[0, int(lines / 2), -1]])
 
         proj_dict2points = {'proj': 'omerc', 'lat_0': lat, 'ellps': ellipsoid,

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -571,6 +571,13 @@ class SwathDefinition(CoordinateDefinition):
         lon1, lon2 = np.asanyarray(self.lons[[0, -1], int(cols / 2)])
         lat1, lat, lat2 = np.asanyarray(
             self.lats[[0, int(lines / 2), -1], int(cols / 2)])
+        if any(np.isnan((lon1, lon2, lat1, lat, lat2))):
+            thelons = self.lons[:, int(cols / 2)]
+            thelons = thelons.where(thelons.notnull(), drop=True)
+            thelats = self.lats[:, int(cols / 2)]
+            thelats = thelats.where(thelats.notnull(), drop=True)
+            lon1, lon2 = np.asanyarray(thelons[[0, -1]])
+            lat1, lat, lat2 = np.asanyarray(thelats[[0, int(lines / 2), -1]])
 
         proj_dict2points = {'proj': 'omerc', 'lat_0': lat, 'ellps': ellipsoid,
                             'lat_1': lat1, 'lon_1': lon1,

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1166,6 +1166,22 @@ class TestSwathDefinition(unittest.TestCase):
                      'gamma': 0, 'lat_0': -0.2821013754097188}
         assert_np_dict_allclose(area._compute_omerc_parameters('WGS84'),
                                 proj_dict)
+        import xarray as xr
+        lats = xr.DataArray(np.array([[85.23900604248047, 62.256004333496094, 35.58000183105469, np.nan],
+                                      [80.84000396728516, 60.74200439453125, 34.08500289916992, np.nan],
+                                      [67.07600402832031, 54.147003173828125, 30.547000885009766, np.nan]]).T,
+                            dims=['y', 'x'])
+
+        lons = xr.DataArray(np.array([[-90.67900085449219, -21.565000534057617, -21.525001525878906, np.nan],
+                                      [79.11000061035156, 7.284000396728516, -5.107000350952148, np.nan],
+                                      [81.26400756835938, 29.672000885009766, 10.260000228881836, np.nan]]).T)
+
+        area = geometry.SwathDefinition(lons, lats)
+        proj_dict = {'lonc': -11.391744043133668, 'ellps': 'WGS84',
+                     'proj': 'omerc', 'alpha': 9.185764390923012,
+                     'gamma': 0, 'lat_0': -0.2821013754097188}
+        assert_np_dict_allclose(area._compute_omerc_parameters('WGS84'),
+                                proj_dict)
 
     def test_get_edge_lonlats(self):
         """Test the `get_edge_lonlats` functionality."""


### PR DESCRIPTION
When the first or last line of the lons and lats of a swath contains nans, the dynamic omerc parameter computation was crashing. This PR resolves the issue by finding the first and last non-nan data in that case.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

