### PR TITLE
Fix geocentric resolution favoring one area dimension over the other

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1997,7 +1997,27 @@ class AreaDefinition(BaseDefinition):
         return new_area
 
     def geocentric_resolution(self, ellps='WGS84', radius=None):
-        """Find best estimate for overall geocentric resolution."""
+        """Find best estimate for overall geocentric resolution.
+
+        This method is extremely important to the results of KDTree-based
+        resamplers like the nearest neighbor resampling. This is used to
+        determine how far the KDTree should be queried for valid pixels
+        before giving up (`radius_of_influence`). This method attempts to
+        make a best guess at what geocentric resolution (the units used by
+        the KDTree) represents the majority of an area.
+
+        To do this this method will:
+
+        1. Create a vertical mid-line and a horizontal mid-line.
+        2. Convert these coordinates to geocentric coordinates.
+        3. Compute the distance between points along these lines.
+        4. Take the histogram of each set of distances and find the
+           bin with the most points.
+        5. Take the average of the edges of that bin.
+        6. Return the maximum of the vertical and horizontal bin
+           edge averages.
+
+        """
         from pyproj import transform
         rows, cols = self.shape
         mid_row = rows // 2

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1266,15 +1266,23 @@ class Test(unittest.TestCase):
         geo_res = area_def.geocentric_resolution()
         np.testing.assert_allclose(10646.562531, geo_res)
 
+        # non-square area non-space area
+        area_extent = (-4570248.477339745, -3561247.267842293, 0, 3570248.477339745)
+        area_def = get_area_def('orig', 'Test area', 'test',
+                                proj_dict,
+                                2000, 5000,
+                                area_extent)
+        geo_res = area_def.geocentric_resolution()
+        np.testing.assert_allclose(2397.687307, geo_res)
+
         # lon/lat
         proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'proj': 'latlong'}
         area_def = get_area_def('orig', 'Test area', 'test',
                                 proj_dict,
                                 3712, 3712,
-                                [-130, 30, -120, 40],
-                                area_extent)
+                                [-130, 30, -120, 40])
         geo_res = area_def.geocentric_resolution()
-        np.testing.assert_allclose(248.594116, geo_res)
+        np.testing.assert_allclose(298.647232, geo_res)
 
 
 class TestMakeSliceDivisible(unittest.TestCase):

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -902,7 +902,7 @@ class TestXArrayResamplerNN(unittest.TestCase):
         self.assertIsInstance(res.data, da.Array)
         res = res.values
         cross_sum = np.nansum(res)
-        expected = 32114793.0
+        expected = 87281406.0
         self.assertEqual(cross_sum, expected)
 
         # pretend the resolutions can't be determined


### PR DESCRIPTION
This is a major fix for how nearest neighbor resampling works by default. In a previous PR (#225), I had added a `geocentric_resolution` method which could be used to come up with a best guess for the `radius_of_influence` of nearest neighbor resampling. However, all of my tests were based on square areas. While investigating a complaint by a coworker, I realized that `geocentric_resolution` actually depends on the size of the X and Y dimension.

The code I had did the following:

1. Create a horizontal midline and vertical midline of coordinates.
2. Calculate the geocentric distance along the points on those lines.
3. Take the histogram of all of those distances.
4. Take the largest bin (the one with the most points) and average the edge values.

The issue with this is that the histogram, and therefore the largest bin, is dependent on how many pixels go in to each midline. So if you have a non-square area, there is a good chance that the longer dimension is going to have the largest bin. This means you end up completely ignoring the other dimension which might actually have a larger resolution that needs to be accounted for to have an accurate `radius_of_influence`. So this PR changes it to perform step 3 and 4 for each midline, then take the maximum.



 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
