### PR TITLE
Update load_area docstring to mention that multiple files are allowed

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -54,8 +54,8 @@ def load_area(area_file_name, *regions):
 
     Parameters
     ----------
-    area_file_name : str
-        Path to area definition file
+    area_file_name : str or list
+        One or more paths to area definition files
     regions : str argument list
         Regions to parse. If no regions are specified all
         regions in the file are returned
@@ -83,8 +83,8 @@ def parse_area_file(area_file_name, *regions):
 
     Parameters
     -----------
-    area_file_name : str
-        Path to area definition file
+    area_file_name : str or list
+        One or more paths to area definition files
     regions : str argument list
         Regions to parse. If no regions are specified all
         regions in the file are returned


### PR DESCRIPTION
Pyresample's area loading methods have accepted multiple files for a while, but it wasn't documented in the higher level functions.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
