### PR TITLE
Fix cartesian coordinate calculations when lon/lats are integers

### DIFF
--- a/pyresample/_spatial_mp.py
+++ b/pyresample/_spatial_mp.py
@@ -188,8 +188,8 @@ class Cartesian(object):
     def transform_lonlats(self, lons, lats):
 
         coords = np.zeros((lons.size, 3), dtype=lons.dtype)
-        deg2rad = lons.dtype.type(np.pi / 180)
-        if ne and deg2rad > 0:
+        if ne:
+            deg2rad = np.pi / 180
             coords[:, 0] = ne.evaluate("R*cos(lats*deg2rad)*cos(lons*deg2rad)")
             coords[:, 1] = ne.evaluate("R*cos(lats*deg2rad)*sin(lons*deg2rad)")
             coords[:, 2] = ne.evaluate("R*sin(lats*deg2rad)")

--- a/pyresample/_spatial_mp.py
+++ b/pyresample/_spatial_mp.py
@@ -189,15 +189,16 @@ class Cartesian(object):
 
         coords = np.zeros((lons.size, 3), dtype=lons.dtype)
         deg2rad = lons.dtype.type(np.pi / 180)
-        if ne:
+        if ne and deg2rad > 0:
             coords[:, 0] = ne.evaluate("R*cos(lats*deg2rad)*cos(lons*deg2rad)")
             coords[:, 1] = ne.evaluate("R*cos(lats*deg2rad)*sin(lons*deg2rad)")
             coords[:, 2] = ne.evaluate("R*sin(lats*deg2rad)")
         else:
-            coords[:, 0] = R * np.cos(lats * deg2rad) * np.cos(lons * deg2rad)
-            coords[:, 1] = R * np.cos(lats * deg2rad) * np.sin(lons * deg2rad)
-            coords[:, 2] = R * np.sin(lats * deg2rad)
+            coords[:, 0] = R * np.cos(np.deg2rad(lats)) * np.cos(np.deg2rad(lons))
+            coords[:, 1] = R * np.cos(np.deg2rad(lats)) * np.sin(np.deg2rad(lons))
+            coords[:, 2] = R * np.sin(np.deg2rad(lats))
         return coords
+
 
 Cartesian_MP = Cartesian
 

--- a/pyresample/_spatial_mp.py
+++ b/pyresample/_spatial_mp.py
@@ -186,10 +186,10 @@ class Cartesian(object):
         pass
 
     def transform_lonlats(self, lons, lats):
-
+        """Transform longitudes and latitues to cartesian coordinates."""
         coords = np.zeros((lons.size, 3), dtype=lons.dtype)
         if ne:
-            deg2rad = np.pi / 180
+            deg2rad = np.pi / 180  # noqa: F841
             coords[:, 0] = ne.evaluate("R*cos(lats*deg2rad)*cos(lons*deg2rad)")
             coords[:, 1] = ne.evaluate("R*cos(lats*deg2rad)*sin(lons*deg2rad)")
             coords[:, 2] = ne.evaluate("R*sin(lats*deg2rad)")

--- a/pyresample/_spatial_mp.py
+++ b/pyresample/_spatial_mp.py
@@ -187,6 +187,8 @@ class Cartesian(object):
 
     def transform_lonlats(self, lons, lats):
         """Transform longitudes and latitues to cartesian coordinates."""
+        if np.issubdtype(lons.dtype, np.integer):
+            lons = lons.astype(np.float)
         coords = np.zeros((lons.size, 3), dtype=lons.dtype)
         if ne:
             deg2rad = np.pi / 180  # noqa: F841

--- a/pyresample/test/test_spatial_mp.py
+++ b/pyresample/test/test_spatial_mp.py
@@ -16,18 +16,18 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Testing the _spatial_mp module"""
+"""Testing the _spatial_mp module."""
 
 
-try:
-    from unittest import mock
-except ImportError:
-    # separate mock package py<3.3
-    import mock
-import pyproj
+# try:
+#     from unittest import mock
+# except ImportError:
+#     # separate mock package py<3.3
+#     import mock
 import unittest
+import numpy as np
 
-from pyresample._spatial_mp import BaseProj
+from pyresample._spatial_mp import Cartesian
 
 
 # class SpatialMPTest(unittest.TestCase):
@@ -48,13 +48,29 @@ from pyresample._spatial_mp import BaseProj
 #             proj_init.assert_called_with(projparams='EPSG:6932', preserve_units=mock.ANY)
 #             proj_init.reset_mock()
 
+class SpatialMPTest(unittest.TestCase):
+    """Test of spatial_mp."""
+
+    def test_cartesian(self):
+        """Test the transform_lonlats of class Cartesian."""
+        exp_coords = np.array([[6370997., 0, 0],
+                               [6178887.9339746, 1089504.6535337, 1106312.0189715],
+                               [5233097.4664751, 2440233.4244888, 2692499.6776952]])
+        lon = np.array([0, 10, 25])
+        lat = np.array([0, 10, 25])
+        my_cartesian = Cartesian()
+        coords_int = my_cartesian.transform_lonlats(lon, lat)
+        coords_float = my_cartesian.transform_lonlats(lon.astype(np.float64), lat.astype(np.float64))
+
+        np.testing.assert_almost_equal(coords_float, exp_coords, decimal=3)
+        np.testing.assert_almost_equal(coords_int, coords_float, decimal=0)
+
 
 def suite():
-    """The test suite.
-    """
-    # loader = unittest.TestLoader()
+    """Test suite for _spatial_mp."""
+    loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
-    # mysuite.addTest(loader.loadTestsFromTestCase(SpatialMPTest))
+    mysuite.addTest(loader.loadTestsFromTestCase(SpatialMPTest))
     return mysuite
 
 

--- a/pyresample/test/test_spatial_mp.py
+++ b/pyresample/test/test_spatial_mp.py
@@ -61,9 +61,11 @@ class SpatialMPTest(unittest.TestCase):
         my_cartesian = Cartesian()
         coords_int = my_cartesian.transform_lonlats(lon, lat)
         coords_float = my_cartesian.transform_lonlats(lon.astype(np.float64), lat.astype(np.float64))
-
+        coords_float32 = my_cartesian.transform_lonlats(lon.astype(np.float32), lat.astype(np.float32))
         np.testing.assert_almost_equal(coords_float, exp_coords, decimal=3)
         np.testing.assert_almost_equal(coords_int, coords_float, decimal=0)
+        self.assertIs(type(coords_float32[0, 0]), np.float32)
+        self.assertIs(type(coords_float[0, 0]), np.float64)
 
 
 def suite():

--- a/pyresample/test/test_spatial_mp.py
+++ b/pyresample/test/test_spatial_mp.py
@@ -27,7 +27,7 @@
 import unittest
 import numpy as np
 
-from pyresample._spatial_mp import Cartesian
+import pyresample._spatial_mp as sp
 
 
 # class SpatialMPTest(unittest.TestCase):
@@ -51,21 +51,42 @@ from pyresample._spatial_mp import Cartesian
 class SpatialMPTest(unittest.TestCase):
     """Test of spatial_mp."""
 
+    def setUp(self):
+        """Set up some variables."""
+        self.exp_coords = np.array([[6370997., 0, 0],
+                                    [6178887.9339746, 1089504.6535337, 1106312.0189715],
+                                    [5233097.4664751, 2440233.4244888, 2692499.6776952]])
+        self.lon = np.array([0, 10, 25])
+        self.lat = np.array([0, 10, 25])
+        self.lon32 = self.lon.astype(np.float32)
+        self.lat32 = self.lon.astype(np.float32)
+        self.lon64 = self.lon.astype(np.float64)
+        self.lat64 = self.lon.astype(np.float64)
+
     def test_cartesian(self):
         """Test the transform_lonlats of class Cartesian."""
-        exp_coords = np.array([[6370997., 0, 0],
-                               [6178887.9339746, 1089504.6535337, 1106312.0189715],
-                               [5233097.4664751, 2440233.4244888, 2692499.6776952]])
-        lon = np.array([0, 10, 25])
-        lat = np.array([0, 10, 25])
-        my_cartesian = Cartesian()
-        coords_int = my_cartesian.transform_lonlats(lon, lat)
-        coords_float = my_cartesian.transform_lonlats(lon.astype(np.float64), lat.astype(np.float64))
-        coords_float32 = my_cartesian.transform_lonlats(lon.astype(np.float32), lat.astype(np.float32))
-        np.testing.assert_almost_equal(coords_float, exp_coords, decimal=3)
+        my_cartesian = sp.Cartesian()
+        coords_int = my_cartesian.transform_lonlats(self.lon, self.lat)
+        coords_float = my_cartesian.transform_lonlats(self.lon64, self.lat64)
+        coords_float32 = my_cartesian.transform_lonlats(self.lon32, self.lat32)
+        np.testing.assert_almost_equal(coords_float, self.exp_coords, decimal=3)
         np.testing.assert_almost_equal(coords_int, coords_float, decimal=0)
         self.assertIs(type(coords_float32[0, 0]), np.float32)
         self.assertIs(type(coords_float[0, 0]), np.float64)
+        self.assertTrue(np.issubdtype(coords_int.dtype, np.floating))
+
+    def test_cartesian_without_ne(self):
+        """Test the transform_lonlats of class Cartesian without numexpr."""
+        sp.ne = False
+        my_cartesian = sp.Cartesian()
+        coords_int = my_cartesian.transform_lonlats(self.lon, self.lat)
+        coords_float = my_cartesian.transform_lonlats(self.lon64, self.lat64)
+        coords_float32 = my_cartesian.transform_lonlats(self.lon32, self.lat32)
+        np.testing.assert_almost_equal(coords_float, self.exp_coords, decimal=3)
+        np.testing.assert_almost_equal(coords_int, coords_float, decimal=0)
+        self.assertIs(type(coords_float32[0, 0]), np.float32)
+        self.assertIs(type(coords_float[0, 0]), np.float64)
+        self.assertTrue(np.issubdtype(coords_int.dtype, np.floating))
 
 
 def suite():


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

The main problem was the casting of pi/180 to the same type as the latitude-longitude data. In the case of integer data it is cast to zero.  Current solution uses np.deg2lats in case the pi/180 was cast to zero. 

 - [x] Closes #233 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
