### PR TITLE
Fix SwathDefinition geocentric_resolution when resolution is None

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,6 @@ extensions = [
 doctest_test_doctest_blocks = ''
 
 # Napoleon Settings (to support numpy style docs)
-napoleon_numpy_docstring = False
 napoleon_numpy_docstring = True
 napoleon_use_admonition_for_examples = True
 napoleon_use_admonition_for_notes = True

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -501,7 +501,8 @@ class CoordinateDefinition(BaseDefinition):
             data points found no valid data points.
 
         """
-        if hasattr(self.lons, 'attrs') and 'resolution' in self.lons.attrs:
+        if hasattr(self.lons, 'attrs') and \
+                self.lons.attrs.get('resolution') is not None:
             return self.lons.attrs['resolution'] * nadir_factor
         if self.ndim == 1:
             raise RuntimeError("Can't confidently determine geocentric "
@@ -826,44 +827,43 @@ class DynamicAreaDefinition(object):
 
     The purpose of this class is to be able to adapt the area extent and shape
     of the area to a given set of longitudes and latitudes, such that e.g.
-    polar satellite granules can be resampled optimaly to a give projection.
+    polar satellite granules can be resampled optimally to a given projection.
+
+    Parameters
+    ----------
+    area_id:
+        The name of the area.
+    description:
+        The description of the area.
+    projection:
+        The dictionary or string of projection parameters. Doesn't have to
+        be complete. If not complete, ``proj_info`` must be provided to
+        ``freeze`` to "fill in" any missing parameters.
+    width:
+        x dimension in number of pixels, aka number of grid columns
+    height:
+        y dimension in number of pixels, aka number of grid rows
+    shape:
+        Corresponding array shape as (height, width)
+    area_extent:
+        The area extent of the area.
+    pixel_size_x:
+        Pixel width in projection units
+    pixel_size_y:
+        Pixel height in projection units
+    resolution:
+        Resolution of the resulting area as (pixel_size_x, pixel_size_y) or a scalar if pixel_size_x == pixel_size_y.
+    optimize_projection:
+        Whether the projection parameters have to be optimized.
+    rotation:
+        Rotation in degrees (negative is cw)
+
     """
 
     def __init__(self, area_id=None, description=None, projection=None,
                  width=None, height=None, area_extent=None,
                  resolution=None, optimize_projection=False, rotation=None):
-        """Initialize the DynamicAreaDefinition.
-
-        Attributes
-        ----------
-        area_id:
-          The name of the area.
-        description:
-          The description of the area.
-        projection:
-          The dictionary or string of projection parameters. Doesn't have to
-          be complete. If not complete, ``proj_info`` must be provided to
-          ``freeze`` to "fill in" any missing parameters.
-        width:
-            x dimension in number of pixels, aka number of grid columns
-        height:
-            y dimension in number of pixels, aka number of grid rows
-        shape:
-            Corresponding array shape as (height, width)
-        area_extent:
-          The area extent of the area.
-        pixel_size_x:
-            Pixel width in projection units
-        pixel_size_y:
-            Pixel height in projection units
-        resolution:
-          Resolution of the resulting area as (pixel_size_x, pixel_size_y) or a scalar if pixel_size_x == pixel_size_y.
-        optimize_projection:
-          Whether the projection parameters have to be optimized.
-        rotation:
-          Rotation in degrees (negative is cw)
-
-        """
+        """Initialize the DynamicAreaDefinition."""
         self.area_id = area_id
         self.description = description
         self.width = width

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1610,12 +1610,25 @@ class TestSwathDefinition(unittest.TestCase):
         # so this seems good
         np.testing.assert_allclose(111301.237078, geo_res)
 
+        # with a resolution attribute that is None
+        xlons.attrs['resolution'] = None
+        xlats.attrs['resolution'] = None
+        sd = SwathDefinition(xlons, xlats)
+        geo_res = sd.geocentric_resolution()
+        np.testing.assert_allclose(111301.237078, geo_res)
+
+        # with a resolution attribute that is a number
+        xlons.attrs['resolution'] = 111301.237078 / 2
+        xlats.attrs['resolution'] = 111301.237078 / 2
+        sd = SwathDefinition(xlons, xlats)
+        geo_res = sd.geocentric_resolution()
+        np.testing.assert_allclose(111301.237078, geo_res)
+
         # 1D
         xlats = xr.DataArray(da.from_array(lats.ravel(), chunks=2), dims=['y'])
         xlons = xr.DataArray(da.from_array(lons.ravel(), chunks=2), dims=['y'])
         sd = SwathDefinition(xlons, xlats)
         self.assertRaises(RuntimeError, sd.geocentric_resolution)
-
 
 class TestStackedAreaDefinition(unittest.TestCase):
 


### PR DESCRIPTION
First noticed by @zxdawn, some Satpy datasets have a `resolution` attribute but it is `None`. This PR fixes this so it doesn't raise an exception.

Also includes docstring fixes for DynamicAreaDefinition. We don't have sphinx document the `__init__` method separately so the docstring for DynamicAreaDefinition was missing in the readthedocs pages.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
