### PR TITLE
Fix resolution not being passed to DynamicAreaDefinitions

### DIFF
--- a/pyresample/test/test_files/areas.yaml
+++ b/pyresample/test/test_files/areas.yaml
@@ -219,3 +219,25 @@ test_latlong:
   area_extent:
     lower_left_xy: [-0.08115781021773638, 0.4038691889114878]
     upper_right_xy: [0.08115781021773638, 0.5427973973702365]
+
+test_dynamic_resolution:
+  description: Dynamic with resolution specified in meters
+  projection:
+    proj: lcc
+    lon_0: -95.0
+    lat_0: 25.0
+    lat_1: 25.0
+    ellps: WGS84
+  resolution: [1000, 1000]
+
+test_dynamic_resolution_ll:
+  description: Dynamic with resolution specified in degrees
+  projection:
+      proj: longlat
+      lat_0: 27.12
+      lon_0: -81.36
+      ellps: WGS84
+  resolution:
+    dy: 1
+    dx: 1
+    units: deg

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -136,6 +136,27 @@ Number of rows: 4058
 Area extent: (-0.0812, 0.4039, 0.0812, 0.5428)"""
         self.assertEqual(test_latlong.__str__(), latlong_str)
 
+    def test_dynamic_area_parser_yaml(self):
+        """Test YAML area parser on dynamic areas."""
+        from pyresample import parse_area_file
+        from pyresample.geometry import DynamicAreaDefinition
+        test_area_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
+        test_area = parse_area_file(test_area_file, 'test_dynamic_resolution')[0]
+
+        self.assertIsInstance(test_area, DynamicAreaDefinition)
+        self.assertTrue(hasattr(test_area, 'resolution'))
+        self.assertEqual(test_area.resolution, (1000.0, 1000.0))
+
+        # lat/lon
+        from pyresample import parse_area_file
+        from pyresample.geometry import DynamicAreaDefinition
+        test_area_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
+        test_area = parse_area_file(test_area_file, 'test_dynamic_resolution_ll')[0]
+
+        self.assertIsInstance(test_area, DynamicAreaDefinition)
+        self.assertTrue(hasattr(test_area, 'resolution'))
+        self.assertEqual(test_area.resolution, (1.0, 1.0))
+
     def test_multiple_file_content(self):
         from pyresample import parse_area_file
         area_list = ["""ease_sh:


### PR DESCRIPTION
I wanted to make a quick dynamic area definition in my areas.yaml file like this:

```
test_dynamic_resolution:
  description: Dynamic with resolution specified in meters
  projection:
    proj: lcc
    lon_0: -95.0
    lat_0: 25.0
    lat_1: 25.0
    ellps: WGS84
  resolution: [1000, 1000]
```

However, this didn't work because `resolution` wasn't being passed to the area definition creation. It seems that my fixes to get this to work haven't broken anything. I'm 90% sure this was supposed to work before so I'm not sure it needs to be documented any more than it already is. Additionally I changed it so that you don't need to specify `center` to convert a value in "degrees" to "meters" (makes `center` default to `(0, 0)`).

I'd like @sfinkens and @wroberts4 to take a look at this if they have the time.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
