### PR TITLE
Make AreaDefinition.area_extent read only

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1111,7 +1111,7 @@ class AreaDefinition(BaseDefinition):
         self.ndim = 2
         self.pixel_size_x = (area_extent[2] - area_extent[0]) / float(width)
         self.pixel_size_y = (area_extent[3] - area_extent[1]) / float(height)
-        self.area_extent = tuple(area_extent)
+        self._area_extent = tuple(area_extent)
         if CRS is not None:
             self.crs_wkt = CRS(projection).to_wkt()
             self._proj_dict = None
@@ -1181,6 +1181,10 @@ class AreaDefinition(BaseDefinition):
             else:
                 self._proj_dict = proj4_str_to_dict(self.crs.to_proj4())
         return self._proj_dict
+
+    @property
+    def area_extent(self):
+        return self._area_extent
 
     def copy(self, **override_kwargs):
         """Make a copy of the current area.

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1480,6 +1480,28 @@ class Test(unittest.TestCase):
         # WKT1 to WKT2 has some different naming of things so this fails
         # self.assertEqual(crs, area_def.crs)
 
+    def test_areadef_immutable(self):
+        import pytest
+        area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
+                                           {'a': '6378144.0',
+                                            'b': '6356759.0',
+                                            'lat_0': '50.00',
+                                            'lat_ts': '50.00',
+                                            'lon_0': '8.00',
+                                            'proj': 'stere'},
+                                           10,
+                                           10,
+                                           [-1370912.72,
+                                               -909968.64000000001,
+                                               1029087.28,
+                                               1490031.3600000001])
+        with pytest.raises(AttributeError):
+            area_def.shape = (10, 10)
+        with pytest.raises(AttributeError):
+            area_def.proj_str = "seaweed"
+        with pytest.raises(AttributeError):
+            area_def.area_extent = (-1000000, -900000, 1000000, 1500000)
+
 
 class TestMakeSliceDivisible(unittest.TestCase):
     """Test the _make_slice_divisible."""


### PR DESCRIPTION
Prohibit setting area_extent on AreaDefinition objects.

<!-- Please make the PR against the `master` branch. -->

 - [x] Closes #289 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
