### PR TITLE
Fix bb computation to generate areas with equal h and v resolutions

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -634,6 +634,32 @@ class SwathDefinition(CoordinateDefinition):
             new_proj.update(proj_dict)
             return new_proj
 
+    def _compute_uniform_shape(self):
+        g = Geod(ellps='WGS84')
+        leftlons = self.lons[:, 0]
+        leftlons = leftlons.where(leftlons.notnull(), drop=True)
+        rightlons = self.lons[:, -1]
+        rightlons = rightlons.where(rightlons.notnull(), drop=True)
+        middlelons = self.lons[:, int(self.lons.shape[1] / 2)]
+        middlelons = middlelons.where(middlelons.notnull(), drop=True)
+        leftlats = self.lats[:, 0]
+        leftlats = leftlats.where(leftlats.notnull(), drop=True)
+        rightlats = self.lats[:, -1]
+        rightlats = rightlats.where(rightlats.notnull(), drop=True)
+        middlelats = self.lats[:, int(self.lats.shape[1] / 2)]
+        middlelats = middlelats.where(middlelats.notnull(), drop=True)
+
+        az1, az2, width1 = g.inv(leftlons[0], leftlats[0], rightlons[0], rightlats[0])
+        az1, az2, width2 = g.inv(leftlons[-1], leftlats[-1], rightlons[-1], rightlats[-1])
+        az1, az2, height = g.inv(middlelons[0], middlelats[0], middlelons[-1], middlelats[-1])
+        width = min(width1, width2)
+        vresolution = height * 1.0 / self.lons.shape[0]
+        hresolution = width * 1.0 / self.lons.shape[1]
+        resolution = min(vresolution, hresolution)
+        width = int(width * 1.1 / resolution)
+        height = int(height * 1.1 / resolution)
+        return height, width
+
     def compute_optimal_bb_area(self, proj_dict=None):
         """Compute the "best" bounding box area for this swath with `proj_dict`.
 
@@ -647,10 +673,7 @@ class SwathDefinition(CoordinateDefinition):
         projection = proj_dict.setdefault('proj', 'omerc')
         area_id = projection + '_otf'
         description = 'On-the-fly ' + projection + ' area'
-        lines, cols = self.lons.shape
-        width = int(cols * 1.1)
-        height = int(lines * 1.1)
-
+        height, width = self._compute_uniform_shape()
         proj_dict = self.compute_bb_proj_params(proj_dict)
 
         area = DynamicAreaDefinition(area_id, description, proj_dict)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -635,6 +635,7 @@ class SwathDefinition(CoordinateDefinition):
             return new_proj
 
     def _compute_uniform_shape(self):
+        """Compute the height and width of a domain to have uniform resolution across dimensions."""
         g = Geod(ellps='WGS84')
         leftlons = self.lons[:, 0]
         leftlons = leftlons.where(leftlons.notnull(), drop=True)
@@ -667,6 +668,9 @@ class SwathDefinition(CoordinateDefinition):
         which case the right projection angle `alpha` is computed from the
         swath centerline. For other projections, only the appropriate center of
         projection and area extents are computed.
+
+        The height and width are computed so that the resolution is
+        approximately the same across dimensions.
         """
         if proj_dict is None:
             proj_dict = {}
@@ -749,10 +753,10 @@ class DynamicAreaDefinition(object):
                 x_resolution, y_resolution = resolution
             except TypeError:
                 x_resolution = y_resolution = resolution
-            width = int(np.rint((corners[2] - corners[0]) * 1.0 /
-                                 x_resolution + 1))
-            height = int(np.rint((corners[3] - corners[1]) * 1.0 /
-                                 y_resolution + 1))
+            width = int(np.rint((corners[2] - corners[0]) * 1.0
+                                / x_resolution + 1))
+            height = int(np.rint((corners[3] - corners[1]) * 1.0
+                                 / y_resolution + 1))
 
         area_extent = (corners[0] - x_resolution / 2,
                        corners[1] - y_resolution / 2,

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1223,25 +1223,27 @@ class TestSwathDefinition(unittest.TestCase):
 
     def test_compute_optimal_bb(self):
         """Test computing the bb area."""
+        import xarray as xr
         lats = np.array([[85.23900604248047, 62.256004333496094, 35.58000183105469],
                          [80.84000396728516, 60.74200439453125, 34.08500289916992],
                          [67.07600402832031, 54.147003173828125, 30.547000885009766]]).T
-
+        lats = xr.DataArray(lats)
         lons = np.array([[-90.67900085449219, -21.565000534057617, -21.525001525878906],
                          [79.11000061035156, 7.284000396728516, -5.107000350952148],
                          [81.26400756835938, 29.672000885009766, 10.260000228881836]]).T
+        lons = xr.DataArray(lons)
 
         area = geometry.SwathDefinition(lons, lats)
 
         res = area.compute_optimal_bb_area({'proj': 'omerc', 'ellps': 'WGS84'})
 
-        np.testing.assert_allclose(res.area_extent, [-2348379.728104, 2284625.526467,
-                                                     2432121.058435, 11719235.223912])
+        np.testing.assert_allclose(res.area_extent, [-2348379.728104, 3228086.496211,
+                                                     2432121.058435, 10775774.254169])
         proj_dict = {'gamma': 0.0, 'lonc': -11.391744043133668,
                      'ellps': 'WGS84', 'proj': 'omerc',
                      'alpha': 9.185764390923012, 'lat_0': -0.2821013754097188}
         assert_np_dict_allclose(res.proj_dict, proj_dict)
-        self.assertEqual(res.shape, (3, 3))
+        self.assertEqual(res.shape, (6, 3))
 
 
 class TestStackedAreaDefinition(unittest.TestCase):
@@ -1536,14 +1538,15 @@ class TestDynamicAreaDefinition(unittest.TestCase):
         lats = [[66, 67, 68, 69.],
                 [58, 59, 60, 61],
                 [50, 51, 52, 53]]
-        sdef = geometry.SwathDefinition(lons, lats)
+        import xarray as xr
+        sdef = geometry.SwathDefinition(xr.DataArray(lons), xr.DataArray(lats))
         result = area.freeze(sdef,
                              resolution=1000)
         np.testing.assert_allclose(result.area_extent,
-                                   [-336277.698941, 5047207.008079,
-                                    192456.651909, 8215588.023806])
+                                   [-336277.698941, 5513145.392745,
+                                    192456.651909, 7749649.63914])
         self.assertEqual(result.x_size, 4)
-        self.assertEqual(result.y_size, 3)
+        self.assertEqual(result.y_size, 18)
 
     def test_compute_domain(self):
         """Test computing size and area extent."""


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
