### PR TITLE
Fix to_cartopy_crs for latlong projections

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1258,7 +1258,7 @@ class AreaDefinition(BaseDefinition):
                   self.area_extent[2],
                   self.area_extent[1],
                   self.area_extent[3])
-        if Proj(**self.proj_dict).is_latlong():
+        if Proj(self.proj_dict).is_latlong():
             # Convert area extent from degrees to radians
             bounds = np.deg2rad(bounds)
         crs = from_proj(self.proj_str, bounds=bounds)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1258,6 +1258,9 @@ class AreaDefinition(BaseDefinition):
                   self.area_extent[2],
                   self.area_extent[1],
                   self.area_extent[3])
+        if Proj(**self.proj_dict).is_latlong():
+            # Convert area extent from degrees to radians
+            bounds = np.deg2rad(bounds)
         crs = from_proj(self.proj_str, bounds=bounds)
         return crs
 

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -33,7 +33,7 @@ import numpy as np
 import yaml
 from pyproj import Geod, transform
 
-from pyresample import CHUNK_SIZE, utils
+from pyresample import CHUNK_SIZE
 from pyresample._spatial_mp import Cartesian, Cartesian_MP, Proj, Proj_MP
 from pyresample.boundary import AreaDefBoundary, Boundary, SimpleBoundary
 from pyresample.utils import proj4_str_to_dict, proj4_dict_to_str, convert_proj_floats

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -131,6 +131,16 @@ class Test(unittest.TestCase):
                 area.to_cartopy_crs()
                 warn.assert_called()
 
+        # Bounds for latlong projection must be specified in radians
+        latlong_crs = geometry.AreaDefinition(area_id='latlong',
+                                              description='Global regular lat-lon grid',
+                                              proj_id='latlong',
+                                              projection={'proj': 'latlong', 'lon0': 0},
+                                              width=360,
+                                              height=180,
+                                              area_extent=(-180, -90, 180, 90)).to_cartopy_crs()
+        self.assertTrue(np.allclose(latlong_crs.bounds, [-np.pi, np.pi, -np.pi/2, np.pi/2]))
+
     def test_create_areas_def(self):
         from pyresample import utils
         import yaml


### PR DESCRIPTION
This PR converts `AreaDefinition.to_cartopy_crs().bounds` from degrees to radians for the `latlong` projection. At the moment they are specified in degrees which leads to tiny coastlines being displayed in the middle of the image.

```python
In [1]: import pyresample 
   ...: import matplotlib.pyplot as plt 
   ...: import numpy as np 
   ...:  
   ...: area_def = pyresample.AreaDefinition( 
   ...:     area_id='test', 
   ...:     description='test', 
   ...:     proj_id='test', 
   ...:     projection={'proj': 'latlong', 'lon0': 0}, 
   ...:     width=360, 
   ...:     height=180, 
   ...:     area_extent=(-180, -90, 180, 90), 
   ...: ) 
   ...: crs = area_def.to_cartopy_crs() 
   ...: crs.bounds                                                                                                                                                                                                                           
Out[1]: (-180, 180, -90, 90)
```

```python
In [2]: lons, lats = area_def.get_lonlats() 
   ...: data = np.sin(np.deg2rad(lons)) * np.cos(np.deg2rad(lats)) 
   ...:  
   ...: fig, ax = plt.subplots(subplot_kw={'projection': crs}) 
   ...: ax.imshow(data, transform=crs, extent=crs.bounds) 
   ...: ax.coastlines() 
   ...: plt.show()  
```

Current:
![coastlines](https://user-images.githubusercontent.com/1991007/60333961-b0b25000-999a-11e9-80c9-75c5f40c5eae.png)

Fixed:
![coastlines_fixed](https://user-images.githubusercontent.com/1991007/60333971-b4de6d80-999a-11e9-9dca-c8fb4fecb017.png)

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

