### PR TITLE
Make the uniform shape computation more effective for dask arrays

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -704,13 +704,26 @@ class SwathDefinition(CoordinateDefinition):
                 return arr.where(arr.notnull(), drop=True)
             except AttributeError:
                 return arr[np.isfinite(arr)]
-
-        leftlons = notnull(self.lons[:, 0])
-        rightlons = notnull(self.lons[:, -1])
-        middlelons = notnull(self.lons[:, int(self.lons.shape[1] / 2)])
-        leftlats = notnull(self.lats[:, 0])
-        rightlats = notnull(self.lats[:, -1])
-        middlelats = notnull(self.lats[:, int(self.lats.shape[1] / 2)])
+        leftlons = self.lons[:, 0]
+        rightlons = self.lons[:, -1]
+        middlelons = self.lons[:, int(self.lons.shape[1] / 2)]
+        leftlats = self.lats[:, 0]
+        rightlats = self.lats[:, -1]
+        middlelats = self.lats[:, int(self.lats.shape[1] / 2)]
+        try:
+            import dask.array as da
+        except ImportError:
+            pass
+        else:
+            leftlons, rightlons, middlelons, leftlats, rightlats, middlelats = da.compute(leftlons, rightlons,
+                                                                                          middlelons, leftlats,
+                                                                                          rightlats, middlelats)
+        leftlons = notnull(leftlons)
+        rightlons = notnull(rightlons)
+        middlelons = notnull(middlelons)
+        leftlats = notnull(leftlats)
+        rightlats = notnull(rightlats)
+        middlelats = notnull(middlelats)
 
         az1, az2, width1 = g.inv(leftlons[0], leftlats[0], rightlons[0], rightlats[0])
         az1, az2, width2 = g.inv(leftlons[-1], leftlats[-1], rightlons[-1], rightlats[-1])


### PR DESCRIPTION
This PR makes the computation of the uniform shape of areas (case of data-dependent areas) more efficient.
This is still not very efficient in the grand scale of things, but improves over the last iteration.

Next step is maybe to use a pre-computed bounding box when available (see satpy issue here: https://github.com/pytroll/satpy/issues/933)

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

