### PR TITLE
Undo libtiff version restriction on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
 install:
 - git clone --depth 1 git://github.com/astropy/ci-helpers.git
 - source ci-helpers/travis/setup_conda.sh
-- conda install -y "libtiff<4.1"
 - pip install --no-deps -e .
 script:
 - pytest --cov=pyresample pyresample/test


### PR DESCRIPTION
There was a problem between libtiff and libwebp on conda-forge. I added a restriction in the past, but this should now be fixed on conda-forge's side.