### PR TITLE
Remove type check for nearest neighbour fill value.

### DIFF
--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -79,7 +79,7 @@ def resample_nearest(source_geo_def,
     epsilon : float, optional
         Allowed uncertainty in meters. Increasing uncertainty
         reduces execution time
-    fill_value : int or None, optional
+    fill_value : int, float, numpy floating, numpy integer or None, optional
             Set undetermined pixels to this value.
             If fill_value is None a masked array is returned
             with undetermined pixels masked
@@ -617,7 +617,7 @@ def get_sample_from_neighbour_info(resample_type, output_shape, data,
         If only one channel is resampled weight_funcs is
         a single function object.
         Must be supplied when using 'custom' resample type
-    fill_value : int or None, optional
+    fill_value : int, float, numpy floating, numpy integer or None, optional
         Set undetermined pixels to this value.
         If fill_value is None a masked array is returned
         with undetermined pixels masked
@@ -677,9 +677,6 @@ def get_sample_from_neighbour_info(resample_type, output_shape, data,
     if resample_type == 'custom' and weight_funcs is None:
         raise ValueError('weight_funcs must be supplied when using '
                          'custom resampling')
-
-    if not isinstance(fill_value, (long, int, float)) and fill_value is not None:
-        raise TypeError('fill_value must be number or None')
 
     if index_array.ndim == 1:
         neighbours = 1

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -621,6 +621,30 @@ class Test(unittest.TestCase):
         expected = 15874591.0
         self.assertEqual(cross_sum, expected)
 
+    def test_nearest_from_sample_np_dtypes(self):
+        lons = np.fromfunction(lambda y, x: 3 + x, (50, 10))
+        lats = np.fromfunction(lambda y, x: 75 - y, (50, 10))
+        swath_def = geometry.SwathDefinition(lons=lons, lats=lats)
+        valid_input_index, valid_output_index, index_array, distance_array = \
+            kd_tree.get_neighbour_info(swath_def,
+                                       self.area_def,
+                                       50000, neighbours=1, segments=1)
+
+        for dtype in [np.uint16, np.float32]:
+            with self.subTest(dtype):
+                data = np.fromfunction(lambda y, x: y * x, (50, 10)).astype(dtype)
+                fill_value = dtype(0.0)
+                res = \
+                    kd_tree.get_sample_from_neighbour_info('nn', (800, 800),
+                                                           data.ravel(),
+                                                           valid_input_index,
+                                                           valid_output_index,
+                                                           index_array,
+                                                           fill_value=fill_value)
+                cross_sum = res.sum()
+                expected = 15874591.0
+                self.assertEqual(cross_sum, expected)
+
     def test_custom_multi_from_sample(self):
         def wf1(dist):
             return 1 - dist / 100000.0


### PR DESCRIPTION
This PR removes a type check for the `fill_value` keyword argument of the `get_sample_from_neighbour_info` function in `pyresample/kd_tree.py`. The previous type check was limiting the fill value to being either `None`, or Python standard `int` or `float` types. This was not compatible with `numpy` data types (e.g. `np.uint8`, `np.float32`, etc).

As a result of this change, if an incompatible fill value (such as a string) is supplied to `get_sample_from_neighbour_info`, the function will fall back on a `ValueError` raised by `numpy`.

 - [x] Closes #272 
 - [x] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff``
