### PR TITLE
Fix calculating area slices for flipped projections

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1997,7 +1997,27 @@ class AreaDefinition(BaseDefinition):
         return new_area
 
     def geocentric_resolution(self, ellps='WGS84', radius=None):
-        """Find best estimate for overall geocentric resolution."""
+        """Find best estimate for overall geocentric resolution.
+
+        This method is extremely important to the results of KDTree-based
+        resamplers like the nearest neighbor resampling. This is used to
+        determine how far the KDTree should be queried for valid pixels
+        before giving up (`radius_of_influence`). This method attempts to
+        make a best guess at what geocentric resolution (the units used by
+        the KDTree) represents the majority of an area.
+
+        To do this this method will:
+
+        1. Create a vertical mid-line and a horizontal mid-line.
+        2. Convert these coordinates to geocentric coordinates.
+        3. Compute the distance between points along these lines.
+        4. Take the histogram of each set of distances and find the
+           bin with the most points.
+        5. Take the average of the edges of that bin.
+        6. Return the maximum of the vertical and horizontal bin
+           edge averages.
+
+        """
         from pyproj import transform
         rows, cols = self.shape
         mid_row = rows // 2

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1928,9 +1928,14 @@ class AreaDefinition(BaseDefinition):
 
             xstart = 0 if x[0] is np.ma.masked else x[0]
             ystart = 0 if y[1] is np.ma.masked else y[1]
-            xstop = self.width if x[1] is np.ma.masked else x[1] + 1
-            ystop = self.height if y[0] is np.ma.masked else y[0] + 1
-
+            if self.area_extent[0] > self.area_extent[2]:
+                xstop = self.width if x[0] is np.ma.masked else x[0] + 1
+            else:
+                xstop = self.width if x[1] is np.ma.masked else x[1] + 1
+            if self.area_extent[1] > self.area_extent[3]:
+                ystop = self.height if y[1] is np.ma.masked else y[1] + 1
+            else:
+                ystop = self.height if y[0] is np.ma.masked else y[0] + 1
             return slice(xstart, xstop), slice(ystart, ystop)
 
         if self.proj_dict.get('proj') != 'geos':
@@ -1953,7 +1958,6 @@ class AreaDefinition(BaseDefinition):
             raise NotImplementedError
         x, y = self.get_xy_from_lonlat(np.rad2deg(intersection.lon),
                                        np.rad2deg(intersection.lat))
-
         x_slice = slice(np.ma.min(x), np.ma.max(x) + 1)
         y_slice = slice(np.ma.min(y), np.ma.max(y) + 1)
         if shape_divisible_by is not None:

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1073,6 +1073,26 @@ class Test(unittest.TestCase):
         self.assertEqual(slice_x, slice(1610, 2343))
         self.assertEqual(slice_y, slice(158, 515, None))
 
+        # The same as source area, but flipped in X and Y
+        area_id = 'cover'
+        area_name = 'Area to cover'
+        proj_id = 'test'
+        x_size = 3712
+        y_size = 3712
+        area_extent = (5567248.074173927, 5570248.477339745, -5570248.477339745, -5561247.267842293)
+        proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'h': 35785831.0,
+                     'lon_0': 0.0, 'proj': 'geos', 'units': 'm'}
+
+        area_to_cover = utils.get_area_def(area_id,
+                                           area_name,
+                                           proj_id,
+                                           proj_dict,
+                                           x_size, y_size,
+                                           area_extent)
+        slice_x, slice_y = area_def.get_area_slices(area_to_cover)
+        self.assertEqual(slice(0, x_size, None), slice_x)
+        self.assertEqual(slice(0, y_size, None), slice_y)
+
         # totally different area
         projections = [{"init": 'EPSG:4326'}]
         if utils.is_pyproj2():

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1266,15 +1266,23 @@ class Test(unittest.TestCase):
         geo_res = area_def.geocentric_resolution()
         np.testing.assert_allclose(10646.562531, geo_res)
 
+        # non-square area non-space area
+        area_extent = (-4570248.477339745, -3561247.267842293, 0, 3570248.477339745)
+        area_def = get_area_def('orig', 'Test area', 'test',
+                                proj_dict,
+                                2000, 5000,
+                                area_extent)
+        geo_res = area_def.geocentric_resolution()
+        np.testing.assert_allclose(2397.687307, geo_res)
+
         # lon/lat
         proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'proj': 'latlong'}
         area_def = get_area_def('orig', 'Test area', 'test',
                                 proj_dict,
                                 3712, 3712,
-                                [-130, 30, -120, 40],
-                                area_extent)
+                                [-130, 30, -120, 40])
         geo_res = area_def.geocentric_resolution()
-        np.testing.assert_allclose(248.594116, geo_res)
+        np.testing.assert_allclose(298.647232, geo_res)
 
 
 class TestMakeSliceDivisible(unittest.TestCase):

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -902,7 +902,7 @@ class TestXArrayResamplerNN(unittest.TestCase):
         self.assertIsInstance(res.data, da.Array)
         res = res.values
         cross_sum = np.nansum(res)
-        expected = 32114793.0
+        expected = 87281406.0
         self.assertEqual(cross_sum, expected)
 
         # pretend the resolutions can't be determined


### PR DESCRIPTION
This fixes a segmentation fault for Satpy data reduction when the source area is flipped and GEO data has space surrounding the full disk data. In this case `pykdtree` was passed coordinates that were `inf` which causes segmentation fault.

 - [x] Closes https://github.com/pytroll/pyresample/issues/274 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
