### PR TITLE
Switch to storing CRS WKT in AreaDefinitions instead of the CRS object

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -236,5 +236,6 @@ intersphinx_mapping = {
     'pyresample': ('https://pyresample.readthedocs.io/en/stable', None),
     'trollsift': ('https://trollsift.readthedocs.io/en/stable', None),
     'trollimage': ('https://trollimage.readthedocs.io/en/stable', None),
+    'pyproj': ('https://pyproj4.github.io/pyproj/dev/', None),
     'proj4': ('https://proj.org', None),
 }

--- a/docs/source/geometry_utils.rst
+++ b/docs/source/geometry_utils.rst
@@ -112,7 +112,7 @@ can be obtained as follows:
 .. doctest::
 
  >>> area_def = create_area_def('my_area',
- ...                            {'proj': 'latlong', 'datum': 'WGS84', 'lon_0': 0},
+ ...                            {'proj': 'latlong', 'datum': 'WGS84'},
  ...                            area_extent=[-180, -90, 180, 90],
  ...                            resolution=1,
  ...                            units='degrees',
@@ -120,7 +120,7 @@ can be obtained as follows:
  >>> print(area_def)
  Area ID: my_area
  Description: Global 1x1 degree lat-lon grid
- Projection: {'datum': 'WGS84', 'no_defs': 'None', 'lon_0': '0', 'proj': 'latlong', 'type': 'crs'}
+ Projection: {'datum': 'WGS84', 'no_defs': 'None', 'proj': 'latlong', 'type': 'crs'}
  Number of columns: 360
  Number of rows: 180
  Area extent: (-180.0, -90.0, 180.0, 90.0)

--- a/docs/source/geometry_utils.rst
+++ b/docs/source/geometry_utils.rst
@@ -22,7 +22,9 @@ necessary to get an area's ``shape`` and ``area_extent``.
 The ``create_area_def`` function has the following required arguments:
 
 * **area_id**: ID of area
-* **projection**: Projection parameters as a proj4_dict or proj4_string
+* **projection**: Projection parameters as a dictionary or string of PROJ
+  parameters or anything that can be accepted by the
+  :class:`pyproj CRS <pyproj.crs.CRS>` object.
 
 and optional arguments:
 
@@ -61,6 +63,13 @@ and optional arguments:
  Number of rows: 425
  Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
 
+.. note::
+
+    Projection (CRS) information is stored internally using the pyproj
+    library's :class:`CRS <pyproj.crs.CRS>` object. To meet certain standards
+    for representing CRS information, pyproj may rename parameters or use
+    completely different parameters from what you provide.
+
 The ``create_area_def`` function accepts some parameters in multiple forms
 to make it as easy as possible. For example, the **resolution** and **radius**
 keyword arguments can be specified with one value if ``dx == dy``:
@@ -92,7 +101,7 @@ the mercator projection with radius and resolution defined in degrees.
  >>> print(area_def)
  Area ID: ease_sh
  Description: Antarctic EASE grid
- Projection: {'a': '6371228.0', 'lat_0': '0', 'lon_0': '0', 'proj': 'merc', 'type': 'crs', 'units': 'm'}
+ Projection: {'R': '6371228', 'k': '1', 'lon_0': '0', 'no_defs': 'None', 'proj': 'merc', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
  Number of columns: 425
  Number of rows: 425
  Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
@@ -103,7 +112,7 @@ can be obtained as follows:
 .. doctest::
 
  >>> area_def = create_area_def('my_area',
- ...                            {'proj': 'latlong', 'lon_0': 0},
+ ...                            {'proj': 'latlong', 'datum': 'WGS84', 'lon_0': 0},
  ...                            area_extent=[-180, -90, 180, 90],
  ...                            resolution=1,
  ...                            units='degrees',
@@ -111,7 +120,7 @@ can be obtained as follows:
  >>> print(area_def)
  Area ID: my_area
  Description: Global 1x1 degree lat-lon grid
- Projection: {'lon_0': '0', 'proj': 'latlong', 'type': 'crs'}
+ Projection: {'datum': 'WGS84', 'no_defs': 'None', 'lon_0': '0', 'proj': 'latlong', 'type': 'crs'}
  Number of columns: 360
  Number of rows: 180
  Area extent: (-180.0, -90.0, 180.0, 90.0)

--- a/docs/source/geometry_utils.rst
+++ b/docs/source/geometry_utils.rst
@@ -23,8 +23,7 @@ The ``create_area_def`` function has the following required arguments:
 
 * **area_id**: ID of area
 * **projection**: Projection parameters as a dictionary or string of PROJ
-  parameters or anything that can be accepted by the
-  :class:`pyproj CRS <pyproj.crs.CRS>` object.
+  parameters.
 
 and optional arguments:
 
@@ -112,7 +111,7 @@ can be obtained as follows:
 .. doctest::
 
  >>> area_def = create_area_def('my_area',
- ...                            {'proj': 'latlong', 'datum': 'WGS84'},
+ ...                            {'proj': 'longlat', 'datum': 'WGS84'},
  ...                            area_extent=[-180, -90, 180, 90],
  ...                            resolution=1,
  ...                            units='degrees',
@@ -120,7 +119,7 @@ can be obtained as follows:
  >>> print(area_def)
  Area ID: my_area
  Description: Global 1x1 degree lat-lon grid
- Projection: {'datum': 'WGS84', 'no_defs': 'None', 'proj': 'latlong', 'type': 'crs'}
+ Projection: {'datum': 'WGS84', 'no_defs': 'None', 'proj': 'longlat', 'type': 'crs'}
  Number of columns: 360
  Number of rows: 180
  Area extent: (-180.0, -90.0, 180.0, 90.0)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1128,7 +1128,6 @@ class AreaDefinition(BaseDefinition):
         self.pixel_size_y = (area_extent[3] - area_extent[1]) / float(height)
         self.area_extent = tuple(area_extent)
         if CRS is not None:
-            # self.crs = CRS(projection)
             self.crs_wkt = CRS(projection).to_wkt()
             self._proj_dict = None
             self.crs = self._crs  # see _crs property for details

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1177,7 +1177,7 @@ class AreaDefinition(BaseDefinition):
 
         For backwards compatibility, we only create the `.crs` property if
         pyproj 2.0+ is installed. Users can then check
-        `hasattr(area_def 'crs')` to easily support older versions of
+        `hasattr(area_def, 'crs')` to easily support older versions of
         pyresample and pyproj.
 
         """

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1024,8 +1024,9 @@ class AreaDefinition(BaseDefinition):
         Human-readable description of the area
     proj_id : str
         ID of projection
-    projection: dict or str
-        Dictionary or string of Proj.4 parameters
+    projection: dict or str or pyproj.crs.CRS
+        Dictionary of PROJ parameters or string of PROJ or WKT parameters.
+        Can also be a :class:`pyproj.crs.CRS` object.
     width : int
         x dimension in number of pixels, aka number of grid columns
     height : int
@@ -1077,8 +1078,22 @@ class AreaDefinition(BaseDefinition):
     pixel_offset_y : float
         y offset between projection center and upper left corner of upper
         left pixel in units of pixels..
+    crs : pyproj.crs.CRS
+        Coordinate reference system object similar to the PROJ parameters in
+        `proj_dict` and `proj_str`. This is the preferred attribute to use
+        when working with the `pyproj` library. Note, however, that this
+        object is not thread-safe and should not be passed between threads.
+    crs_wkt : str
+        WellKnownText version of the CRS object. This is the preferred
+        way of describing CRS information as a string.
+    proj_dict : dict
+        Projection defined as a dictionary of PROJ parameters. This is no
+        longer the preferred way of describing CRS information. Switch to
+        the `crs` or `crs_wkt` properties for the most flexibility.
     proj_str : str
-        Projection defined as Proj.4 string
+        Projection defined as a PROJ string. This is no
+        longer the preferred way of describing CRS information. Switch to
+        the `crs` or `crs_wkt` properties for the most flexibility.
     cartesian_coords : object
         Grid cartesian coordinates
     projection_x_coords : object
@@ -1113,8 +1128,10 @@ class AreaDefinition(BaseDefinition):
         self.pixel_size_y = (area_extent[3] - area_extent[1]) / float(height)
         self.area_extent = tuple(area_extent)
         if CRS is not None:
-            self.crs = CRS(projection)
+            # self.crs = CRS(projection)
+            self.crs_wkt = CRS(projection).to_wkt()
             self._proj_dict = None
+            self.crs = self._crs  # see _crs property for details
         else:
             if isinstance(projection, str):
                 proj_dict = proj4_str_to_dict(projection)
@@ -1148,6 +1165,23 @@ class AreaDefinition(BaseDefinition):
         self._projection_y_coords = None
 
         self.dtype = dtype
+
+    @property
+    def _crs(self):
+        """Helper property for the `crs` property.
+
+        The :class:`pyproj.crs.CRS` object is not thread-safe. To avoid
+        accidentally passing it between threads, we only create it when it
+        is requested (the `self.crs` property). The alternative of storing it
+        as a normal instance attribute could cause issues between threads.
+
+        For backwards compatibility, we only create the `.crs` property if
+        pyproj 2.0+ is installed. Users can then check
+        `hasattr(area_def 'crs')` to easily support older versions of
+        pyresample and pyproj.
+
+        """
+        return CRS.from_wkt(self.crs_wkt)
 
     @property
     def proj_dict(self):
@@ -1877,7 +1911,7 @@ class AreaDefinition(BaseDefinition):
             raise ValueError("Can't specify 'nprocs' and 'chunks' at the same time")
 
         # Proj.4 definition of target area projection
-        proj_def = self.crs if hasattr(self, 'crs') else self.proj_dict
+        proj_def = self.crs_wkt if hasattr(self, 'crs_wkt') else self.proj_dict
         if hasattr(target_x, 'chunks'):
             # we are using dask arrays, map blocks to th
             from dask.array import map_blocks

--- a/pyresample/test/test_files/areas.yaml
+++ b/pyresample/test/test_files/areas.yaml
@@ -210,8 +210,7 @@ test_latlong:
   description: Basic latlong grid
   projection:
     proj: longlat
-    lat_0: 27.12
-    lon_0: -81.36
+    pm: -81.36
     ellps: WGS84
   shape:
     height: 4058

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -166,7 +166,7 @@ class Test(unittest.TestCase):
                                            'areaD',
                                            {'a': '6378144.0',
                                             'b': '6356759.0',
-                                            'lat_0': '50.00',
+                                            'lat_0': '90.00',
                                             'lat_ts': '50.00',
                                             'lon_0': '8.00',
                                             'proj': 'stere'},
@@ -179,7 +179,7 @@ class Test(unittest.TestCase):
         res = yaml.safe_load(area_def.create_areas_def())
         expected = yaml.safe_load(('areaD:\n  description: Europe (3km, HRV, VTC)\n'
                                    '  projection:\n    a: 6378144.0\n    b: 6356759.0\n'
-                                   '    lat_0: 50.0\n    lat_ts: 50.0\n    lon_0: 8.0\n'
+                                   '    lat_0: 90.0\n    lat_ts: 50.0\n    lon_0: 8.0\n'
                                    '    proj: stere\n  shape:\n    height: 800\n'
                                    '    width: 800\n  area_extent:\n'
                                    '    lower_left_xy: [-1370912.72, -909968.64]\n'
@@ -194,8 +194,7 @@ class Test(unittest.TestCase):
         self.assertEqual(res['area_extent']['lower_left_xy'],
                          expected['area_extent']['lower_left_xy'])
         # pyproj versions may effect how the PROJ is formatted
-        # TODO: Add lat_ts. See https://github.com/pyproj4/pyproj/issues/592
-        for proj_key in ['a', 'lat_0', 'lon_0', 'proj']:
+        for proj_key in ['a', 'lat_0', 'lon_0', 'proj', 'lat_ts']:
             self.assertEqual(res['projection'][proj_key],
                              expected['projection'][proj_key])
 

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1128,12 +1128,11 @@ class Test(unittest.TestCase):
         from pyresample.test.utils import friendly_crs_equal
 
         # pyproj 2.0+ adds a +type=crs parameter
-        extra_params = ' +type=crs' if utils.is_pyproj2() else ''
         proj_dict = OrderedDict()
         proj_dict['proj'] = 'stere'
         proj_dict['a'] = 6378144.0
         proj_dict['b'] = 6356759.0
-        proj_dict['lat_0'] = 50.00
+        proj_dict['lat_0'] = 90.00
         proj_dict['lat_ts'] = 50.00
         proj_dict['lon_0'] = 8.00
         area = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
@@ -1141,12 +1140,13 @@ class Test(unittest.TestCase):
                                        [-1370912.72, -909968.64, 1029087.28,
                                         1490031.36])
         assert friendly_crs_equal(
-            '+a=6378144.0 +b=6356759.0 +lat_0=50.0 +lat_ts=50.0 '
-            '+lon_0=8.0 +proj=stere' + extra_params,
+            '+a=6378144.0 +b=6356759.0 +lat_0=90.0 +lat_ts=50.0 '
+            '+lon_0=8.0 +proj=stere',
             area
         )
         # try a omerc projection and no_rot parameters
         proj_dict['proj'] = 'omerc'
+        proj_dict['lat_0'] = 50.0
         proj_dict['alpha'] = proj_dict.pop('lat_ts')
         proj_dict['no_rot'] = ''
         area = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
@@ -1155,7 +1155,7 @@ class Test(unittest.TestCase):
                                         1490031.36])
         assert friendly_crs_equal(
             '+a=6378144.0 +alpha=50.0 +b=6356759.0 +lat_0=50.0 '
-            '+lon_0=8.0 +no_rot +proj=omerc' + extra_params,
+            '+lon_0=8.0 +no_rot +proj=omerc',
             area
         )
 

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1680,6 +1680,7 @@ class TestSwathDefinition(unittest.TestCase):
         sd = SwathDefinition(xlons, xlats)
         self.assertRaises(RuntimeError, sd.geocentric_resolution)
 
+
 class TestStackedAreaDefinition(unittest.TestCase):
     """Test the StackedAreaDefition."""
 

--- a/pyresample/test/test_grid.py
+++ b/pyresample/test/test_grid.py
@@ -205,6 +205,8 @@ class Test(unittest.TestCase):
         proj4_string = self.area_def.proj_str
         expected_string = '+a=6378144.0 +b=6356759.0 +lat_ts=50.0 +lon_0=8.0 +proj=stere +lat_0=50.0'
         if is_pyproj2():
-            expected_string += ' +type=crs'
+            expected_string = '+a=6378144 +k=1 +lat_0=50 +lon_0=8 ' \
+                              '+no_defs +proj=stere +rf=298.253168108487 ' \
+                              '+type=crs +units=m +x_0=0 +y_0=0'
         self.assertEqual(
             frozenset(proj4_string.split()), frozenset(expected_string.split()))

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -355,7 +355,7 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(b, 6356889.44891)
 
         # test again but force pyproj <2 behavior
-        with unittest.mock.patch.object(utils._proj4, 'CRS', None):
+        with mock.patch.object(utils._proj4, 'CRS', None):
             a, b = utils._proj4.proj4_radius_parameters(
                 '+proj=stere +a=6378273 +b=6356889.44891',
             )
@@ -372,7 +372,7 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
 
         # test again but force pyproj <2 behavior
-        with unittest.mock.patch.object(utils._proj4, 'CRS', None):
+        with mock.patch.object(utils._proj4, 'CRS', None):
             a, b = utils._proj4.proj4_radius_parameters(
                 '+proj=stere +ellps=WGS84',
             )
@@ -390,7 +390,7 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
 
         # test again but force pyproj <2 behavior
-        with unittest.mock.patch.object(utils._proj4, 'CRS', None):
+        with mock.patch.object(utils._proj4, 'CRS', None):
             a, b = utils._proj4.proj4_radius_parameters(
                 '+proj=lcc +lat_0=10 +lat_1=10',
             )
@@ -408,7 +408,7 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(b, 6378273.)
 
         # test again but force pyproj <2 behavior
-        with unittest.mock.patch.object(utils._proj4, 'CRS', None):
+        with mock.patch.object(utils._proj4, 'CRS', None):
             a, b = utils._proj4.proj4_radius_parameters(
                 '+proj=stere +R=6378273',
             )

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -173,12 +173,9 @@ Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)""".forma
 
         if is_pyproj2():
             # pyproj 2.0+ adds some extra parameters
-            # FIXME: See https://github.com/pyproj4/pyproj/issues/592
-            # projection = ("{'ellps': 'WGS84', 'no_defs': 'None', 'lat_0': '27.12', "
-            #               "'lon_0': '-81.36', 'proj': 'longlat', "
-            #               "'type': 'crs'}")
             projection = ("{'ellps': 'WGS84', 'no_defs': 'None', "
-                          "'proj': 'longlat', 'type': 'crs'}")
+                          "'pm': '-81.36', 'proj': 'longlat', "
+                          "'type': 'crs'}")
         else:
             projection = ("{'ellps': 'WGS84', 'lat_0': '27.12', "
                           "'lon_0': '-81.36', 'proj': 'longlat'}")

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -19,6 +19,7 @@
 
 import os
 import unittest
+from unittest import mock
 import io
 import pathlib
 from tempfile import NamedTemporaryFile
@@ -353,6 +354,14 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(a, 6378273)
         np.testing.assert_almost_equal(b, 6356889.44891)
 
+        # test again but force pyproj <2 behavior
+        with unittest.mock.patch.object(utils._proj4, 'CRS', None):
+            a, b = utils._proj4.proj4_radius_parameters(
+                '+proj=stere +a=6378273 +b=6356889.44891',
+            )
+            np.testing.assert_almost_equal(a, 6378273)
+            np.testing.assert_almost_equal(b, 6356889.44891)
+
     def test_proj4_radius_parameters_ellps(self):
         """Test proj4_radius_parameters with ellps."""
         from pyresample import utils
@@ -361,6 +370,14 @@ class TestMisc(unittest.TestCase):
         )
         np.testing.assert_almost_equal(a, 6378137.)
         np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
+
+        # test again but force pyproj <2 behavior
+        with unittest.mock.patch.object(utils._proj4, 'CRS', None):
+            a, b = utils._proj4.proj4_radius_parameters(
+                '+proj=stere +ellps=WGS84',
+            )
+            np.testing.assert_almost_equal(a, 6378137.)
+            np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
 
     def test_proj4_radius_parameters_default(self):
         """Test proj4_radius_parameters with default parameters."""
@@ -372,6 +389,15 @@ class TestMisc(unittest.TestCase):
         np.testing.assert_almost_equal(a, 6378137.)
         np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
 
+        # test again but force pyproj <2 behavior
+        with unittest.mock.patch.object(utils._proj4, 'CRS', None):
+            a, b = utils._proj4.proj4_radius_parameters(
+                '+proj=lcc +lat_0=10 +lat_1=10',
+            )
+            # WGS84
+            np.testing.assert_almost_equal(a, 6378137.)
+            np.testing.assert_almost_equal(b, 6356752.314245, decimal=6)
+
     def test_proj4_radius_parameters_spherical(self):
         """Test proj4_radius_parameters in case of a spherical earth."""
         from pyresample import utils
@@ -380,6 +406,14 @@ class TestMisc(unittest.TestCase):
         )
         np.testing.assert_almost_equal(a, 6378273.)
         np.testing.assert_almost_equal(b, 6378273.)
+
+        # test again but force pyproj <2 behavior
+        with unittest.mock.patch.object(utils._proj4, 'CRS', None):
+            a, b = utils._proj4.proj4_radius_parameters(
+                '+proj=stere +R=6378273',
+            )
+            np.testing.assert_almost_equal(a, 6378273.)
+            np.testing.assert_almost_equal(b, 6378273.)
 
     def test_convert_proj_floats(self):
         from collections import OrderedDict

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -173,9 +173,12 @@ Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)""".forma
 
         if is_pyproj2():
             # pyproj 2.0+ adds some extra parameters
-            projection = ("{'ellps': 'WGS84', 'lat_0': '27.12', "
-                          "'lon_0': '-81.36', 'proj': 'longlat', "
-                          "'type': 'crs'}")
+            # FIXME: See https://github.com/pyproj4/pyproj/issues/592
+            # projection = ("{'ellps': 'WGS84', 'no_defs': 'None', 'lat_0': '27.12', "
+            #               "'lon_0': '-81.36', 'proj': 'longlat', "
+            #               "'type': 'crs'}")
+            projection = ("{'ellps': 'WGS84', 'no_defs': 'None', "
+                          "'proj': 'longlat', 'type': 'crs'}")
         else:
             projection = ("{'ellps': 'WGS84', 'lat_0': '27.12', "
                           "'lon_0': '-81.36', 'proj': 'longlat'}")
@@ -366,7 +369,7 @@ class TestMisc(unittest.TestCase):
         """Test proj4_radius_parameters with default parameters."""
         from pyresample import utils
         a, b = utils._proj4.proj4_radius_parameters(
-            '+proj=lcc',
+            '+proj=lcc +lat_0=10 +lat_1=10',
         )
         # WGS84
         np.testing.assert_almost_equal(a, 6378137.)

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -234,4 +234,3 @@ def friendly_crs_equal(expected, actual, keys=None, use_obj=True, use_wkt=True):
             actual_crs = CRS(actual_crs.to_wkt())
         return expected_crs == actual_crs
     raise NotImplementedError("""TODO""")
-

--- a/pyresample/utils/_proj4.py
+++ b/pyresample/utils/_proj4.py
@@ -90,6 +90,16 @@ def proj4_radius_parameters(proj4_dict):
     Returns:
         a (float), b (float): equatorial and polar radius
     """
+    if CRS is not None:
+        import math
+        crs = CRS(proj4_dict)
+        a = crs.ellipsoid.semi_major_metre
+        b = crs.ellipsoid.semi_minor_metre
+        if not math.isnan(b):
+            return a, b
+        # older versions of pyproj didn't always have a valid minor radius
+        proj4_dict = crs.to_dict()
+
     if isinstance(proj4_dict, str):
         new_info = proj4_str_to_dict(proj4_dict)
     else:


### PR DESCRIPTION
This PR is an effort to resolve the issues discussed in:

https://github.com/pyproj4/pyproj/issues/589
https://github.com/pytroll/satpy/issues/1114

The summary of these issues is that the pyproj `CRS` object is not thread-safe. If you access one from multiple threads you can get strange corrupt strings and bytes. I've found one case in all of satpy, pyresample, and trollimage (I think) where we explicitly pass a CRS or Proj object to a dask function (map_blocks, blockwise, delayed) and that's what this PR fixes (call to `invproj` with a `CRS` object). There is an additional usage in the EWA resampling in Satpy where an AreaDefinition is passed to a delayed function. I would like to be able to confidently pass AreaDefinitions between threads so that issue is also addressed here.

The main switch is that AreaDefinition objects will now store `crs_wkt` (the WellKnownText string of a CRS object) which can be used to reconstruct the `CRS` object. Since it is a string it is perfectly thread-safe. This has the unintended consequence that if you pass a PROJ dict to an AreaDefinition and then do `area_def.proj_dict` you will get the result of `dict -> CRS -> WKT -> CRS -> dict`. Due to the simplifications that pyproj and PROJ do this can result in completely different PROJ dicts being produced which can be confusing and can require rewriting a lot of tests which I also tried to do here. Some examples of the simplications:

1. Convert a/b parameters to the equivalent `ellps`.
2. Convert a/b parameters to the equivalent a + rf parameters.
3. Drop unused parameters.

However, I'm also finding a few bugs in pyproj/PROJ which I've brought up here: https://github.com/pyproj4/pyproj/issues/592. I consider this PR a WIP until those can get resolved and the tests in pyresample fixed.

 - [x] Closes #https://github.com/pytroll/satpy/issues/1114 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
