### PR TITLE
Implement striding and aggregation for Swath- and AreaDefinitions

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -896,7 +896,6 @@ class AreaDefinition(BaseDefinition):
         self.proj_id = proj_id
         self.width = int(width)
         self.height = int(height)
-        self.shape = (height, width)
         self.crop_offset = (0, 0)
         try:
             self.rotation = float(rotation)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -575,6 +575,9 @@ class SwathDefinition(CoordinateDefinition):
                          coords=res.coords, attrs=self.lons.attrs.copy())
         lats = DataArray(lonlatalt[:, :, 1], dims=self.lons.dims,
                          coords=res.coords, attrs=self.lons.attrs.copy())
+        resolution = lons.attrs['resolution'] / (dims.get('x', 1) + dims.get('y', 1)) / 2
+        lons.attrs['resolution'] = resolution
+        lats.attrs['resolution'] = resolution
         return SwathDefinition(lons, lats)
 
     def __hash__(self):

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -575,7 +575,7 @@ class SwathDefinition(CoordinateDefinition):
                          coords=res.coords, attrs=self.lons.attrs.copy())
         lats = DataArray(lonlatalt[:, :, 1], dims=self.lons.dims,
                          coords=res.coords, attrs=self.lons.attrs.copy())
-        resolution = lons.attrs['resolution'] / (dims.get('x', 1) + dims.get('y', 1)) / 2
+        resolution = lons.attrs['resolution'] / ((dims.get('x', 1) + dims.get('y', 1)) / 2)
         lons.attrs['resolution'] = resolution
         lats.attrs['resolution'] = resolution
         return SwathDefinition(lons, lats)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -548,9 +548,15 @@ class SwathDefinition(CoordinateDefinition):
             raise ValueError('Only 1 and 2 dimensional swaths are allowed')
 
     def copy(self):
+        """Copy the current swath."""
         return SwathDefinition(self.lons, self.lats)
 
     def aggregate(self, **dims):
+        """Aggregate the current swath definition by averaging.
+
+        For example, averaging over 2x2 windows:
+        `sd.aggregate(x=2, y=2)`
+        """
         import pyproj
         import dask.array as da
 
@@ -942,7 +948,10 @@ class AreaDefinition(BaseDefinition):
         self.dtype = dtype
 
     def copy(self, **override_kwargs):
-        """Make a copy of the current area, replacing the current values with anything in *override_kwargs*."""
+        """Make a copy of the current area.
+
+        This replaces the current values with anything in *override_kwargs*.
+        """
         kwargs = {'area_id': self.area_id,
                   'description': self.description,
                   'proj_id': self.proj_id,
@@ -962,7 +971,7 @@ class AreaDefinition(BaseDefinition):
 
     @property
     def shape(self):
-        return (self.height, self.width)
+        return self.height, self.width
 
     @property
     def name(self):

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -575,9 +575,12 @@ class SwathDefinition(CoordinateDefinition):
                          coords=res.coords, attrs=self.lons.attrs.copy())
         lats = DataArray(lonlatalt[:, :, 1], dims=self.lons.dims,
                          coords=res.coords, attrs=self.lons.attrs.copy())
-        resolution = lons.attrs['resolution'] / ((dims.get('x', 1) + dims.get('y', 1)) / 2)
-        lons.attrs['resolution'] = resolution
-        lats.attrs['resolution'] = resolution
+        try:
+            resolution = lons.attrs['resolution'] / ((dims.get('x', 1) + dims.get('y', 1)) / 2)
+            lons.attrs['resolution'] = resolution
+            lats.attrs['resolution'] = resolution
+        except KeyError:
+            pass
         return SwathDefinition(lons, lats)
 
     def __hash__(self):

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1254,6 +1254,8 @@ class TestSwathDefinition(unittest.TestCase):
 
     def test_aggregation(self):
         """Test aggregation on SwathDefinitions."""
+        if (sys.version_info < (3, 0)):
+            self.skipTest("Not implemented in python 2 (xarray).")
         import dask.array as da
         import xarray as xr
         import numpy as np

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -986,6 +986,31 @@ class Test(unittest.TestCase):
         self.assertEqual(area.proj_str,
                          '+a=6378144.0 +b=6356759.0 +lat_0=50.0 +lat_ts=50.0 +lon_0=8.0 +no_rot +proj=stere')
 
+    def test_striding(self):
+        """Test striding AreaDefinitions."""
+        from pyresample import utils
+
+        area_id = 'orig'
+        area_name = 'Test area'
+        proj_id = 'test'
+        x_size = 3712
+        y_size = 3712
+        area_extent = (-5570248.477339745, -5561247.267842293, 5567248.074173927, 5570248.477339745)
+        proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'h': 35785831.0,
+                     'lon_0': 0.0, 'proj': 'geos', 'units': 'm'}
+        area_def = utils.get_area_def(area_id,
+                                      area_name,
+                                      proj_id,
+                                      proj_dict,
+                                      x_size, y_size,
+                                      area_extent)
+
+        reduced_area = area_def[::4, ::4]
+        np.testing.assert_allclose(reduced_area.area_extent, (area_extent[0],
+                                                              area_extent[1] + 3 * area_def.pixel_size_y,
+                                                              area_extent[2] - 3 * area_def.pixel_size_x,
+                                                              area_extent[3]))
+
 
 def assert_np_dict_allclose(dict1, dict2):
 
@@ -1659,11 +1684,31 @@ class TestCrop(unittest.TestCase):
                                         1029087.28,
                                         1490031.3600000001])
         res = area[slice(20, 720), slice(100, 500)]
-        self.assertTrue(np.allclose((-1070912.72, -669968.6399999999,
-                                     129087.28000000003, 1430031.36),
-                                    res.area_extent))
+        np.testing.assert_allclose((-1070912.72, -669968.6399999999,
+                                    129087.28000000003, 1430031.36),
+                                   res.area_extent)
         self.assertEqual(res.shape, (700, 400))
 
+    def test_aggregate(self):
+        """Test aggregation of AreaDefinitions."""
+        area = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
+                               {'a': '6378144.0',
+                                'b': '6356759.0',
+                                'lat_0': '50.00',
+                                'lat_ts': '50.00',
+                                'lon_0': '8.00',
+                                'proj': 'stere'},
+                               800,
+                               800,
+                               [-1370912.72,
+                                -909968.64000000001,
+                                1029087.28,
+                                1490031.3600000001])
+        res = area.aggregate(x=4, y=2)
+        self.assertDictEqual(res.proj_dict, area.proj_dict)
+        np.testing.assert_allclose(res.area_extent, area.area_extent)
+        self.assertEqual(res.shape[0], area.shape[0] / 2)
+        self.assertEqual(res.shape[1], area.shape[1] / 4)
 
 def suite():
     """The test suite.

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1692,23 +1692,24 @@ class TestCrop(unittest.TestCase):
     def test_aggregate(self):
         """Test aggregation of AreaDefinitions."""
         area = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
-                               {'a': '6378144.0',
-                                'b': '6356759.0',
-                                'lat_0': '50.00',
-                                'lat_ts': '50.00',
-                                'lon_0': '8.00',
-                                'proj': 'stere'},
-                               800,
-                               800,
-                               [-1370912.72,
-                                -909968.64000000001,
-                                1029087.28,
-                                1490031.3600000001])
+                                       {'a': '6378144.0',
+                                        'b': '6356759.0',
+                                        'lat_0': '50.00',
+                                        'lat_ts': '50.00',
+                                        'lon_0': '8.00',
+                                        'proj': 'stere'},
+                                       800,
+                                       800,
+                                       [-1370912.72,
+                                           -909968.64000000001,
+                                           1029087.28,
+                                           1490031.3600000001])
         res = area.aggregate(x=4, y=2)
         self.assertDictEqual(res.proj_dict, area.proj_dict)
         np.testing.assert_allclose(res.area_extent, area.area_extent)
         self.assertEqual(res.shape[0], area.shape[0] / 2)
         self.assertEqual(res.shape[1], area.shape[1] / 4)
+
 
 def suite():
     """The test suite.

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1227,6 +1227,37 @@ class TestSwathDefinition(unittest.TestCase):
         assert_np_dict_allclose(res.proj_dict, proj_dict)
         self.assertEqual(res.shape, (3, 3))
 
+    def test_aggregation(self):
+        """Test aggregation on SwathDefinitions."""
+        import dask.array as da
+        import xarray as xr
+        import numpy as np
+        lats = np.array([[0, 0, 0, 0], [1, 1, 1, 1.0]])
+        lons = np.array([[178.5, 179.5, -179.5, -178.5], [178.5, 179.5, -179.5, -178.5]])
+        xlats = xr.DataArray(da.from_array(lats, chunks=2), dims=['y', 'x'])
+        xlons = xr.DataArray(da.from_array(lons, chunks=2), dims=['y', 'x'])
+        from pyresample.geometry import SwathDefinition
+        sd = SwathDefinition(xlons, xlats)
+        res = sd.aggregate(y=2, x=2)
+        np.testing.assert_allclose(res.lons, [[179, -179]])
+        np.testing.assert_allclose(res.lats, [[0.5, 0.5]], atol=2e-5)
+
+    def test_striding(self):
+        """Test striding."""
+        import dask.array as da
+        import xarray as xr
+        import numpy as np
+        lats = np.array([[0, 0, 0, 0], [1, 1, 1, 1.0]])
+        lons = np.array([[178.5, 179.5, -179.5, -178.5], [178.5, 179.5, -179.5, -178.5]])
+        xlats = xr.DataArray(da.from_array(lats, chunks=2), dims=['y', 'x'])
+        xlons = xr.DataArray(da.from_array(lons, chunks=2), dims=['y', 'x'])
+        from pyresample.geometry import SwathDefinition
+        sd = SwathDefinition(xlons, xlats)
+        res = sd[::2, ::2]
+        np.testing.assert_allclose(res.lons, [[178.5, -179.5]])
+        np.testing.assert_allclose(res.lats, [[0, 0]], atol=2e-5)
+
+
 
 class TestStackedAreaDefinition(unittest.TestCase):
 


### PR DESCRIPTION
This PR implements striding and aggregation for a couple of Definition objects.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
