### PR TITLE
Create AreaDefinition from epsg codes

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1211,6 +1211,25 @@ class AreaDefinition(BaseDefinition):
         return self.height
 
     @classmethod
+    def from_epsg(cls, code, resolution):
+        """Create an AreaDefinition object from an epsg code (string or int) and a resolution."""
+        if CRS is None:
+            raise NotImplementedError
+        crs = CRS('EPSG:' + str(code))
+        bounds = crs.area_of_use.bounds
+        proj = Proj(crs)
+        left1, low1 = proj(bounds[0], bounds[1])
+        right1, up1 = proj(bounds[2], bounds[3])
+        left2, up2 = proj(bounds[0], bounds[3])
+        right2, low2 = proj(bounds[2], bounds[1])
+        left = min(left1, left2)
+        right = max(right1, right2)
+        up = max(up1, up2)
+        low = min(low1, low2)
+        area_extent = (left, low, right, up)
+        return create_area_def(crs.name, crs.to_dict(), area_extent=area_extent, resolution=resolution)
+
+    @classmethod
     def from_extent(cls, area_id, projection, shape, area_extent, units=None, **kwargs):
         """Create an AreaDefinition object from area_extent and shape.
 

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1276,6 +1276,21 @@ class Test(unittest.TestCase):
         geo_res = area_def.geocentric_resolution()
         np.testing.assert_allclose(248.594116, geo_res)
 
+    def test_from_epsg(self):
+        """Test the from_epsg class method."""
+        from pyresample.geometry import AreaDefinition
+        sweref = AreaDefinition.from_epsg('3006', 2000)
+        assert sweref.name == 'SWEREF99 TM'
+        assert sweref.proj_dict == {'ellps': 'GRS80', 'no_defs': None,
+                                    'proj': 'utm', 'type': 'crs', 'units': 'm',
+                                    'zone': 33}
+        assert sweref.width == 453
+        assert sweref.height == 794
+        import numpy as np
+        np.testing.assert_allclose(sweref.area_extent,
+                                   (181896.3291, 6101648.0705,
+                                    1086312.942376, 7689478.3056))
+
 
 class TestMakeSliceDivisible(unittest.TestCase):
     """Test the _make_slice_divisible."""
@@ -1662,6 +1677,7 @@ class TestSwathDefinition(unittest.TestCase):
         xlons = xr.DataArray(da.from_array(lons.ravel(), chunks=2), dims=['y'])
         sd = SwathDefinition(xlons, xlats)
         self.assertRaises(RuntimeError, sd.geocentric_resolution)
+
 
 class TestStackedAreaDefinition(unittest.TestCase):
     """Test the StackedAreaDefition."""


### PR DESCRIPTION
This PR adds the possibility to create AreaDefintions from EPSG codes that include an area of use.


 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

The usage is for example:
`sweref = AreaDefinition.from_epsg('3006', 1000)`
to get the SWEREF99 TM area in 1km resolution.

Some example of imagery generated with satpy for epsg 3006 and 3034:
![3006](https://user-images.githubusercontent.com/167802/81393806-3c4f4e00-9121-11ea-9f6a-b1eefce3693e.png)
![3034](https://user-images.githubusercontent.com/167802/81393815-3fe2d500-9121-11ea-8aab-271f484c80c9.png)

