### PR TITLE
Add Example for Regular Lat-Lon Grid

### DIFF
--- a/docs/source/geo_def.rst
+++ b/docs/source/geo_def.rst
@@ -51,23 +51,21 @@ where
 * **upper_right_x**: projection x coordinate of upper right corner of upper right pixel
 * **upper_right_y**: projection y coordinate of upper right corner of upper right pixel
 
-Below are three examples of creating an ``AreaDefinition``:
+Example:
 
 .. doctest::
 
  >>> from pyresample.geometry import AreaDefinition
-
- >>> # a) Using a projection dictionary
  >>> area_id = 'ease_sh'
  >>> description = 'Antarctic EASE grid'
  >>> proj_id = 'ease_sh'
- >>> proj_dict = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
+ >>> projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
  >>> width = 425
  >>> height = 425
  >>> area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
- >>> area_def = AreaDefinition(area_id, description, proj_id, proj_dict,
+ >>> area_def = AreaDefinition(area_id, description, proj_id, projection,
  ...                           width, height, area_extent)
- >>> print(area_def)
+ >>> area_def
  Area ID: ease_sh
  Description: Antarctic EASE grid
  Projection ID: ease_sh
@@ -76,35 +74,25 @@ Below are three examples of creating an ``AreaDefinition``:
  Number of rows: 425
  Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
 
- >>> # b) Using an explicit proj4 string
- >>> proj_string = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
- >>> area_def = AreaDefinition(area_id, description, proj_id, proj_string,
- ...                           width, height, area_extent)
- >>> print(area_def)
- Area ID: ease_sh
- Description: Antarctic EASE grid
- Projection ID: ease_sh
- Projection: {'a': '6371228.0', 'lat_0': '-90.0', 'lon_0': '0.0', 'proj': 'laea', 'units': 'm'}
- Number of columns: 425
- Number of rows: 425
- Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
+You can also specify the projection using a PROJ.4 string
 
- >>> # c) Using an EPSG code in a proj4 string
- >>> proj_string = '+init=EPSG:3409'  # Use 'EPSG:3409' with pyproj 2.0+
- >>> area_def = AreaDefinition(area_id, description, proj_id, proj_string,
+.. doctest::
+
+ >>> projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+ >>> area_def = AreaDefinition(area_id, description, proj_id, projection,
  ...                           width, height, area_extent)
- >>> print(area_def)
- Area ID: ease_sh
- Description: Antarctic EASE grid
- Projection ID: ease_sh
- Projection: {'init': 'EPSG:3409'}
- Number of columns: 425
- Number of rows: 425
- Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
+
+or an `EPSG code <https://www.epsg-registry.org/>`_:
+
+.. doctest::
+
+ >>> projection = '+init=EPSG:3409'  # Use 'EPSG:3409' with pyproj 2.0+
+ >>> area_def = AreaDefinition(area_id, description, proj_id, projection,
+ ...                           width, height, area_extent)
 
 .. note::
 
-  When using pyproj 2.0+, please use the new ``'EPSG:XXXX'`` syntax
+  With pyproj 2.0+ please use the new ``'EPSG:XXXX'`` syntax
   as the old ``'+init=EPSG:XXXX'`` is no longer supported.
 
 Creating an ``AreaDefinition`` can be complex if you don't know everything

--- a/docs/source/geometry_utils.rst
+++ b/docs/source/geometry_utils.rst
@@ -79,23 +79,42 @@ keyword arguments can be specified with one value if ``dx == dy``:
  Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
 
 You can also specify parameters in degrees even if the projection space
-is defined in meters. For example the below code creates an area in
-the mercator projection with radius and resolution defined in degrees.
+is defined in meters:
 
-.. doctest::
+* Create an area in the mercator projection with radius and resolution defined in degrees
 
- >>> proj_dict = {'proj': 'merc', 'lat_0': 0, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
- >>> area_def = create_area_def(area_id, proj_dict, center=(0, 0),
- ...                              radius=(47.90379019311, 43.1355420077),
- ...                              resolution=(0.22542960090875294, 0.22542901929487608),
- ...                              units='degrees', description='Antarctic EASE grid')
- >>> print(area_def)
- Area ID: ease_sh
- Description: Antarctic EASE grid
- Projection: {'a': '6371228.0', 'lat_0': '0.0', 'lon_0': '0.0', 'proj': 'merc', 'units': 'm'}
- Number of columns: 425
- Number of rows: 425
- Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
+ .. doctest::
+
+  >>> proj_dict = {'proj': 'merc', 'lat_0': 0, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
+  >>> area_def = create_area_def(area_id, proj_dict, center=(0, 0),
+  ...                            radius=(47.90379019311, 43.1355420077),
+  ...                            resolution=(0.22542960090875294, 0.22542901929487608),
+  ...                            units='degrees', description='Antarctic EASE grid')
+  >>> print(area_def)
+  Area ID: ease_sh
+  Description: Antarctic EASE grid
+  Projection: {'a': '6371228.0', 'lat_0': '0.0', 'lon_0': '0.0', 'proj': 'merc', 'units': 'm'}
+  Number of columns: 425
+  Number of rows: 425
+  Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
+
+* Create a global 1x1 degree lat-lon grid with area extent and resolution defined in degrees
+
+ .. doctest::
+
+  >>> area_def = create_area_def('my_area',
+  ...                            {'proj': 'eqc', 'lon_0': 0, 'units': 'm'},
+  ...                            area_extent=[-180, -90, 180, 90],
+  ...                            resolution=1,
+  ...                            units='degrees',
+  ...                            description='Global 1x1 degree lat-lon grid')
+  >>> print(area_def)
+  Area ID: my_area
+  Description: Global 1x1 degree lat-lon grid
+  Projection: {'lon_0': '0.0', 'proj': 'eqc'}
+  Number of columns: 360
+  Number of rows: 180
+  Area extent: (-20037508.3428, -10018754.1714, 20037508.3428, 10018754.1714)
 
 If only one of **area_extent** or **shape** can be computed from the
 information provided by the user, a


### PR DESCRIPTION
After introducing a couple of students/interns to pyresample I found that it would be useful to have an example explaining how to get the area definition for a given regular lat-lon grid.

I also separated the are definition examples into separate code blocks to improve the readability.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
