### PR TITLE
Fix proj_str returning invalid PROJ strings when towgs84 was included

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1347,7 +1347,17 @@ class AreaDefinition(BaseDefinition):
     @property
     def proj_str(self):
         """Return PROJ projection string."""
-        return proj4_dict_to_str(self.proj_dict, sort=True)
+        proj_dict = self.proj_dict.copy()
+        if 'towgs84' in proj_dict and isinstance(proj_dict['towgs84'], list):
+            # pyproj 2+ creates a list in the dictionary
+            # but the string should be comma-separated
+            if all(x == 0 for x in proj_dict['towgs84']):
+                # all 0s in towgs84 are technically equal to not having them
+                # specified, but PROJ considers them different
+                proj_dict.pop('towgs84')
+            else:
+                proj_dict['towgs84'] = ','.join(str(x) for x in proj_dict['towgs84'])
+        return proj4_dict_to_str(proj_dict, sort=True)
 
     def __str__(self):
         """Return string representation of the AreaDefinition."""

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1133,6 +1133,37 @@ class Test(unittest.TestCase):
                 area_extent=[-40000., -40000., 40000., 40000.])
             self.assertEqual(area.proj_str, expected_proj)
 
+        # CRS with towgs84 in it
+        # we remove towgs84 if they are all 0s
+        projection = {'proj': 'laea', 'lat_0': 52, 'lon_0': 10, 'x_0': 4321000, 'y_0': 3210000,
+                      'ellps': 'GRS80', 'towgs84': '0,0,0,0,0,0,0', 'units': 'm', 'no_defs': True}
+        area = geometry.AreaDefinition(
+            area_id='test_towgs84',
+            description='',
+            proj_id='',
+            projection=projection,
+            width=123, height=123,
+            area_extent=[-40000., -40000., 40000., 40000.])
+        self.assertEqual(area.proj_str,
+                         '+ellps=GRS80 +lat_0=52 +lon_0=10 +no_defs +proj=laea '
+                         # '+towgs84=0.0,0.0,0.0,0.0,0.0,0.0,0.0 '
+                         '+type=crs +units=m '
+                         '+x_0=4321000 +y_0=3210000')
+        projection = {'proj': 'laea', 'lat_0': 52, 'lon_0': 10, 'x_0': 4321000, 'y_0': 3210000,
+                      'ellps': 'GRS80', 'towgs84': '0,5,0,0,0,0,0', 'units': 'm', 'no_defs': True}
+        area = geometry.AreaDefinition(
+            area_id='test_towgs84',
+            description='',
+            proj_id='',
+            projection=projection,
+            width=123, height=123,
+            area_extent=[-40000., -40000., 40000., 40000.])
+        self.assertEqual(area.proj_str,
+                         '+ellps=GRS80 +lat_0=52 +lon_0=10 +no_defs +proj=laea '
+                         '+towgs84=0.0,5.0,0.0,0.0,0.0,0.0,0.0 '
+                         '+type=crs +units=m '
+                         '+x_0=4321000 +y_0=3210000')
+
     def test_striding(self):
         """Test striding AreaDefinitions."""
         from pyresample import utils

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1133,36 +1133,37 @@ class Test(unittest.TestCase):
                 area_extent=[-40000., -40000., 40000., 40000.])
             self.assertEqual(area.proj_str, expected_proj)
 
-        # CRS with towgs84 in it
-        # we remove towgs84 if they are all 0s
-        projection = {'proj': 'laea', 'lat_0': 52, 'lon_0': 10, 'x_0': 4321000, 'y_0': 3210000,
-                      'ellps': 'GRS80', 'towgs84': '0,0,0,0,0,0,0', 'units': 'm', 'no_defs': True}
-        area = geometry.AreaDefinition(
-            area_id='test_towgs84',
-            description='',
-            proj_id='',
-            projection=projection,
-            width=123, height=123,
-            area_extent=[-40000., -40000., 40000., 40000.])
-        self.assertEqual(area.proj_str,
-                         '+ellps=GRS80 +lat_0=52 +lon_0=10 +no_defs +proj=laea '
-                         # '+towgs84=0.0,0.0,0.0,0.0,0.0,0.0,0.0 '
-                         '+type=crs +units=m '
-                         '+x_0=4321000 +y_0=3210000')
-        projection = {'proj': 'laea', 'lat_0': 52, 'lon_0': 10, 'x_0': 4321000, 'y_0': 3210000,
-                      'ellps': 'GRS80', 'towgs84': '0,5,0,0,0,0,0', 'units': 'm', 'no_defs': True}
-        area = geometry.AreaDefinition(
-            area_id='test_towgs84',
-            description='',
-            proj_id='',
-            projection=projection,
-            width=123, height=123,
-            area_extent=[-40000., -40000., 40000., 40000.])
-        self.assertEqual(area.proj_str,
-                         '+ellps=GRS80 +lat_0=52 +lon_0=10 +no_defs +proj=laea '
-                         '+towgs84=0.0,5.0,0.0,0.0,0.0,0.0,0.0 '
-                         '+type=crs +units=m '
-                         '+x_0=4321000 +y_0=3210000')
+        if utils.is_pyproj2():
+            # CRS with towgs84 in it
+            # we remove towgs84 if they are all 0s
+            projection = {'proj': 'laea', 'lat_0': 52, 'lon_0': 10, 'x_0': 4321000, 'y_0': 3210000,
+                          'ellps': 'GRS80', 'towgs84': '0,0,0,0,0,0,0', 'units': 'm', 'no_defs': True}
+            area = geometry.AreaDefinition(
+                area_id='test_towgs84',
+                description='',
+                proj_id='',
+                projection=projection,
+                width=123, height=123,
+                area_extent=[-40000., -40000., 40000., 40000.])
+            self.assertEqual(area.proj_str,
+                             '+ellps=GRS80 +lat_0=52 +lon_0=10 +no_defs +proj=laea '
+                             # '+towgs84=0.0,0.0,0.0,0.0,0.0,0.0,0.0 '
+                             '+type=crs +units=m '
+                             '+x_0=4321000 +y_0=3210000')
+            projection = {'proj': 'laea', 'lat_0': 52, 'lon_0': 10, 'x_0': 4321000, 'y_0': 3210000,
+                          'ellps': 'GRS80', 'towgs84': '0,5,0,0,0,0,0', 'units': 'm', 'no_defs': True}
+            area = geometry.AreaDefinition(
+                area_id='test_towgs84',
+                description='',
+                proj_id='',
+                projection=projection,
+                width=123, height=123,
+                area_extent=[-40000., -40000., 40000., 40000.])
+            self.assertEqual(area.proj_str,
+                             '+ellps=GRS80 +lat_0=52 +lon_0=10 +no_defs +proj=laea '
+                             '+towgs84=0.0,5.0,0.0,0.0,0.0,0.0,0.0 '
+                             '+type=crs +units=m '
+                             '+x_0=4321000 +y_0=3210000')
 
     def test_striding(self):
         """Test striding AreaDefinitions."""


### PR DESCRIPTION
This helps fix some of the issues with satpy generic_image reader tests failing. Basically rasterio/pyproj will sometimes add a `+towgs84=0,0,0,0,0,0,0` to the PROJ/CRS definition. This is generally fine as it doesn't change the specification (the projection is the same projection) but it is a problem in that doing a CRS equality will now fail. Right now we do AreaDefinition equality based on `proj_str` and one will have the `towgs84` and the other might not. In the long run we should use `CRS(proj_str) == `CRS(other.proj_str)` but this also fails with this `towgs84` difference. I made an issue on pyproj but as expected this is handled by the lower-level PROJ library so it would take longer and be more involved of a change to make it work (see https://github.com/pyproj4/pyproj/issues/459).

This PR is a workaround to remove `towgs84` if it exists with all 0s when generating `proj_str` for an AreaDefinition.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
