### PR TITLE
Fix type-alien areadef comparisons

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -116,6 +116,8 @@ class BaseDefinition(object):
         """Test for approximate equality."""
         if self is other:
             return True
+        if not isinstance(other, BaseDefinition):
+            return False
         if other.lons is None or other.lats is None:
             other_lons, other_lats = other.get_lonlats()
         else:

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -515,6 +515,8 @@ class Test(unittest.TestCase):
                                            )
         self.assertFalse(
             area_def == msg_area, 'area_defs are not expected to be equal')
+        self.assertFalse(
+            area_def == "area", 'area_defs are not expected to be equal')
 
     def test_swath_equal_area(self):
         """Test equality swath area."""


### PR DESCRIPTION
When comparing an AreaDefinition for equality against a type that isn't
an AreaDefinition, return False rather than raising an AttributeError.
Fixes #287.

<!-- Please make the PR against the `master` branch. -->

 - [x] Closes #287 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
