### PR TITLE
Fix parameter order in AreaDefinition docstring

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1030,10 +1030,10 @@ class AreaDefinition(BaseDefinition):
         x dimension in number of pixels, aka number of grid columns
     height : int
         y dimension in number of pixels, aka number of grid rows
-    rotation: float
-        rotation in degrees (negative is cw)
     area_extent : list
         Area extent as a list (lower_left_x, lower_left_y, upper_right_x, upper_right_y)
+    rotation: float, optional
+        rotation in degrees (negative is clockwise)
     nprocs : int, optional
         Number of processor cores to be used for certain calculations
 


### PR DESCRIPTION
In the AreaDefinition docstring, fix the order in which the parameters
are document to match the order in which they are defined, and clarify
that the rotation is optional.

Fixes #261.

<!-- Please make the PR against the `master` branch. -->

 - [x] Closes #261<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
