### PR TITLE
Fix for python3 rpm-build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
-requires=numpy pykdtree python2-numexpr pyproj python-configobj
+requires=numpy pykdtree python3-numexpr pyproj python3-configobj
 release=1
 doc_files = docs/Makefile docs/source/*.rst
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
-requires=numpy pykdtree python3-numexpr pyproj python3-configobj
+requires=python3-numpy pykdtree python3-numexpr pyproj python3-configobj
 release=1
 doc_files = docs/Makefile docs/source/*.rst
 


### PR DESCRIPTION
Fix so that it is possible to make an rpm package for Python 3 (only)

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
