### PR TITLE
Fix argument order in get_area_def doc

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -305,10 +305,10 @@ def get_area_def(area_id, area_name, proj_id, proj4_args, width, height, area_ex
     -----------
     area_id : str
         ID of area
-    proj_id : str
-        ID of projection
     area_name :str
         Description of area
+    proj_id : str
+        ID of projection
     proj4_args : list, dict, or str
         Proj4 arguments as list of arguments or string
     width : int


### PR DESCRIPTION
Document the arguments for get_area_def in the same order in which they
are defined.

<!-- Please make the PR against the `master` branch. -->

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
