### PR TITLE
Fix proj4 radius parameters for spherical cases

### DIFF
--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -354,6 +354,14 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(a, 6378137.)
         np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
 
+    def test_proj4_radius_parameters_spherical(self):
+        from pyresample import utils
+        a, b = utils._proj4.proj4_radius_parameters(
+            '+proj=stere +a=6378273 +b=6378273',
+        )
+        np.testing.assert_almost_equal(a, 6378137.)
+        np.testing.assert_almost_equal(b, 6378137.)
+
     def test_convert_proj_floats(self):
         from collections import OrderedDict
         import pyresample.utils as utils

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -359,8 +359,8 @@ class TestMisc(unittest.TestCase):
         a, b = utils._proj4.proj4_radius_parameters(
             '+proj=stere +a=6378273 +b=6378273',
         )
-        np.testing.assert_almost_equal(a, 6378137.)
-        np.testing.assert_almost_equal(b, 6378137.)
+        np.testing.assert_almost_equal(a, 6378273.)
+        np.testing.assert_almost_equal(b, 6378273.)
 
     def test_convert_proj_floats(self):
         from collections import OrderedDict

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -357,7 +357,7 @@ class TestMisc(unittest.TestCase):
     def test_proj4_radius_parameters_spherical(self):
         from pyresample import utils
         a, b = utils._proj4.proj4_radius_parameters(
-            '+proj=stere +a=6378273 +b=6378273',
+            '+proj=stere +R=6378273',
         )
         np.testing.assert_almost_equal(a, 6378273.)
         np.testing.assert_almost_equal(b, 6378273.)

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -330,6 +330,7 @@ class TestMisc(unittest.TestCase):
                            1000, 1000, (-1000, -1000, 1000, 1000))
 
     def test_proj4_radius_parameters_provided(self):
+        """Test proj4_radius_parameters with a/b."""
         from pyresample import utils
         a, b = utils._proj4.proj4_radius_parameters(
             '+proj=stere +a=6378273 +b=6356889.44891',
@@ -338,6 +339,7 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(b, 6356889.44891)
 
     def test_proj4_radius_parameters_ellps(self):
+        """Test proj4_radius_parameters with ellps."""
         from pyresample import utils
         a, b = utils._proj4.proj4_radius_parameters(
             '+proj=stere +ellps=WGS84',
@@ -346,6 +348,7 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
 
     def test_proj4_radius_parameters_default(self):
+        """Test proj4_radius_parameters with default parameters."""
         from pyresample import utils
         a, b = utils._proj4.proj4_radius_parameters(
             '+proj=lcc',
@@ -355,6 +358,7 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
 
     def test_proj4_radius_parameters_spherical(self):
+        """Test proj4_radius_parameters in case of a spherical earth."""
         from pyresample import utils
         a, b = utils._proj4.proj4_radius_parameters(
             '+proj=stere +R=6378273',

--- a/pyresample/utils/_proj4.py
+++ b/pyresample/utils/_proj4.py
@@ -113,6 +113,9 @@ def proj4_radius_parameters(proj4_dict):
             new_info['b'] = float(new_info['a']) * (1 - float(new_info['f']))
         elif 'b' in new_info and 'f' in new_info:
             new_info['a'] = float(new_info['b']) / (1 - float(new_info['f']))
+        elif 'R' in new_info:
+            new_info['a'] = new_info['R']
+            new_info['b'] = new_info['R']
         else:
             geod = Geod(**{'ellps': 'WGS84'})
             new_info['a'] = geod.a


### PR DESCRIPTION
Providing a=b in the proj definition gets converted to R. We add support for this parameter.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

