### PR TITLE
Clarify warning if no overlap data and projection

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1725,7 +1725,8 @@ class AreaDefinition(BaseDefinition):
         intersection = data_boundary.contour_poly.intersection(
             area_boundary.contour_poly)
         if intersection is None:
-            logger.debug('Cannot determine appropriate slicing.')
+            logger.debug('Cannot determine appropriate slicing. '
+                         "Perhaps data and projection area do not overlap?")
             raise NotImplementedError
         x, y = self.get_xy_from_lonlat(np.rad2deg(intersection.lon),
                                        np.rad2deg(intersection.lat))


### PR DESCRIPTION
When projecting data onto an area with which the data do not overlap,
give a more informative warning message to the user.

<!-- Please make the PR against the `master` branch. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
