### PR TITLE
Fix get_geostationary_angle_extent assuming a/b definitions

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1904,8 +1904,10 @@ class AreaDefinition(BaseDefinition):
 def get_geostationary_angle_extent(geos_area):
     """Get the max earth (vs space) viewing angles in x and y."""
     # get some projection parameters
-    req = geos_area.proj_dict['a'] / 1000.0
-    rp = geos_area.proj_dict['b'] / 1000.0
+    from pyresample.utils import proj4_radius_parameters
+    a, b = proj4_radius_parameters(geos_area.proj_dict)
+    req = a / 1000.0
+    rp = b / 1000.0
     h = geos_area.proj_dict['h'] / 1000.0 + req
 
     # compute some constants

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -36,7 +36,8 @@ from pyproj import Geod, transform
 from pyresample import CHUNK_SIZE
 from pyresample._spatial_mp import Cartesian, Cartesian_MP, Proj, Proj_MP
 from pyresample.boundary import AreaDefBoundary, Boundary, SimpleBoundary
-from pyresample.utils import proj4_str_to_dict, proj4_dict_to_str, convert_proj_floats
+from pyresample.utils import (proj4_str_to_dict, proj4_dict_to_str,
+                              convert_proj_floats, proj4_radius_parameters)
 from pyresample.area_config import create_area_def
 
 try:
@@ -1904,7 +1905,6 @@ class AreaDefinition(BaseDefinition):
 def get_geostationary_angle_extent(geos_area):
     """Get the max earth (vs space) viewing angles in x and y."""
     # get some projection parameters
-    from pyresample.utils import proj4_radius_parameters
     a, b = proj4_radius_parameters(geos_area.proj_dict)
     req = a / 1000.0
     rp = b / 1000.0

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1870,6 +1870,13 @@ class TestCrop(unittest.TestCase):
         np.testing.assert_allclose(expected,
                                    geometry.get_geostationary_angle_extent(geos_area))
 
+        geos_area.proj_dict = {'ellps': 'GRS80',
+                               'h': 35785831.00}
+        expected = (0.15185277703584374, 0.15133971368991794)
+
+        np.testing.assert_allclose(expected,
+                                   geometry.get_geostationary_angle_extent(geos_area))
+
         geos_area.proj_dict = {'a': 1000.0,
                                'b': 1000.0,
                                'h': np.sqrt(2) * 1000.0 - 1000.0}


### PR DESCRIPTION
Fixes an issue some users have been running in to recently with newer version of PROJ. Pyproj/PROJ are interpreting `+a` and `+b` being defined as being the same thing as `+ellps=` when they match an ellipsoid. This was causing issues in `get_geostationary_angle_extent` where it was using the `proj_dict` and assuming `a` and `b` existed.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->

Side note: I wanted to try to use the `crs.ellipsoid.semi_major_metre` and `crs.ellipsoid.semi_minor_metre` but, at least on my machine, PROJ only provides the minor/polar radius if it is part of the ellipsoid definition (often the flattening is defined along with `a`). I made this pyproj issue to ask if there is a good way to get this information from pyproj instead of computing it ourselves in pyresample: https://github.com/pyproj4/pyproj/issues/457