### PR TITLE
Add Azure configuration to build wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,6 @@ jobs:
         cd $(Pipeline.Workspace)
         python -m pip install --upgrade pip
         pip install twine
-        twine upload -u "__token__" --skip-existing pyresampleDeployLinux/* vispyDeployMacOS/* vispyDeployWindows/*
+        twine upload -u "__token__" --skip-existing pyresampleDeployLinux/* pyresampleDeployMacOS/* pyresampleDeployWindows/*
       env:
         TWINE_PASSWORD: $(pypiToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,8 @@ variables:
   CIBW_TEST_COMMAND: "python -c \"import pyresample; from pyresample.ewa import *\""
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython pip setuptools"
+  # needed until pykdtree auto-detects this
+  CIBW_ENVIRONMENT_MACOS: "USE_OMP=0"
 jobs:
 - job: linux
   pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
         path: $(System.DefaultWorkingDirectory)/wheelhouse
         artifact: pyresampleDeployLinux
 - job: macos
-  pool: {vmImage: 'macOS-10.13'}
+  pool: {vmImage: 'macOS-10.14'}
   steps:
     - task: UsePythonVersion@0
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,80 @@
+trigger:
+  branches:
+    include:
+      - '*'
+  tags:
+    include:
+      - v*
+variables:
+  CIBW_BUILDING: "true"
+  CIBW_SKIP: "cp27-* cp34-* cp35-*"
+  CIBW_TEST_REQUIRES: "pytest pytest-sugar"
+  CIBW_TEST_COMMAND: "python -c \"import pyresample; from pyresample.ewa import *\""
+  CIBW_BUILD_VERBOSITY: "2"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython pip setuptools"
+jobs:
+- job: linux
+  pool: {vmImage: 'Ubuntu-16.04'}
+  steps:
+    - task: UsePythonVersion@0
+    - bash: |
+        git submodule update --init --recursive
+        python -m pip install --upgrade pip
+        pip install cibuildwheel twine numpy Cython
+        python setup.py sdist -d wheelhouse
+        cibuildwheel --output-dir wheelhouse .
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/wheelhouse
+        artifact: pyresampleDeployLinux
+- job: macos
+  pool: {vmImage: 'macOS-10.13'}
+  steps:
+    - task: UsePythonVersion@0
+    - bash: |
+        git submodule update --init --recursive
+        python -m pip install --upgrade pip
+        pip install cibuildwheel
+        cibuildwheel --output-dir wheelhouse .
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/wheelhouse
+        artifact: pyresampleDeployMacOS
+- job: windows
+  pool: {vmImage: 'vs2017-win2016'}
+  steps:
+    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x86}}
+    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
+    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
+    - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+    - bash: |
+        git submodule update --init --recursive
+        python -m pip install --upgrade pip
+        pip install cibuildwheel
+        cibuildwheel --output-dir wheelhouse .
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(System.DefaultWorkingDirectory)/wheelhouse
+        artifact: pyresampleDeployWindows
+- job: deployPyPI
+  pool: {vmImage: 'Ubuntu-16.04'}
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+  dependsOn:
+    - linux
+    - macos
+    - windows
+  steps:
+    - task: UsePythonVersion@0
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        patterns: |
+          pyresampleDeployLinux/*
+          pyresampleDeployMacOS/*.whl
+          pyresampleDeployWindows/*.whl
+    - bash: |
+        cd $(Pipeline.Workspace)
+        python -m pip install --upgrade pip
+        pip install twine
+        twine upload -u "__token__" --skip-existing pyresampleDeployLinux/* vispyDeployMacOS/* vispyDeployWindows/*
+      env:
+        TWINE_PASSWORD: $(pypiToken)


### PR DESCRIPTION
This PR adds an Azure configuration file to build python binary wheels on Microsoft Azure and upload them to PyPI for releases.

 - [x] Closes #244  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Add token to Azure build so upload will work
 - [ ] Decide whether pytest tests should be performed
 - [ ] Remove appveyor and travis with azure only?
