### PR TITLE
Respect dtype when get_lonlats provide dask array

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1822,8 +1822,7 @@ class AreaDefinition(BaseDefinition):
             from dask.array import map_blocks
             res = map_blocks(invproj, target_x, target_y,
                              chunks=(target_x.chunks[0], target_x.chunks[1], 2),
-                             new_axis=[2], proj_dict=proj_def,
-                             dtype=dtype)
+                             new_axis=[2], proj_dict=proj_def).astype(dtype)
             return res[:, :, 0], res[:, :, 1]
 
         if nprocs > 1:

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1822,7 +1822,8 @@ class AreaDefinition(BaseDefinition):
             from dask.array import map_blocks
             res = map_blocks(invproj, target_x, target_y,
                              chunks=(target_x.chunks[0], target_x.chunks[1], 2),
-                             new_axis=[2], proj_dict=proj_def)
+                             new_axis=[2], proj_dict=proj_def,
+                             dtype=dtype)
             return res[:, :, 0], res[:, :, 1]
 
         if nprocs > 1:

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1191,6 +1191,37 @@ class Test(unittest.TestCase):
                                                               area_extent[3]))
         self.assertEqual(reduced_area.shape, (928, 928))
 
+    def test_get_lonlats_options(self):
+        """Test that lotlat options are respected
+        """
+        area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
+                                           {'a': '6378144.0',
+                                            'b': '6356759.0',
+                                            'lat_0': '50.00',
+                                            'lat_ts': '50.00',
+                                            'lon_0': '8.00',
+                                            'proj': 'stere'},
+                                           800,
+                                           800,
+                                           [-1370912.72,
+                                               -909968.64000000001,
+                                               1029087.28,
+                                               1490031.3600000001])
+        (lon, _) = area_def.get_lonlats(dtype="f4")
+        self.assertEqual(lon.dtype, np.dtype("f4"))
+
+        (lon, _) = area_def.get_lonlats(dtype="f8")
+        self.assertEqual(lon.dtype, np.dtype("f8"))
+
+        from dask.array.core import Array as dask_array
+        (lon, _) = area_def.get_lonlats(dtype="f4", chunks=4)
+        self.assertEqual(lon.dtype, np.dtype("f4"))
+        self.assertIsInstance(lon, dask_array)
+
+        (lon, _) = area_def.get_lonlats(dtype="f8", chunks=4)
+        self.assertEqual(lon.dtype, np.dtype("f8"))
+        self.assertIsInstance(lon, dask_array)
+
 
 def assert_np_dict_allclose(dict1, dict2):
 


### PR DESCRIPTION
Respect dtype when get_lonlats provide dask array.

 - [x] Closes #242  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
