### PR TITLE
Exclude NaNs from Bucket Average

### DIFF
--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -234,7 +234,8 @@ class BucketResampler(object):
         LOG.info("Get average value for each location")
 
         sums = self.get_sum(data, mask_all_nan=mask_all_nan)
-        counts = self.get_count()
+        counts = self.get_sum(np.logical_not(np.isnan(data)).astype(int),
+                              mask_all_nan=False)
 
         average = sums / counts
         mask = (counts == 0) | np.isnan(sums)

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -237,9 +237,8 @@ class BucketResampler(object):
         counts = self.get_sum(np.logical_not(np.isnan(data)).astype(int),
                               mask_all_nan=False)
 
-        average = sums / counts
-        mask = (counts == 0) | np.isnan(sums)
-        average = da.where(mask, fill_value, average)
+        average = sums / da.where(counts == 0, np.nan, counts)
+        average = da.where(np.isnan(average), fill_value, average)
 
         return average
 

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -166,10 +166,10 @@ class Test(unittest.TestCase):
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_average(data, mask_all_nan=True)
         self.assertTrue(np.all(np.isnan(result)))
-        # By default all-NaN bins have a value of 0.0
+        # By default all-NaN bins have a value of NaN
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_average(data)
-        self.assertEqual(np.nanmax(result), 0.0)
+        self.assertTrue(np.all(np.isnan(result)))
 
     def test_resample_bucket_fractions(self):
         """Test fraction calculations for categorical data."""

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -24,8 +24,11 @@ class Test(unittest.TestCase):
                            'proj': 'stere'}, 2560, 2048,
                           (-3780000.0, -7644000.0, 3900000.0, -1500000.0))
 
-    lons = da.from_array(np.array([[25., 25.], [25., 25.]]))
-    lats = da.from_array(np.array([[60., 60.00001], [60.2, 60.3]]))
+    chunks = 2
+    lons = da.from_array(np.array([[25., 25.], [25., 25.]]),
+                         chunks=chunks)
+    lats = da.from_array(np.array([[60., 60.00001], [60.2, 60.3]]),
+                         chunks=chunks)
 
     def setUp(self):
         self.resampler = bucket.BucketResampler(self.adef, self.lons, self.lats)
@@ -92,7 +95,8 @@ class Test(unittest.TestCase):
 
     def test_get_sum(self):
         """Test drop-in-a-bucket sum."""
-        data = da.from_array(np.array([[2., 2.], [2., 2.]]))
+        data = da.from_array(np.array([[2., 2.], [2., 2.]]),
+                             chunks=self.chunks)
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_sum(data)
 
@@ -118,7 +122,8 @@ class Test(unittest.TestCase):
         self.assertEqual(result.shape, self.adef.shape)
 
         # Test masking all-NaN bins
-        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]))
+        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+                             chunks=self.chunks)
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_sum(data, mask_all_nan=True)
         self.assertTrue(np.all(np.isnan(result)))
@@ -139,7 +144,8 @@ class Test(unittest.TestCase):
 
     def test_get_average(self):
         """Test averaging bucket resampling."""
-        data = da.from_array(np.array([[2., 4.], [2., 2.]]))
+        data = da.from_array(np.array([[2., 4.], [3., np.nan]]),
+                             chunks=self.chunks)
         # Without pre-calculated indices
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_average(data)
@@ -155,7 +161,8 @@ class Test(unittest.TestCase):
         self.assertFalse(np.any(np.isnan(result)))
 
         # Test masking all-NaN bins
-        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]))
+        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+                             chunks=self.chunks)
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_average(data, mask_all_nan=True)
         self.assertTrue(np.all(np.isnan(result)))
@@ -166,7 +173,8 @@ class Test(unittest.TestCase):
 
     def test_resample_bucket_fractions(self):
         """Test fraction calculations for categorical data."""
-        data = da.from_array(np.array([[2, 4], [2, 2]]))
+        data = da.from_array(np.array([[2, 4], [2, 2]]),
+                             chunks=self.chunks)
         categories = [1, 2, 3, 4]
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             result = self.resampler.get_fractions(data, categories=categories)


### PR DESCRIPTION
Currently the bucket average counts NaNs in the data as valid observations. For example values [1, 2, 3, np.nan] are averaged to (1+2+3) / 4 = 1.5 instead of (1+2+3) / 3 = 2. Here is a snippet to reproduce:

```python
import pyresample.bucket
from pyresample import create_area_def
import numpy as np
import dask.array as da

area_def = create_area_def('my_area',
                           {'proj': 'eqc', 'lon_0': 0},
                           center=(0, 0),
                           width=2, height=2,
                           resolution=10,
                           units='degrees')

lons = da.from_array([[0, 0], [0, 0]], chunks=1)
lats = da.from_array([[0, 0], [0, 0]], chunks=1)
data = da.from_array([[1, 2], [3, np.nan]], chunks=1)

resampler = pyresample.bucket.BucketResampler(target_area=area_def,
                                              source_lons=lons,
                                              source_lats=lats)
avg = resampler.get_average(data=data, mask_all_nan=True, fill_value=np.nan).compute()
print(avg)
```

This PR attempts to exclude NaNs from the bucket average.


<!-- Please make the PR against the `master` branch. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
