### PR TITLE
Fix python3 rpm naming of pyproj

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
-requires=python3-numpy pykdtree python3-numexpr pyproj python3-configobj python3-shapely
+requires=python3-numpy pykdtree python3-numexpr python3-pyproj python3-configobj python3-shapely
 release=1
 doc_files = docs/Makefile docs/source/*.rst
 


### PR DESCRIPTION
It seems we forgot to also update the python3 naming of the pyproj rpm package when we had a similar PR a while ago.
This PR is supposed to complete this.


<!-- Please make the PR against the `master` branch. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
