### PR TITLE
Fix bucket assignment

### DIFF
--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -126,8 +126,8 @@ class BucketResampler(object):
         # Calculate array indices. Orient so that 0-meridian is pointing down.
         adef = self.target_area
         x_res, y_res = adef.resolution
-        x_idxs = ((proj_x - adef.area_extent[0]) / x_res).astype(np.int)
-        y_idxs = ((adef.area_extent[3] - proj_y) / y_res).astype(np.int)
+        x_idxs = da.floor((proj_x - adef.area_extent[0]) / x_res).astype(np.int)
+        y_idxs = da.floor((adef.area_extent[3] - proj_y) / y_res).astype(np.int)
 
         # Get valid index locations
         mask = ((x_idxs >= 0) & (x_idxs < adef.width) &

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -90,8 +90,8 @@ class BucketResampler(object):
         self._get_indices()
         self.counts = None
 
-    def _get_proj_coordinates(self, lons, lats, x_res, y_res):
-        """Calculate projection coordinates and round to resolution unit.
+    def _get_proj_coordinates(self, lons, lats):
+        """Calculate projection coordinates.
 
         Parameters
         ----------
@@ -99,15 +99,8 @@ class BucketResampler(object):
             Longitude coordinates
         lats : Numpy or Dask array
             Latitude coordinates
-        x_res : float
-            Resolution of the output in X direction
-        y_res : float
-            Resolution of the output in Y direction
         """
         proj_x, proj_y = self.prj(lons, lats)
-        proj_x = round_to_resolution(proj_x, x_res)
-        proj_y = round_to_resolution(proj_y, y_res)
-
         return np.stack((proj_x, proj_y))
 
     def _get_indices(self):
@@ -121,30 +114,20 @@ class BucketResampler(object):
             Y indices of the target grid where the data are put
         """
         LOG.info("Determine bucket resampling indices")
-        adef = self.target_area
 
+        # Transform source lons/lats to target projection coordinates x/y
         lons = self.source_lons.ravel()
         lats = self.source_lats.ravel()
-
-        # Create output grid coordinates in projection units
-        x_res = (adef.area_extent[2] - adef.area_extent[0]) / adef.width
-        y_res = (adef.area_extent[3] - adef.area_extent[1]) / adef.height
-        x_vect = da.arange(adef.area_extent[0] + x_res / 2.,
-                           adef.area_extent[2] - x_res / 2., x_res)
-        # Orient so that 0-meridian is pointing down
-        y_vect = da.arange(adef.area_extent[3] - y_res / 2.,
-                           adef.area_extent[1] + y_res / 2.,
-                           -y_res)
-
-        result = da.map_blocks(self._get_proj_coordinates, lons,
-                               lats, x_res, y_res,
+        result = da.map_blocks(self._get_proj_coordinates, lons, lats,
                                new_axis=0, chunks=(2,) + lons.chunks)
         proj_x = result[0, :]
         proj_y = result[1, :]
 
-        # Calculate array indices
-        x_idxs = ((proj_x - np.min(x_vect)) / x_res).astype(np.int)
-        y_idxs = ((np.max(y_vect) - proj_y) / y_res).astype(np.int)
+        # Calculate array indices. Orient so that 0-meridian is pointing down.
+        adef = self.target_area
+        x_res, y_res = adef.resolution
+        x_idxs = ((proj_x - adef.area_extent[0]) / x_res).astype(np.int)
+        y_idxs = ((adef.area_extent[3] - proj_y) / y_res).astype(np.int)
 
         # Get valid index locations
         mask = ((x_idxs >= 0) & (x_idxs < adef.width) &

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -91,21 +91,21 @@ class Test(unittest.TestCase):
         adef = create_area_def(
             area_id='test',
             projection={'proj': 'latlong'},
-            width=4, height=4,
+            width=2, height=2,
             center=(0, 0),
             resolution=10)
         lons = da.from_array(
-            np.array([-20.0, -19.9, -10.1, -10.0, -9.9, -0.1, 0, 0.1, 9.9, 10.0, 19.9, 20.0]),
+            np.array([-10.0, -9.9, -0.1, 0, 0.1, 9.9, 10.0, -10.1, 0]),
             chunks=2)
         lats = da.from_array(
-            np.array([-20.0, -19.9, -10.1, -10.0, -9.9, -0.1, 0, 0.1, 9.9, 10.0, 19.9, 20.0]),
+            np.array([-10.0, -9.9, -0.1, 0, 0.1, 9.9, 10.0, 0, 10.1]),
             chunks=2)
         resampler = bucket.BucketResampler(source_lats=lats,
                                            source_lons=lons,
                                            target_area=adef)
         resampler._get_indices()
-        np.testing.assert_equal(resampler.x_idxs, np.array([-1, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, -1]))
-        np.testing.assert_equal(resampler.y_idxs, np.array([-1, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0, -1]))
+        np.testing.assert_equal(resampler.x_idxs, np.array([-1, 0, 0, 1, 1, 1, -1, -1, -1]))
+        np.testing.assert_equal(resampler.y_idxs, np.array([-1, 1, 1, 1, 0, 0, -1, -1, -1]))
 
     def test_get_sum(self):
         """Test drop-in-a-bucket sum."""


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->
The bucket assignment in the bucket resampler seems to be off by half a pixel. This PR provides a fix. 

Example:

```python
from pyresample import create_area_def
from pyresample.bucket import BucketResampler
import dask.array as da
import numpy as np

area = create_area_def(
    area_id='test',
    projection={'proj': 'latlong'},
    center=(0., 0.),
    width=4,
    height=4,
    resolution=10.0
)

lons = da.from_array(np.array([-15, -5, 5, 15]), chunks=2)
lats = da.from_array(np.array([-15, -5, 5, 15]), chunks=2)
data = da.from_array(np.array([1, 2, 3, 4]), chunks=2)
resampler = BucketResampler(source_lats=lats,
                            source_lons=lons,
                            target_area=area)
count = resampler.get_count()
```
Output with current master:
```
[[0 0 0 1]
 [0 2 0 0]
 [0 0 0 0]
 [1 0 0 0]]
```

Output with this PR:
```
[[0 0 0 1]
 [0 0 1 0]
 [0 1 0 0]
 [1 0 0 0]]
```

Changes:
- Compute bucket indices with respect to the edge of the corner
  pixel, not the center.
- Don't round projection coordinates. This is already done by
  casting to integer.
- That also means that we don't need the projection coordinates
  anymore. We can use the area extent instead.



 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
