### PR TITLE
Make omerc bouding box use sphere as ellps

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -748,10 +748,11 @@ class SwathDefinition(CoordinateDefinition):
     def compute_bb_proj_params(self, proj_dict):
         """Compute BB projection parameters."""
         projection = proj_dict['proj']
-        ellipsoid = proj_dict.get('ellps', 'WGS84')
         if projection == 'omerc':
+            ellipsoid = proj_dict.get('ellps', 'sphere')
             return self._compute_omerc_parameters(ellipsoid)
         else:
+            ellipsoid = proj_dict.get('ellps', 'WGS84')
             new_proj = self._compute_generic_parameters(projection, ellipsoid)
             new_proj.update(proj_dict)
             return new_proj
@@ -884,7 +885,6 @@ class DynamicAreaDefinition(object):
 
     def _get_proj_dict(self):
         projection = self._projection
-
         if CRS is not None:
             try:
                 crs = CRS(projection)
@@ -1963,7 +1963,6 @@ class AreaDefinition(BaseDefinition):
                                             factor=shape_divisible_by)
 
         return (x_slice, y_slice)
-
 
     def crop_around(self, other_area):
         """Crop this area around `other_area`."""

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1,4 +1,27 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# pyresample, Resampling of remote sensing image data in python
+#
+# Copyright (C) 2010-2016
+#
+# Authors:
+#    Esben S. Nielsen
+#    Thomas Lavergne
+#    Adam Dybbroe
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Test the geometry objects."""
 from __future__ import with_statement
 
 import random
@@ -28,6 +51,7 @@ class Test(unittest.TestCase):
     """Unit testing the geometry and geo_filter modules."""
 
     def test_lonlat_precomp(self):
+        """Test the lonlat precomputation."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -49,6 +73,7 @@ class Test(unittest.TestCase):
                                msg='lat retrieval from precomputated grid failed')
 
     def test_cartesian(self):
+        """Test getting the cartesian coordinates."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -68,7 +93,7 @@ class Test(unittest.TestCase):
                         msg='Calculation of cartesian coordinates failed')
 
     def test_cartopy_crs(self):
-        """Test conversion from area definition to cartopy crs"""
+        """Test conversion from area definition to cartopy crs."""
         from pyresample import utils
 
         europe = geometry.AreaDefinition(area_id='areaD',
@@ -143,6 +168,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(latlong_crs.bounds, [-np.pi, np.pi, -np.pi/2, np.pi/2]))
 
     def test_create_areas_def(self):
+        """Test exporting area defs."""
         from pyresample import utils
         import yaml
 
@@ -197,6 +223,7 @@ class Test(unittest.TestCase):
         self.assertDictEqual(res, expected)
 
     def test_parse_area_file(self):
+        """Test parsing the are file."""
         from pyresample import utils
 
         expected = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)',
@@ -248,6 +275,7 @@ class Test(unittest.TestCase):
             self.assertEqual(area_def, expected)
 
     def test_base_type(self):
+        """Test the base type."""
         lons1 = np.arange(-135., +135, 50.)
         lats = np.ones_like(lons1) * 70.
 
@@ -285,6 +313,7 @@ class Test(unittest.TestCase):
                          (lons2_ints.dtype, lons.dtype,))
 
     def test_area_hash(self):
+        """Test the area hash."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -334,6 +363,7 @@ class Test(unittest.TestCase):
         self.assertIsInstance(hash(area_def), int)
 
     def test_get_array_hashable(self):
+        """Test making the array hashable."""
         arr = np.array([1.2, 1.3, 1.4, 1.5])
         if sys.byteorder == 'little':
             # arr.view(np.uint8)
@@ -369,6 +399,7 @@ class Test(unittest.TestCase):
                              xrarr.attrs['hash'])
 
     def test_swath_hash(self):
+        """Test swath hash."""
         lons = np.array([1.2, 1.3, 1.4, 1.5])
         lats = np.array([65.9, 65.86, 65.82, 65.78])
         swath_def = geometry.SwathDefinition(lons, lats)
@@ -416,6 +447,7 @@ class Test(unittest.TestCase):
         self.assertIsInstance(hash(swath_def), int)
 
     def test_area_equal(self):
+        """Test areas equality."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -446,6 +478,7 @@ class Test(unittest.TestCase):
             area_def != area_def2, 'area_defs are not equal as expected')
 
     def test_not_area_equal(self):
+        """Test areas inequality."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -478,6 +511,7 @@ class Test(unittest.TestCase):
             area_def == msg_area, 'area_defs are not expected to be equal')
 
     def test_swath_equal_area(self):
+        """Test equality swath area."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -515,6 +549,7 @@ class Test(unittest.TestCase):
             area_def != swath_def, "swath_def and area_def should be equal")
 
     def test_swath_not_equal_area(self):
+        """Test inequality swath area."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -554,6 +589,7 @@ class Test(unittest.TestCase):
             area_def == swath_def, "swath_def and area_def should be different")
 
     def test_grid_filter_valid(self):
+        """Test valid grid filtering."""
         lons = np.array([-170, -30, 30, 170])
         lats = np.array([20, -40, 50, -80])
         swath_def = geometry.SwathDefinition(lons, lats)
@@ -578,6 +614,7 @@ class Test(unittest.TestCase):
             np.array_equal(valid_index, expected), 'Failed to find grid filter')
 
     def test_grid_filter(self):
+        """Test filtering a grid."""
         lons = np.array([-170, -30, 30, 170])
         lats = np.array([20, -40, 50, -80])
         swath_def = geometry.SwathDefinition(lons, lats)
@@ -608,6 +645,7 @@ class Test(unittest.TestCase):
                         'Failed finding grid filtering lon lats')
 
     def test_grid_filter2D(self):
+        """Test filtering a 2D grid."""
         lons = np.array([[-170, -30, 30, 170],
                          [-170, -30, 30, 170]])
         lats = np.array([[20, -40, 50, -80],
@@ -643,6 +681,7 @@ class Test(unittest.TestCase):
                         'Failed finding 2D grid filtering lon lats')
 
     def test_boundary(self):
+        """Test getting the boundary."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -669,6 +708,7 @@ class Test(unittest.TestCase):
                         'Failed to find projection y coords')
 
     def test_area_extent_ll(self):
+        """Test getting the lower left area extent."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -687,6 +727,7 @@ class Test(unittest.TestCase):
                                'Failed to get lon and lats of area extent')
 
     def test_latlong_area(self):
+        """Test getting lons and lats from an area."""
         area_def = geometry.AreaDefinition('', '', '',
                                            {'proj': 'latlong'},
                                            360, 180,
@@ -696,6 +737,7 @@ class Test(unittest.TestCase):
         self.assertEqual(lats[0, 0], 89.5)
 
     def test_lonlat2colrow(self):
+        """Test lonlat2colrow."""
         from pyresample import utils
         area_id = 'meteosat_0deg'
         area_name = 'Meteosat 0 degree Service'
@@ -732,7 +774,7 @@ class Test(unittest.TestCase):
         self.assertTrue(area.lonlat2colrow(lon, lat) == (1567, 2375))
 
     def test_colrow2lonlat(self):
-
+        """Test colrow2lonlat."""
         from pyresample import utils
         area_id = 'meteosat_0deg'
         area_name = 'Meteosat 0 degree Service'
@@ -873,7 +915,7 @@ class Test(unittest.TestCase):
                                               7500.])))
 
     def test_get_xy_from_lonlat(self):
-        """Test the function get_xy_from_lonlat"""
+        """Test the function get_xy_from_lonlat."""
         from pyresample import utils
         area_id = 'test'
         area_name = 'Test area with 2x2 pixels'
@@ -1191,8 +1233,7 @@ class Test(unittest.TestCase):
         self.assertEqual(reduced_area.shape, (928, 928))
 
     def test_get_lonlats_options(self):
-        """Test that lotlat options are respected
-        """
+        """Test that lotlat options are respected."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
@@ -1247,7 +1288,6 @@ class Test(unittest.TestCase):
 
 
 class TestMakeSliceDivisible(unittest.TestCase):
-
     """Test the _make_slice_divisible."""
 
     def test_make_slice_divisible(self):
@@ -1277,7 +1317,7 @@ class TestMakeSliceDivisible(unittest.TestCase):
 
 
 def assert_np_dict_allclose(dict1, dict2):
-
+    """Check allclose on dicts."""
     assert set(dict1.keys()) == set(dict2.keys())
     for key, val in dict1.items():
         try:
@@ -1290,6 +1330,7 @@ class TestSwathDefinition(unittest.TestCase):
     """Test the SwathDefinition."""
 
     def test_swath(self):
+        """Test swath."""
         lons1 = np.fromfunction(lambda y, x: 3 + (10.0 / 100) * x, (5000, 100))
         lats1 = np.fromfunction(
             lambda y, x: 75 - (50.0 / 5000) * y, (5000, 100))
@@ -1313,6 +1354,7 @@ class TestSwathDefinition(unittest.TestCase):
         self.assertTupleEqual(new_swath_def.lats.shape, (3000, 20))
 
     def test_concat_1d(self):
+        """Test concatenating in 1d."""
         lons1 = np.array([1, 2, 3])
         lats1 = np.array([1, 2, 3])
         lons2 = np.array([4, 5, 6])
@@ -1326,6 +1368,7 @@ class TestSwathDefinition(unittest.TestCase):
                         'Failed to concatenate 1D swaths')
 
     def test_concat_2d(self):
+        """Test concatenating in 2d."""
         lons1 = np.array([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
         lats1 = np.array([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
         lons2 = np.array([[4, 5, 6], [6, 7, 8]])
@@ -1340,6 +1383,7 @@ class TestSwathDefinition(unittest.TestCase):
                         'Failed to concatenate 2D swaths')
 
     def test_append_1d(self):
+        """Test appending in 1d."""
         lons1 = np.array([1, 2, 3])
         lats1 = np.array([1, 2, 3])
         lons2 = np.array([4, 5, 6])
@@ -1353,6 +1397,7 @@ class TestSwathDefinition(unittest.TestCase):
                         'Failed to append 1D swaths')
 
     def test_append_2d(self):
+        """Test appending in 2d."""
         lons1 = np.array([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
         lats1 = np.array([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
         lons2 = np.array([[4, 5, 6], [6, 7, 8]])
@@ -1618,7 +1663,6 @@ class TestSwathDefinition(unittest.TestCase):
 
 
 class TestStackedAreaDefinition(unittest.TestCase):
-
     """Test the StackedAreaDefition."""
 
     def test_append(self):
@@ -1859,7 +1903,7 @@ class TestStackedAreaDefinition(unittest.TestCase):
                                                        resolution))
         # Tests non-poles using degrees and mercator.
         area_def = cad(area_id, '+a=6371228.0 +units=m +lon_0=0 +proj=merc +lat_0=0',
-                        center=(0, 0), radius=45, resolution=(1, 0.9999291722135637), units='degrees')
+                       center=(0, 0), radius=45, resolution=(1, 0.9999291722135637), units='degrees')
         self.assertTrue(isinstance(area_def, AreaDefinition))
         self.assertTrue(np.allclose(area_def.area_extent, (-5003950.7698, -5615432.0761, 5003950.7698, 5615432.0761)))
         self.assertEqual(area_def.shape, (101, 90))
@@ -1888,7 +1932,6 @@ class TestStackedAreaDefinition(unittest.TestCase):
 
 
 class TestDynamicAreaDefinition(unittest.TestCase):
-
     """Test the DynamicAreaDefinition class."""
 
     def test_freeze(self):
@@ -1939,8 +1982,9 @@ class TestDynamicAreaDefinition(unittest.TestCase):
         sdef = geometry.SwathDefinition(xr.DataArray(lons), xr.DataArray(lats))
         result = area.freeze(sdef, resolution=1000)
         np.testing.assert_allclose(result.area_extent,
-                                   [-336277.698941, 5513145.392745,
-                                    192456.651909, 7749649.63914])
+                                   [-335439.956533, 5502125.451125,
+                                    191991.313351, 7737532.343683])
+
         self.assertEqual(result.width, 4)
         self.assertEqual(result.height, 18)
         # Test for properties and shape usage in freeze.
@@ -1974,12 +2018,10 @@ class TestDynamicAreaDefinition(unittest.TestCase):
 
 
 class TestCrop(unittest.TestCase):
-
     """Test the area helpers."""
 
     def test_get_geostationary_bbox(self):
         """Get the geostationary bbox."""
-
         geos_area = MagicMock()
         lon_0 = 0
         geos_area.proj_dict = {'a': 6378169.00,
@@ -2089,8 +2131,7 @@ class TestCrop(unittest.TestCase):
 
 
 def suite():
-    """The test suite.
-    """
+    """Test suite."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(Test))


### PR DESCRIPTION
Omerc bounding box computation was using WGS84 as an ellps, which causes problems, see
https://github.com/pytroll/satpy/issues/1002

 - [x] Closes https://github.com/pytroll/satpy/issues/1002
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
