### PR TITLE
Add bucket resampling

### DIFF
--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -45,3 +45,8 @@ pyresample.ewa
 --------------
 .. automodule:: pyresample.ewa
     :members:
+
+pyresample.bucket
+-----------------
+.. automodule:: pyresample.bucket
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Pyresample offers multiple resampling algorithms including:
 - Nearest Neighbor
 - Elliptical Weighted Average (EWA)
 - Bilinear
+- Bucket resampling (count hits per bin, averaging, ratios)
 
 For nearest neighbor and bilinear interpolation pyresample uses a kd-tree
 approach by using the fast KDTree implementation provided by the

--- a/docs/source/swath.rst
+++ b/docs/source/swath.rst
@@ -459,3 +459,11 @@ Example
  >>> rows_per_scan = 5
  >>> # fornav resamples the swath data to the gridded area
  >>> num_valid_points, gridded_data = fornav(cols, rows, area_def, data, rows_per_scan=rows_per_scan)
+
+pyresample.bucket
+-----------------
+
+.. autoclass:: pyresample.bucket.BucketResampler
+
+See :class:`~pyresample.bucket.BucketResampler` API documentation for
+the details of method parameters.

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -41,40 +41,40 @@ class BucketResampler(object):
 
     .. code-block:: python
 
-        >>> from pyresample.bucket import BucketResampler
-        >>> from satpy import Scene
-        >>> from satpy.resample import get_area_def
-        >>> fname = "hrpt_noaa19_20170519_1214_42635.l1b"
-        >>> glbl = Scene(filenames=[fname])
-        >>> glbl.load(['4'])
-        >>> data = glbl['4']
-        >>> lons, lats = data.area.get_lonlats()
-        >>> target_area = get_area_def('euro4')
+        from pyresample.bucket import BucketResampler
+        from satpy import Scene
+        from satpy.resample import get_area_def
+        fname = "hrpt_noaa19_20170519_1214_42635.l1b"
+        glbl = Scene(filenames=[fname])
+        glbl.load(['4'])
+        data = glbl['4']
+        lons, lats = data.area.get_lonlats()
+        target_area = get_area_def('euro4')
 
     Initialize the resampler
 
     .. code-block:: python
 
-        >>> resampler = BucketResampler(adef, lons, lats)
+        resampler = BucketResampler(adef, lons, lats)
 
     Calculate the sum of all the data in each grid location:
 
     .. code-block:: python
 
-        >>> sums = resampler.get_sum(data)
+        sums = resampler.get_sum(data)
 
     Calculate how many values were collected at each grid location:
 
     .. code-block:: python
 
-        >>> counts = resampler.get_count()
+        counts = resampler.get_count()
 
     The average can be calculated from the above two results, or directly
     using the helper method:
 
     .. code-block:: python
 
-        >>> average = resampler.get_average(data)
+        average = resampler.get_average(data)
 
     Calculate fractions of occurrences of different values in each grid
     location.  The data needs to be categorical (in integers), so
@@ -84,10 +84,10 @@ class BucketResampler(object):
 
     .. code-block:: python
 
-        >>> data = da.where(data > 250, 1, 0)
-        >>> fractions = resampler.get_fractions(data, categories=[0, 1])
-        >>> import matplotlib.pyplot as plt
-        >>> plt.imshow(fractions[0]); plt.show()
+        data = da.where(data > 250, 1, 0)
+        fractions = resampler.get_fractions(data, categories=[0, 1])
+        import matplotlib.pyplot as plt
+        plt.imshow(fractions[0]); plt.show()
     """
 
     def __init__(self, target_area, source_lons, source_lats):

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -276,6 +276,8 @@ def resample_bucket_fractions(adef, data, lons, lats, categories=None,
         cat_data = da.where(data == cat, 1.0, 0.0)
 
         sums = get_sum_from_bucket_indices(cat_data, x_idxs, y_idxs, adef.shape)
-        results[cat] = sums.astype(float) / counts
+        result = sums.astype(float) / counts
+        result = da.where(counts == 0.0, fill_value, result)
+        results[cat] = result
 
     return results

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -203,8 +203,9 @@ def get_count_from_bucket_indices(x_idxs, y_idxs, target_shape):
     return counts.reshape(target_shape)
 
 
-def resample_bucket_average(adef, data, lons, lats,
-                            fill_value=np.nan, x_idxs=None, y_idxs=None):
+def resample_bucket_average(data, adef=None, lons=None, lats=None,
+                            fill_value=np.nan, x_idxs=None, y_idxs=None,
+                            target_shape=None):
     """Calculate bin-averages using bucket resampling.
 
     Parameters
@@ -230,7 +231,17 @@ def resample_bucket_average(adef, data, lons, lats,
         Binned and averaged data.
     """
     if x_idxs is None or y_idxs is None:
+        if lons is None or lats is None:
+            raise ValueError("Either lons/lats or x/y indices are needed.")
+        if adef is None:
+            raise ValueError("Area definition needed for index calculations.")
         x_idxs, y_idxs = get_bucket_indices(adef, lons, lats)
+    try:
+        shape = target_shape or adef.shape
+        if shape is None:
+            raise ValueError
+    except (AttributeError, ValueError):
+        raise ValueError("Either target_shape or adef needs to be given.")
     sums = get_sum_from_bucket_indices(data, x_idxs, y_idxs, adef.shape)
     counts = get_count_from_bucket_indices(x_idxs, y_idxs, adef.shape)
 

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -255,7 +255,7 @@ def resample_bucket_fractions(adef, data, lons, lats, categories=None,
     lats : Numpy or Dask array
         Latitude coordinates of the input data
     categories : iterable or None
-        One dimensional list of categories in the data, or None.  If None, 
+        One dimensional list of categories in the data, or None.  If None,
         categories are determined from the data.
     fill_value : float
         Fill value to replace missing values.  Default: np.nan

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -113,7 +113,6 @@ def get_count_from_bucket_indices(x_idxs, y_idxs, target_shape):
 
     # Convert X- and Y-indices to raveled index
     idxs = y_idxs * target_shape[1] + x_idxs
-    # idxs = idxs.ravel()
 
     out_size = target_shape[0] * target_shape[1]
 
@@ -123,7 +122,7 @@ def get_count_from_bucket_indices(x_idxs, y_idxs, target_shape):
     return counts.reshape(target_shape)
 
 
-def resample_bucket_average(adef, data, lats, lons,
+def resample_bucket_average(adef, data, lons, lats,
                             fill_value=np.nan, x_idxs=None, y_idxs=None):
     """Calculate bin-averages using bucket resampling."""
     if x_idxs is None or y_idxs is None:

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -100,8 +100,7 @@ class BucketResampler(object):
         self.counts = None
 
     def _get_proj_coordinates(self, lons, lats, x_res, y_res):
-        """Calculate projection coordinates and round them to the closest
-        resolution unit.
+        """Calculate projection coordinates and round to resolution unit.
 
         Parameters
         ----------

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -185,6 +185,10 @@ class BucketResampler(object):
         # Remove NaN values from the data when used as weights
         weights = da.where(np.isnan(data), 0, data)
 
+        # Rechunk indices to match the data chunking
+        if weights.chunks != self.idxs.chunks:
+            self.idxs = da.rechunk(self.idxs, weights.chunks)
+
         # Calculate the sum of the data falling to each bin
         out_size = self.target_area.size
         sums, _ = da.histogram(self.idxs, bins=out_size, range=(0, out_size),

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -242,8 +242,8 @@ def resample_bucket_average(data, adef=None, lons=None, lats=None,
             raise ValueError
     except (AttributeError, ValueError):
         raise ValueError("Either target_shape or adef needs to be given.")
-    sums = get_sum_from_bucket_indices(data, x_idxs, y_idxs, adef.shape)
-    counts = get_count_from_bucket_indices(x_idxs, y_idxs, adef.shape)
+    sums = get_sum_from_bucket_indices(data, x_idxs, y_idxs, shape)
+    counts = get_count_from_bucket_indices(x_idxs, y_idxs, shape)
 
     average = sums / counts
     average = da.where(counts == 0, fill_value, average)
@@ -292,12 +292,12 @@ def resample_bucket_fractions(data, adef=None, lons=None, lats=None,
     if categories is None:
         categories = da.unique(data)
     results = {}
-    counts = get_count_from_bucket_indices(x_idxs, y_idxs, adef.shape)
+    counts = get_count_from_bucket_indices(x_idxs, y_idxs, shape)
     counts = counts.astype(float)
     for cat in categories:
         cat_data = da.where(data == cat, 1.0, 0.0)
 
-        sums = get_sum_from_bucket_indices(cat_data, x_idxs, y_idxs, adef.shape)
+        sums = get_sum_from_bucket_indices(cat_data, x_idxs, y_idxs, shape)
         result = sums.astype(float) / counts
         result = da.where(counts == 0.0, fill_value, result)
         results[cat] = result

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -2,10 +2,6 @@
 #
 # Copyright (C) 2019  Pytroll developers
 #
-# Author(s):
-#
-#   Panu Lahtinen <panu.lahtinen@fmi.fi>
-#
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation, either version 3 of the License, or (at your option) any

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -210,10 +210,10 @@ def resample_bucket_average(data, adef=None, lons=None, lats=None,
 
     Parameters
     ----------
-    adef : AreaDefinition
-        Definition of the target area
     data : Numpy or Dask array
         Data to be binned and averaged
+    adef : AreaDefinition
+        Definition of the target area
     lons : Numpy or Dask array
         Longitude coordinates of the input data
     lats : Numpy or Dask array
@@ -251,16 +251,17 @@ def resample_bucket_average(data, adef=None, lons=None, lats=None,
     return average
 
 
-def resample_bucket_fractions(adef, data, lons, lats, categories=None,
-                              fill_value=np.nan, x_idxs=None, y_idxs=None):
+def resample_bucket_fractions(data, adef=None, lons=None, lats=None,
+                              categories=None, fill_value=np.nan,
+                              x_idxs=None, y_idxs=None, target_shape=None):
     """Get fraction of occurences for each given categorical value.
 
     Parameters
     ----------
-    adef : AreaDefinition
-        Definition of the target area
     data : Numpy or Dask array
         Categorical data to be processed
+    adef : AreaDefinition
+        Definition of the target area
     lons : Numpy or Dask array
         Longitude coordinates of the input data
     lats : Numpy or Dask array
@@ -277,7 +278,17 @@ def resample_bucket_fractions(adef, data, lons, lats, categories=None,
 
     """
     if x_idxs is None or y_idxs is None:
+        if lons is None or lats is None:
+            raise ValueError("Either lons/lats or x/y indices are needed.")
+        if adef is None:
+            raise ValueError("Area definition needed for index calculations.")
         x_idxs, y_idxs = get_bucket_indices(adef, lons, lats)
+    try:
+        shape = target_shape or adef.shape
+        if shape is None:
+            raise ValueError
+    except (AttributeError, ValueError):
+        raise ValueError("Either target_shape or adef needs to be given.")
     if categories is None:
         categories = da.unique(data)
     results = {}

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -135,17 +135,6 @@ def resample_bucket_average(adef, data, lats, lons,
     return average
 
 
-def resample_bucket_counts(adef, data, lats, lons,
-                           fill_value=np.nan, x_idxs=None, y_idxs=None):
-    """Get number of hits for each bin."""
-    if x_idxs is None or y_idxs is None:
-        x_idxs, y_idxs = get_bucket_indices(adef, lons, lats)
-    _, counts = get_sample_from_bucket_indices(data, x_idxs, y_idxs,
-                                               adef.shape)
-
-    return counts
-
-
 def resample_bucket_fractions(adef, data, lats, lons, categories,
                               fill_value=np.nan, x_idxs=None, y_idxs=None):
     """Get fraction of occurences for each given categorical value."""

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -25,7 +25,9 @@ from pyresample._spatial_mp import Proj
 
 class BucketResampler(object):
 
-    """Bucket resampling is useful for calculating averages and hit-counts
+    """Class for bucket resampling.
+
+    Bucket resampling is useful for calculating averages and hit-counts
     when aggregating data to coarser scale grids.
 
     Below are examples how to use the resampler.

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -256,12 +256,13 @@ class BucketResampler(object):
             Categorical data to be processed
         categories : iterable or None
             One dimensional list of categories in the data, or None.  If None,
-            categories are determined from the data.
+            categories are determined from the data by fully processing the
+            data and finding the unique category values.
         fill_value : float
             Fill value to replace missing values.  Default: np.nan
         """
         if categories is None:
-            categories = da.unique(data)
+            categories = np.unique(data)
         results = {}
         counts = self.get_count()
         counts = counts.astype(float)

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -33,6 +33,8 @@ from pyresample._spatial_mp import Proj
 
 def round_to_resolution(arr, resolution):
     """Round the values in *arr* to closest resolution element."""
+    if isinstance(arr, (list, tuple)):
+        arr = np.array(arr)
     return resolution * np.round(arr / resolution)
 
 

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -95,6 +95,7 @@ class BucketResampler(object):
         self.y_idxs = None
         self.idxs = None
         self._get_indices()
+        self.counts = None
 
     def _get_proj_coordinates(self, lons, lats, x_res, y_res):
         """Calculate projection coordinates and round them to the closest
@@ -200,9 +201,12 @@ class BucketResampler(object):
         out_size = self.target_area.size
 
         # Calculate the sum of the data falling to each bin
-        counts, _ = da.histogram(self.idxs, bins=out_size, range=(0, out_size))
+        if self.counts is None:
+            counts, _ = da.histogram(self.idxs, bins=out_size,
+                                     range=(0, out_size))
+            self.counts = counts.reshape(self.target_area.shape)
 
-        return counts.reshape(self.target_area.shape)
+        return self.counts
 
     def get_average(self, data, fill_value=np.nan):
         """Calculate bin-averages using bucket resampling.

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -1,6 +1,6 @@
 # pyresample, Resampling of remote sensing image data in python
 #
-# Copyright (C) 2019  Pytroll developers
+# Copyright (C) 2019  Pyresample developers
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -126,12 +126,10 @@ def resample_bucket_fractions(adef, data, lats, lons, categories,
     results = []
     for cat in categories:
         cat_data = np.where(data == cat, 1.0, 0.0)
-        sums, _ = get_sample_from_bucket_indices(cat_data, x_idxs, y_idxs,
-                                                 adef.shape)
+        sums, counts = get_sample_from_bucket_indices(cat_data, x_idxs, y_idxs,
+                                                      adef.shape)
         results.append(sums)
 
-    total_hits = np.sum(results, axis=0)
-
-    fractions = [res / total_hits for res in results]
+    fractions = [res / counts for res in results]
 
     return fractions

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -136,19 +136,18 @@ def resample_bucket_average(adef, data, lons, lats,
     return average
 
 
-def resample_bucket_fractions(adef, data, lats, lons, categories,
+def resample_bucket_fractions(adef, data, lons, lats, categories,
                               fill_value=np.nan, x_idxs=None, y_idxs=None):
     """Get fraction of occurences for each given categorical value."""
     if x_idxs is None or y_idxs is None:
         x_idxs, y_idxs = get_bucket_indices(adef, lons, lats)
-    results = []
+    results = {}
+    counts = get_count_from_bucket_indices(x_idxs, y_idxs, adef.shape)
+    counts = counts.astype(float)
     for cat in categories:
         cat_data = da.where(data == cat, 1.0, 0.0)
 
         sums = get_sum_from_bucket_indices(cat_data, x_idxs, y_idxs, adef.shape)
-        results.append(sums)
+        results[cat] = sums.astype(float) / counts
 
-    counts = get_count_from_bucket_indices(x_idxs, y_idxs, adef.shape)
-    fractions = [res / counts for res in results]
-
-    return fractions
+    return results

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -155,10 +155,10 @@ class BucketResampler(object):
         y_idxs = ((np.max(y_vect) - proj_y) / y_res).astype(np.int)
 
         # Get valid index locations
-        idxs = ((x_idxs >= 0) & (x_idxs < adef.width) &
+        mask = ((x_idxs >= 0) & (x_idxs < adef.width) &
                 (y_idxs >= 0) & (y_idxs < adef.height))
-        self.y_idxs = da.where(idxs, y_idxs, -1)
-        self.x_idxs = da.where(idxs, x_idxs, -1)
+        self.y_idxs = da.where(mask, y_idxs, -1)
+        self.x_idxs = da.where(mask, x_idxs, -1)
 
         # Convert X- and Y-indices to raveled indexing
         target_shape = self.target_area.shape
@@ -238,8 +238,8 @@ class BucketResampler(object):
         counts = self.get_count()
 
         average = sums / counts
-        idxs = (counts == 0) | np.isnan(sums)
-        average = da.where(idxs, fill_value, average)
+        mask = (counts == 0) | np.isnan(sums)
+        average = da.where(mask, fill_value, average)
 
         return average
 

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -39,42 +39,32 @@ class BucketResampler(object):
     fractions) directly from Satpy, but this demonstrates the direct
     low-level usage.
 
-    .. code-block:: python
-
-        from pyresample.bucket import BucketResampler
-        from satpy import Scene
-        from satpy.resample import get_area_def
-        fname = "hrpt_noaa19_20170519_1214_42635.l1b"
-        glbl = Scene(filenames=[fname])
-        glbl.load(['4'])
-        data = glbl['4']
-        lons, lats = data.area.get_lonlats()
-        target_area = get_area_def('euro4')
+    >>> from pyresample.bucket import BucketResampler
+    >>> from satpy import Scene
+    >>> from satpy.resample import get_area_def
+    >>> fname = "hrpt_noaa19_20170519_1214_42635.l1b"
+    >>> glbl = Scene(filenames=[fname])
+    >>> glbl.load(['4'])
+    >>> data = glbl['4']
+    >>> lons, lats = data.area.get_lonlats()
+    >>> target_area = get_area_def('euro4')
 
     Initialize the resampler
 
-    .. code-block:: python
-
-        resampler = BucketResampler(adef, lons, lats)
+    >>> resampler = BucketResampler(adef, lons, lats)
 
     Calculate the sum of all the data in each grid location:
 
-    .. code-block:: python
-
-        sums = resampler.get_sum(data)
+    >>> sums = resampler.get_sum(data)
 
     Calculate how many values were collected at each grid location:
 
-    .. code-block:: python
-
-        counts = resampler.get_count()
+    >>> counts = resampler.get_count()
 
     The average can be calculated from the above two results, or directly
     using the helper method:
 
-    .. code-block:: python
-
-        average = resampler.get_average(data)
+    >>> average = resampler.get_average(data)
 
     Calculate fractions of occurrences of different values in each grid
     location.  The data needs to be categorical (in integers), so
@@ -82,12 +72,10 @@ class BucketResampler(object):
     data that were read earlier.  The data are returned in a
     dictionary with the categories as keys.
 
-    .. code-block:: python
-
-        data = da.where(data > 250, 1, 0)
-        fractions = resampler.get_fractions(data, categories=[0, 1])
-        import matplotlib.pyplot as plt
-        plt.imshow(fractions[0]); plt.show()
+    >>> data = da.where(data > 250, 1, 0)
+    >>> fractions = resampler.get_fractions(data, categories=[0, 1])
+    >>> import matplotlib.pyplot as plt
+    >>> plt.imshow(fractions[0]); plt.show()
     """
 
     def __init__(self, target_area, source_lons, source_lats):

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -71,7 +71,7 @@ class BucketResampler(object):
 
         >>> average = resampler.get_average(data)
 
-    Calculate fractions of occurences of different values in each grid
+    Calculate fractions of occurrences of different values in each grid
     location.  The data needs to be categorical (in integers), so
     we'll create some categorical data from the brightness temperature
     data that were read earlier.  The data are returned in a
@@ -188,7 +188,7 @@ class BucketResampler(object):
         return sums.reshape(self.target_area.shape)
 
     def get_count(self):
-        """Count the number of occurances for each bin using drop-in-a-bucket
+        """Count the number of occurrences for each bin using drop-in-a-bucket
         resampling.
 
         Returns
@@ -228,7 +228,7 @@ class BucketResampler(object):
         return average
 
     def get_fractions(self, data, categories=None, fill_value=np.nan):
-        """Get fraction of occurences for each given categorical value.
+        """Get fraction of occurrences for each given categorical value.
 
         Parameters
         ----------

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -144,7 +144,7 @@ def resample_bucket_fractions(adef, data, lats, lons, categories,
     for cat in categories:
         cat_data = da.where(data == cat, 1.0, 0.0)
 
-        sums = get_sum_from_bucket_indices(data, x_idxs, y_idxs, adef.shape)
+        sums = get_sum_from_bucket_indices(cat_data, x_idxs, y_idxs, adef.shape)
         results.append(sums)
 
     counts = get_count_from_bucket_indices(x_idxs, y_idxs, adef.shape)

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -1,0 +1,137 @@
+# pyresample, Resampling of remote sensing image data in python
+#
+# Copyright (C) 2019  Pytroll developers
+#
+# Author(s):
+#
+#   Panu Lahtinen <panu.lahtinen@fmi.fi>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Code for resampling using bucket resampling.
+
+Bucket resampling is useful for calculating averages and hit-counts
+when aggregating data to coarser scale grids.
+"""
+
+import numpy as np
+from pyresample._spatial_mp import Proj
+
+def round_to_resolution(arr, resolution):
+    """Round the values in *arr* to closest resolution element."""
+    return resolution * np.round(arr / resolution)
+
+
+def get_bucket_indices(adef, lons, lats):
+    """Get projection indices"""
+
+    prj = Proj(adef.proj_dict)
+
+    # Create output grid coordinates in projection units
+    x_res = (adef.area_extent[2] - adef.area_extent[0]) / adef.width
+    y_res = (adef.area_extent[3] - adef.area_extent[1]) / adef.height
+    x_vect = np.arange(adef.area_extent[0] + x_res / 2.,
+                       adef.area_extent[2] - x_res / 2., x_res)
+    # Orient so that 0-meridian is pointing down
+    y_vect = np.arange(adef.area_extent[3] - y_res / 2.,
+                       adef.area_extent[1] + y_res / 2.,
+                       -y_res)
+
+    lons = np.ravel(lons)
+    lats = np.ravel(lats)
+
+    # Round coordinates to the closest resolution element
+    proj_x, proj_y = prj(lons, lats)
+    proj_x = round_to_resolution(proj_x, x_res)
+    proj_y = round_to_resolution(proj_y, y_res)
+
+    # Calculate array indices
+    x_idxs = ((proj_x - np.min(x_vect)) / x_res).astype(np.int)
+    y_idxs = ((np.max(y_vect) - proj_y) / y_res).astype(np.int)
+
+    # Mark invalid array indices with -1
+    idxs = ((x_idxs < 0) | (x_idxs >= adef.width) |
+            (y_idxs < 0) | (y_idxs >= adef.height))
+    y_idxs[idxs] = -1
+    x_idxs[idxs] = -1
+
+    return x_idxs, y_idxs
+
+
+def get_sample_from_bucket_indices(data, x_idxs, y_idxs, target_shape):
+    """Resample the given data with drop-in-a-bucket resampling.  Return
+    the sum and counts for each bin as two Numpy arrays."""
+
+    sums = np.zeros(target_shape)
+    count = np.zeros(target_shape)
+    data = np.ravel(data)
+
+    idxs = (x_idxs > 0) & (y_idxs > 0) & np.isfinite(data)
+    x_idxs = x_idxs[idxs]
+    y_idxs = y_idxs[idxs]
+    data = data[idxs]
+
+    # Place the data to proper locations
+    for i in range(x_idxs.size):
+        x_idx = x_idxs[i]
+        y_idx = y_idxs[i]
+        #if x_idx < 0 | y_idx < 0 | np.isnan(data[i]):
+        #    continue
+        sums[y_idx, x_idx] += data[i]
+        count[y_idx, x_idx] += 1
+
+    return sums, count
+
+
+def resample_bucket_average(adef, data, lats, lons,
+                            fill_value=np.nan, x_idxs=None, y_idxs=None):
+    """Calculate bin-averages using bucket resampling."""
+    if x_idxs is None or y_idxs is None:
+        x_idxs, y_idxs = get_bucket_indices(adef, lons, lats)
+    sums, counts = get_sample_from_bucket_indices(data, x_idxs, y_idxs,
+                                                  adef.shape)
+    average = sums / counts
+    average = np.where(count == 0, fill_value, average)
+
+    return average
+
+
+def resample_bucket_counts(adef, data, lats, lons,
+                           fill_value=np.nan, x_idxs=None, y_idxs=None):
+    """Get number of hits for each bin."""
+    if x_idxs is None or y_idxs is None:
+        x_idxs, y_idxs = get_bucket_indices(adef, lons, lats)
+    _, counts = get_sample_from_bucket_indices(data, x_idxs, y_idxs,
+                                               adef.shape)
+
+    return counts
+
+
+def resample_bucket_fractions(adef, data, lats, lons, categories,
+                              fill_value=np.nan, x_idxs=None, y_idxs=None):
+    """Get fraction of occurences for each given categorical value."""
+    if x_idxs is None or y_idxs is None:
+        x_idxs, y_idxs = get_bucket_indices(adef, lons, lats)
+    results = []
+    for cat in categories:
+        cat_data = np.where(data == cat, 1.0, 0.0)
+        sums, _ = get_sample_from_bucket_indices(cat_data, x_idxs, y_idxs,
+                                                 adef.shape)
+        results.append(sums)
+
+    total_hits = np.sum(results, axis=0)
+
+    fractions = [res / total_hits for res in results]
+
+    return fractions

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -74,7 +74,7 @@ def get_sample_from_bucket_indices(data, x_idxs, y_idxs, target_shape):
     the sum and counts for each bin as two Numpy arrays."""
 
     sums = np.zeros(target_shape)
-    count = np.zeros(target_shape)
+    counts = np.zeros(target_shape)
     data = np.ravel(data)
 
     idxs = (x_idxs > 0) & (y_idxs > 0) & np.isfinite(data)
@@ -89,9 +89,9 @@ def get_sample_from_bucket_indices(data, x_idxs, y_idxs, target_shape):
         #if x_idx < 0 | y_idx < 0 | np.isnan(data[i]):
         #    continue
         sums[y_idx, x_idx] += data[i]
-        count[y_idx, x_idx] += 1
+        counts[y_idx, x_idx] += 1
 
-    return sums, count
+    return sums, counts
 
 
 def resample_bucket_average(adef, data, lats, lons,
@@ -102,7 +102,7 @@ def resample_bucket_average(adef, data, lats, lons,
     sums, counts = get_sample_from_bucket_indices(data, x_idxs, y_idxs,
                                                   adef.shape)
     average = sums / counts
-    average = np.where(count == 0, fill_value, average)
+    average = np.where(counts == 0, fill_value, average)
 
     return average
 

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -142,11 +142,12 @@ def resample_bucket_fractions(adef, data, lats, lons, categories,
         x_idxs, y_idxs = get_bucket_indices(adef, lons, lats)
     results = []
     for cat in categories:
-        cat_data = np.where(data == cat, 1.0, 0.0)
-        sums, counts = get_sample_from_bucket_indices(cat_data, x_idxs, y_idxs,
-                                                      adef.shape)
+        cat_data = da.where(data == cat, 1.0, 0.0)
+
+        sums = get_sum_from_bucket_indices(data, x_idxs, y_idxs, adef.shape)
         results.append(sums)
 
+    counts = get_count_from_bucket_indices(x_idxs, y_idxs, adef.shape)
     fractions = [res / counts for res in results]
 
     return fractions

--- a/pyresample/test/__init__.py
+++ b/pyresample/test/__init__.py
@@ -37,7 +37,8 @@ from pyresample.test import (
     test_ewa_fornav,
     test_bilinear,
     test_data_reduce,
-    test_spatial_mp
+    test_spatial_mp,
+    test_bucket
 )
 
 import unittest
@@ -61,6 +62,7 @@ def suite():
     mysuite.addTests(test_bilinear.suite())
     mysuite.addTests(test_data_reduce.suite())
     mysuite.addTests(test_spatial_mp.suite())
+    mysuite.addTests(test_bucket.suite())
     return mysuite
 
 

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -4,10 +4,10 @@ import dask.array as da
 import dask
 import xarray as xr
 try:
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import MagicMock
 except ImportError:
     # separate mock package py<3.3
-    from mock import MagicMock, patch
+    from mock import MagicMock
 
 from pyresample.geometry import AreaDefinition
 import pyresample.bucket as bucket

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -4,10 +4,10 @@ import dask.array as da
 import dask
 import xarray as xr
 try:
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, patch
 except ImportError:
     # separate mock package py<3.3
-    from mock import MagicMock
+    from mock import MagicMock, patch
 
 from pyresample.geometry import AreaDefinition
 from pyresample import bucket
@@ -29,6 +29,13 @@ class Test(unittest.TestCase):
 
     def setUp(self):
         self.resampler = bucket.BucketResampler(self.adef, self.lons, self.lats)
+
+    @patch('pyresample.bucket.Proj')
+    @patch('pyresample.bucket.BucketResampler._get_indices')
+    def test_init(self, get_indices, prj):
+        resampler = bucket.BucketResampler(self.adef, self.lons, self.lats)
+        get_indices.assert_called_once()
+        prj.assert_called_once_with(self.adef.proj_dict)
 
     def test_round_to_resolution(self):
         """Test rounding to given resolution"""

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -36,6 +36,17 @@ class Test(unittest.TestCase):
         resampler = bucket.BucketResampler(self.adef, self.lons, self.lats)
         get_indices.assert_called_once()
         prj.assert_called_once_with(self.adef.proj_dict)
+        self.assertTrue(hasattr(resampler, 'target_area'))
+        self.assertTrue(hasattr(resampler, 'source_lons'))
+        self.assertTrue(hasattr(resampler, 'source_lats'))
+        self.assertTrue(hasattr(resampler, 'x_idxs'))
+        self.assertTrue(hasattr(resampler, 'y_idxs'))
+        self.assertTrue(hasattr(resampler, 'idxs'))
+        self.assertTrue(hasattr(resampler, 'get_sum'))
+        self.assertTrue(hasattr(resampler, 'get_count'))
+        self.assertTrue(hasattr(resampler, 'get_average'))
+        self.assertTrue(hasattr(resampler, 'get_fractions'))
+
 
     def test_round_to_resolution(self):
         """Test rounding to given resolution"""

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -11,25 +11,7 @@ except ImportError:
 
 from pyresample.geometry import AreaDefinition
 import pyresample.bucket as bucket
-
-
-class CustomScheduler(object):
-    """Custom dask scheduler that raises an exception if dask is computed
-    too many times."""
-
-    def __init__(self, max_computes=1):
-        """Set starting and maximum compute counts."""
-        self.max_computes = max_computes
-        self.total_computes = 0
-
-    def __call__(self, dsk, keys, **kwargs):
-        """Compute dask task and keep track of number of times we do so."""
-        import dask
-        self.total_computes += 1
-        if self.total_computes > self.max_computes:
-            raise RuntimeError("Too many dask computations were scheduled: "
-                               "{}".format(self.total_computes))
-        return dask.get(dsk, keys, **kwargs)
+from pyresample.test.utils import CustomScheduler
 
 
 class Test(unittest.TestCase):

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -159,6 +159,21 @@ class Test(unittest.TestCase):
         res = result[4].compute()
         self.assertTrue(np.nanmax(res) == 0.5)
         self.assertTrue(np.nanmin(res) == 0.)
+        # There should be NaN values
+        self.assertTrue(np.any(np.isnan(res)))
+
+        # Use a fill value
+        with dask.config.set(scheduler=CustomScheduler(max_computes=10)):
+            result = bucket.resample_bucket_fractions(self.adef,
+                                                      data, self.lons,
+                                                      self.lats,
+                                                      categories,
+                                                      fill_value=-1)
+        # There should not be any NaN values
+        for i in categories:
+            res = result[i].compute()
+            self.assertFalse(np.any(np.isnan(res)))
+            self.assertTrue(np.min(res) == -1)
 
 
 def suite():

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -1,0 +1,37 @@
+import unittest
+import numpy as np
+import dask.array as da
+
+from pyresample._spatial_mp import Proj
+
+import pyresample.bucket as bucket
+
+
+class Test(unittest.TestCase):
+
+    def test_round_to_resolution(self):
+        """Test rounding to given resolution"""
+        # Scalar, integer resolution
+        self.assertEqual(bucket.round_to_resolution(5.5, 2.), 6)
+        # Scalar, non-integer resolution
+        self.assertEqual(bucket.round_to_resolution(5.5, 1.7), 5.1)
+        # List
+        self.assertTrue(np.all(bucket.round_to_resolution([4.2, 5.6], 2) ==
+                               np.array([4., 6.])))
+        # Numpy array
+        self.assertTrue(np.all(bucket.round_to_resolution(np.array([4.2, 5.6]), 2) ==
+                               np.array([4., 6.])))
+        # Dask array
+        self.assertTrue(
+            np.all(bucket.round_to_resolution(da.array([4.2, 5.6]), 2) ==
+                   np.array([4., 6.])))
+
+
+def suite():
+    """The test suite.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(Test))
+
+    return mysuite

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -195,6 +195,11 @@ class Test(unittest.TestCase):
             self.assertFalse(np.any(np.isnan(res)))
             self.assertTrue(np.min(res) == -1)
 
+        # No categories given, need to compute the data once to get
+        # the categories
+        with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
+            result = self.resampler.get_fractions(data, categories=None)
+
 
 def suite():
     """The test suite.

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -2,8 +2,6 @@ import unittest
 import numpy as np
 import dask.array as da
 
-from pyresample._spatial_mp import Proj
-
 import pyresample.bucket as bucket
 
 

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -117,6 +117,16 @@ class Test(unittest.TestCase):
         self.assertEqual(np.sum(result == 4.), 1)
         self.assertEqual(result.shape, self.adef.shape)
 
+        # Test masking all-NaN bins
+        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]))
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = self.resampler.get_sum(data, mask_all_nan=True)
+        self.assertTrue(np.all(np.isnan(result)))
+        # By default all-NaN bins have a value of 0.0
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = self.resampler.get_sum(data)
+        self.assertEqual(np.nanmax(result), 0.0)
+
     def test_get_count(self):
         """Test drop-in-a-bucket sum."""
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
@@ -143,6 +153,16 @@ class Test(unittest.TestCase):
         self.assertEqual(np.max(result), 3.)
         self.assertEqual(np.min(result), -1)
         self.assertFalse(np.any(np.isnan(result)))
+
+        # Test masking all-NaN bins
+        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]))
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = self.resampler.get_average(data, mask_all_nan=True)
+        self.assertTrue(np.all(np.isnan(result)))
+        # By default all-NaN bins have a value of 0.0
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = self.resampler.get_average(data)
+        self.assertEqual(np.nanmax(result), 0.0)
 
     def test_resample_bucket_fractions(self):
         """Test fraction calculations for categorical data."""

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -168,7 +168,7 @@ class Test(unittest.TestCase):
         """Test fraction calculations for categorical data."""
         data = da.from_array(np.array([[2, 4], [2, 2]]))
         categories = [1, 2, 3, 4]
-        with dask.config.set(scheduler=CustomScheduler(max_computes=10)):
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_fractions(data, categories=categories)
         self.assertEqual(set(categories), set(result.keys()))
         res = result[1].compute()
@@ -185,7 +185,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.any(np.isnan(res)))
 
         # Use a fill value
-        with dask.config.set(scheduler=CustomScheduler(max_computes=10)):
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_fractions(data, categories=categories,
                                                   fill_value=-1)
 

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -1,11 +1,49 @@
 import unittest
 import numpy as np
 import dask.array as da
+import dask
+import xarray as xr
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    # separate mock package py<3.3
+    from mock import MagicMock, patch
 
+from pyresample.geometry import AreaDefinition
 import pyresample.bucket as bucket
 
 
+class CustomScheduler(object):
+    """Custom dask scheduler that raises an exception if dask is computed
+    too many times."""
+
+    def __init__(self, max_computes=1):
+        """Set starting and maximum compute counts."""
+        self.max_computes = max_computes
+        self.total_computes = 0
+
+    def __call__(self, dsk, keys, **kwargs):
+        """Compute dask task and keep track of number of times we do so."""
+        import dask
+        self.total_computes += 1
+        if self.total_computes > self.max_computes:
+            raise RuntimeError("Too many dask computations were scheduled: "
+                               "{}".format(self.total_computes))
+        return dask.get(dsk, keys, **kwargs)
+
+
 class Test(unittest.TestCase):
+
+    adef = AreaDefinition('eurol', 'description', '',
+                          {'ellps': 'WGS84',
+                           'lat_0': '90.0',
+                           'lat_ts': '60.0',
+                           'lon_0': '0.0',
+                           'proj': 'stere'}, 2560, 2048,
+                          (-3780000.0, -7644000.0, 3900000.0, -1500000.0))
+
+    lons = da.from_array(np.array([[25., 25.], [25., 25.]]))
+    lats = da.from_array(np.array([[60., 60.1], [60.2, 60.3]]))
 
     def test_round_to_resolution(self):
         """Test rounding to given resolution"""
@@ -23,6 +61,95 @@ class Test(unittest.TestCase):
         self.assertTrue(
             np.all(bucket.round_to_resolution(da.array([4.2, 5.6]), 2) ==
                    np.array([4., 6.])))
+
+    def test_get_proj_coordinates(self):
+        """Test calculation of projection coordinates."""
+        prj = MagicMock()
+        prj.return_value = ([3.1, 3.1, 3.1], [4.8, 4.8, 4.8])
+        lons = [1., 1., 1.]
+        lats = [2., 2., 2.]
+        x_res, y_res = 0.5, 0.5
+        result = bucket._get_proj_coordinates(lons, lats, x_res, y_res, prj)
+        prj.assert_called_once_with(lons, lats)
+        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertEqual(result.shape, (2, 3))
+        self.assertTrue(np.all(result == np.array([[3., 3., 3.],
+                                                   [5., 5., 5.]])))
+
+    def test_get_bucket_indices(self):
+        """Test calculation of array indices."""
+        # Ensure nothing is calculated
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            x_idxs, y_idxs = bucket.get_bucket_indices(self.adef, self.lons,
+                                                       self.lats)
+        x_idxs, y_idxs = da.compute(x_idxs, y_idxs)
+        self.assertTrue(np.all(x_idxs == np.array([1709, 1708, 1706, 1705])))
+        self.assertTrue(np.all(y_idxs == np.array([465, 461, 458, 455])))
+
+    def test_get_sum_from_bucket_indices(self):
+        """Test drop-in-a-bucket sum."""
+        x_idxs, y_idxs = bucket.get_bucket_indices(self.adef, self.lons,
+                                                   self.lats)
+        data = da.from_array(np.array([[2., 2.], [2., 2.]]))
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = bucket.get_sum_from_bucket_indices(data, x_idxs, y_idxs,
+                                                        self.adef.shape)
+        result = result.compute()
+        # Only one value per bin, so max value is 1.0
+        self.assertTrue(np.max(result) == 2.)
+        # Four values in four separate bins
+        self.assertEqual(np.sum(result == 2.), 4)
+        self.assertEqual(result.shape, self.adef.shape)
+
+        # Test that also Xarray.DataArrays work
+        data = xr.DataArray(data)
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = bucket.get_sum_from_bucket_indices(data, x_idxs, y_idxs,
+                                                        self.adef.shape)
+        # Only one value per bin, so max value is 1.0
+        self.assertTrue(np.max(result) == 2.)
+        # Four values in four separate bins
+        self.assertEqual(np.sum(result == 2.), 4)
+        self.assertEqual(result.shape, self.adef.shape)
+
+    def test_get_count_from_bucket_indices(self):
+        """Test drop-in-a-bucket sum."""
+        x_idxs, y_idxs = bucket.get_bucket_indices(self.adef, self.lons,
+                                                   self.lats)
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = bucket.get_count_from_bucket_indices(x_idxs, y_idxs,
+                                                          self.adef.shape)
+        result = result.compute()
+        self.assertTrue(np.max(result) == 1)
+        self.assertEqual(np.sum(result == 1), 4)
+
+    def test_resample_bucket_average(self):
+        """Test averaging bucket resampling."""
+        data = da.from_array(np.array([[2., 2.], [2., 2.]]))
+        # Without pre-calculated indices
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = bucket.resample_bucket_average(self.adef,
+                                                    data, self.lons, self.lats)
+        result = result.compute()
+        self.assertEqual(np.nanmax(result), 2.)
+        self.assertTrue(np.any(np.isnan(result)))
+        # Use a fill value other than np.nan
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = bucket.resample_bucket_average(self.adef,
+                                                    data, self.lons, self.lats,
+                                                    fill_value=-1)
+        result = result.compute()
+        self.assertEqual(np.max(result), 2.)
+        self.assertEqual(np.min(result), -1)
+        self.assertFalse(np.any(np.isnan(result)))
+        # Pre-calculate the indices
+        x_idxs, y_idxs = bucket.get_bucket_indices(self.adef, self.lons,
+                                                   self.lats)
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = bucket.resample_bucket_average(self.adef,
+                                                    data, self.lons, self.lats,
+                                                    x_idxs=x_idxs,
+                                                    y_idxs=y_idxs)
 
 
 def suite():

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -138,6 +138,28 @@ class Test(unittest.TestCase):
                                                     x_idxs=x_idxs,
                                                     y_idxs=y_idxs)
 
+    def test_resample_bucket_fractions(self):
+        """Test fraction calculations for categorical data."""
+        data = da.from_array(np.array([[2, 4], [2, 2]]))
+        categories = [1, 2, 3, 4]
+        # Without pre-calculated indices
+        with dask.config.set(scheduler=CustomScheduler(max_computes=10)):
+            result = bucket.resample_bucket_fractions(self.adef,
+                                                      data, self.lons,
+                                                      self.lats,
+                                                      categories)
+        self.assertEqual(set(categories), set(result.keys()))
+        res = result[1].compute()
+        self.assertTrue(np.nanmax(res) == 0.)
+        res = result[2].compute()
+        self.assertTrue(np.nanmax(res) == 1.)
+        self.assertTrue(np.nanmin(res) == 0.5)
+        res = result[3].compute()
+        self.assertTrue(np.nanmax(res) == 0.)
+        res = result[4].compute()
+        self.assertTrue(np.nanmax(res) == 0.5)
+        self.assertTrue(np.nanmin(res) == 0.)
+
 
 def suite():
     """The test suite.

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -46,7 +46,7 @@ class Test(unittest.TestCase):
         self.assertTrue(hasattr(resampler, 'get_count'))
         self.assertTrue(hasattr(resampler, 'get_average'))
         self.assertTrue(hasattr(resampler, 'get_fractions'))
-
+        self.assertIsNone(resampler.counts)
 
     def test_round_to_resolution(self):
         """Test rounding to given resolution"""
@@ -125,6 +125,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.max(result) == 2)
         self.assertEqual(np.sum(result == 1), 2)
         self.assertEqual(np.sum(result == 2), 1)
+        self.assertTrue(self.resampler.counts is not None)
 
     def test_get_average(self):
         """Test averaging bucket resampling."""

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -181,8 +181,7 @@ def create_test_latitude(start, stop, shape, twist_factor=0.0, dtype=np.float32)
 
 
 class CustomScheduler(object):
-    """Custom dask scheduler that raises an exception if dask is computed
-    too many times."""
+    """Scheduler raising an exception if data are computed too many times."""
 
     def __init__(self, max_computes=1):
         """Set starting and maximum compute counts."""

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -178,3 +178,22 @@ def create_test_latitude(start, stop, shape, twist_factor=0.0, dtype=np.float32)
     lat_array = np.repeat(lat_col, shape[1], axis=1)
     lat_array += twist_array
     return lat_array
+
+
+class CustomScheduler(object):
+    """Custom dask scheduler that raises an exception if dask is computed
+    too many times."""
+
+    def __init__(self, max_computes=1):
+        """Set starting and maximum compute counts."""
+        self.max_computes = max_computes
+        self.total_computes = 0
+
+    def __call__(self, dsk, keys, **kwargs):
+        """Compute dask task and keep track of number of times we do so."""
+        import dask
+        self.total_computes += 1
+        if self.total_computes > self.max_computes:
+            raise RuntimeError("Too many dask computations were scheduled: "
+                               "{}".format(self.total_computes))
+        return dask.get(dsk, keys, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {'numexpr': ['numexpr'],
                   'rasterio': ['rasterio'],
                   'dask': ['dask>=0.16.1']}
 
-test_requires = ['rasterio', 'dask', 'xarray', 'cartopy', 'pillow', 'matplotlib', 'scipy', 'pyproj', 'numpy']
+test_requires = ['rasterio', 'dask', 'xarray', 'cartopy', 'pillow', 'matplotlib', 'scipy']
 if sys.version_info < (3, 3):
     test_requires.append('mock')
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {'numexpr': ['numexpr'],
                   'rasterio': ['rasterio'],
                   'dask': ['dask>=0.16.1']}
 
-test_requires = ['rasterio', 'dask', 'xarray', 'cartopy', 'pillow', 'matplotlib', 'scipy']
+test_requires = ['rasterio', 'dask', 'xarray', 'cartopy', 'pillow', 'matplotlib', 'scipy', 'pyproj', 'numpy']
 if sys.version_info < (3, 3):
     test_requires.append('mock')
 


### PR DESCRIPTION
This PR adds few methods to do "drop-in-a-bucket" resampling for calculating

- averages (average of all the values hitting a bin)
- hit-counts (number of values hitting a bin)
- fractions of different categorical values (e.g. water fraction of a bin)

when aggregating high resolution data to a lower resolution grid.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
