### PR TITLE
Fix inconsistent radius

### DIFF
--- a/pyresample/spherical.py
+++ b/pyresample/spherical.py
@@ -359,7 +359,7 @@ class SphPolygon(object):
 
     def inverse(self):
         """Return an inverse of the polygon."""
-        return SphPolygon(np.flipud(self.vertices))
+        return SphPolygon(np.flipud(self.vertices), radius=self.radius)
 
     def aedges(self):
         """Iterator over the edges, in arcs of Coordinates."""
@@ -483,8 +483,7 @@ class SphPolygon(object):
                 break
             if inter == nodes[0]:
                 break
-
-        return SphPolygon(np.array([(node.lon, node.lat) for node in nodes]))
+        return SphPolygon(np.array([(node.lon, node.lat) for node in nodes]), radius=self.radius)
 
     def union(self, other):
         """Return the union of this and `other` polygon."""

--- a/pyresample/test/test_spherical.py
+++ b/pyresample/test/test_spherical.py
@@ -556,6 +556,16 @@ class TestSphericalPolygon(unittest.TestCase):
         self.assertTrue(np.allclose(poly_inter.vertices,
                                     np.deg2rad(res)))
 
+    def test_consistent_radius(self):
+        poly1 = np.array([(-50, 69), (-36, 69), (-36, 64), (-50, 64)])
+        poly2 = np.array([(-46, 68), (-40, 68), (-40, 65), (-45, 65)])
+        poly_outer = SphPolygon(np.deg2rad(poly1), radius=6371)
+        poly_inner = SphPolygon(np.deg2rad(poly2), radius=6371)
+        poly_inter = poly_outer.intersection(poly_inner)
+        self.assertAlmostEqual(poly_inter.radius, poly_inner.radius)
+        # Well, now when we are at it.
+        self.assertAlmostEqual(poly_inter.area(), poly_inner.area())
+
 
 def suite():
     """The suite for test_spherical


### PR DESCRIPTION
When spherical.SphPolygon is returning an instance of a SphPolygon (f.x in _bool_oper) it should pass the radius of it self. So area computations are consistent.
