### PR TITLE
Fix colrow2lonlat working only for square areadefs

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1618,7 +1618,7 @@ class AreaDefinition(BaseDefinition):
         p = Proj(self.proj_str)
         x = self.projection_x_coords
         y = self.projection_y_coords
-        return p(y[y.size - cols], x[x.size - rows], inverse=True)
+        return p(x[cols],  y[rows], inverse=True)
 
     def lonlat2colrow(self, lons, lats):
         """Return image columns and rows for the given lons and lats.

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -784,18 +784,18 @@ class Test(unittest.TestCase):
     def test_colrow2lonlat(self):
         """Test colrow2lonlat."""
         from pyresample import utils
-        area_id = 'meteosat_0deg'
-        area_name = 'Meteosat 0 degree Service'
-        proj_id = 'geos0'
-        x_size = 3712
-        y_size = 3712
-        area_extent = [-5570248.477339261, -5567248.074173444,
-                       5567248.074173444, 5570248.477339261]
-        proj_dict = {'a': '6378169.00',
-                     'b': '6356583.80',
-                     'h': '35785831.0',
-                     'lon_0': '0.0',
-                     'proj': 'geos'}
+        area_id = 'eurol'
+        area_name = 'Euro 3.0km area - Europe'
+        proj_id = 'eurol'
+        x_size = 2560
+        y_size = 2048
+        area_extent = [-3780000.0, -7644000.0, 3900000.0, -1500000.0]
+        proj_dict = {
+            'lat_0': 90.0,
+            'lon_0': 0.0,
+            'lat_ts': 60.0,
+            'ellps': 'WGS84',
+            'proj': 'stere'}
         area = utils.get_area_def(area_id,
                                   area_name,
                                   proj_id,
@@ -803,21 +803,21 @@ class Test(unittest.TestCase):
                                   x_size, y_size,
                                   area_extent)
 
-        # Imatra, Wiesbaden
-        cols = np.array([2304, 2040])
-        rows = np.array([186, 341])
+        # Darmstadt, Gibraltar
+        cols = np.array([1477, 1069])
+        rows = np.array([938, 1513])
         lons__, lats__ = area.colrow2lonlat(cols, rows)
 
         # test arrays
-        lon_expects = np.array([28.77763033, 8.23765962])
-        lat_expects = np.array([61.20120556, 50.05836402])
+        lon_expects = np.array([8.597949006575268, -5.404744177829209])
+        lat_expects = np.array([49.79024658538765, 36.00540657185169])
         self.assertTrue(np.allclose(lons__, lon_expects, rtol=0, atol=1e-7))
         self.assertTrue(np.allclose(lats__, lat_expects, rtol=0, atol=1e-7))
 
         # test scalars
-        lon__, lat__ = area.colrow2lonlat(1567, 2375)
-        lon_expect = -8.125547604568746
-        lat_expect = -14.345524111874646
+        lon__, lat__ = area.colrow2lonlat(1069, 1513)
+        lon_expect = -5.404744177829209
+        lat_expect = 36.00540657185169
         self.assertTrue(np.allclose(lon__, lon_expect, rtol=0, atol=1e-7))
         self.assertTrue(np.allclose(lat__, lat_expect, rtol=0, atol=1e-7))
 

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -784,6 +784,46 @@ class Test(unittest.TestCase):
     def test_colrow2lonlat(self):
         """Test colrow2lonlat."""
         from pyresample import utils
+
+        # test square, symmetric areadef
+        area_id = 'meteosat_0deg'
+        area_name = 'Meteosat 0 degree Service'
+        proj_id = 'geos0'
+        x_size = 3712
+        y_size = 3712
+        area_extent = [-5570248.477339261, -5567248.074173444,
+                       5567248.074173444, 5570248.477339261]
+        proj_dict = {'a': '6378169.00',
+                     'b': '6356583.80',
+                     'h': '35785831.0',
+                     'lon_0': '0.0',
+                     'proj': 'geos'}
+        area = utils.get_area_def(area_id,
+                                  area_name,
+                                  proj_id,
+                                  proj_dict,
+                                  x_size, y_size,
+                                  area_extent)
+
+        # Imatra, Wiesbaden
+        cols = np.array([2304, 2040])
+        rows = np.array([186, 341])
+        lons__, lats__ = area.colrow2lonlat(cols, rows)
+
+        # test arrays
+        lon_expects = np.array([28.77763033, 8.23765962])
+        lat_expects = np.array([61.20120556, 50.05836402])
+        self.assertTrue(np.allclose(lons__, lon_expects, rtol=0, atol=1e-7))
+        self.assertTrue(np.allclose(lats__, lat_expects, rtol=0, atol=1e-7))
+
+        # test scalars
+        lon__, lat__ = area.colrow2lonlat(1567, 2375)
+        lon_expect = -8.125547604568746
+        lat_expect = -14.345524111874646
+        self.assertTrue(np.allclose(lon__, lon_expect, rtol=0, atol=1e-7))
+        self.assertTrue(np.allclose(lat__, lat_expect, rtol=0, atol=1e-7))
+
+        # test rectangular areadef
         area_id = 'eurol'
         area_name = 'Euro 3.0km area - Europe'
         proj_id = 'eurol'
@@ -815,9 +855,10 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(lats__, lat_expects, rtol=0, atol=1e-7))
 
         # test scalars
-        lon__, lat__ = area.colrow2lonlat(1069, 1513)
-        lon_expect = -5.404744177829209
-        lat_expect = 36.00540657185169
+        # Selva di Val Gardena
+        lon__, lat__ = area.colrow2lonlat(1582, 1049)
+        lon_expect = 11.75721385976652
+        lat_expect = 46.56384754346095
         self.assertTrue(np.allclose(lon__, lon_expect, rtol=0, atol=1e-7))
         self.assertTrue(np.allclose(lat__, lat_expect, rtol=0, atol=1e-7))
 


### PR DESCRIPTION
This PR fixes a bug observed in the `AreaDefinition `method `colrow2lonlat`. The function was working properly only for square areadefs, while returning wrong values for other areas. 

To reproduce:

```python
from satpy.resample import get_area_def
from satpy.scene import Scene

def lonlat2colrow2lonlat(lon_in, lat_in, area_def, desc):
    """Checks the reciprocity of lonlat2colrow and colrow2lonlat."""

    col, row = area_def.lonlat2colrow(lon_in, lat_in)
    lon_out, lat_out = area_def.colrow2lonlat(col, row)

    print("\nLon out "+desc+": ", lon_out)
    print("Lat out "+desc+": ", lat_out)

    return

lon_in = 30
lat_in = 40
print("Lon in: ", lon_in)
print("Lat in: ", lat_in)

# let's check upright areadefs
area_def = get_area_def("seviri_0deg")
lonlat2colrow2lonlat(lon_in, lat_in, area_def, 'seviri_0deg')

area_def = get_area_def("eurol")
lonlat2colrow2lonlat(lon_in, lat_in, area_def, 'eurol')

# let's check flipped areadefs
test_image = '/you/path/to/a/SEVIRI/native/image.nat'
scn = Scene(reader="seviri_l1b_native", filenames=[test_image])

scn.load(['HRV'])
area_def = scn['HRV'].attrs['area'].defs[1]
lonlat2colrow2lonlat(lon_in, lat_in, area_def, 'nat HRV')

scn.load(['VIS008'])
area_def = scn['VIS008'].attrs['area']
lonlat2colrow2lonlat(lon_in, lat_in, area_def, 'nat vis08')
```
Output with the current master:
```
Lon in:  30
Lat in:  40

Lon out seviri_0deg:  29.99159844726278 
Lat out seviri_0deg:  40.006400108344515

Lon out eurol:  -94.68203082968928
Lat out eurol:  27.231622640431453

Lon out nat HRV:  73.08085247495852
Lat out nat HRV:  -17.06078516437714

Lon out nat vis08:  30.037311995180985
Lat out nat vis08:  39.92747931402665
```
note how the non-square `eurol `and the (upper) `HRV `areas have wrong values.

Output after this PR:
```bash
Lon in:  30
Lat in:  40

Lon out seviri_0deg:  29.99159844726278 
Lat out seviri_0deg:  40.006400108344515

Lon out eurol:  29.992464774442446
Lat out eurol:  40.01002332383795

Lon out nat HRV:  29.999208764610334
Lat out nat HRV:  39.993233105064675

Lon out nat vis08:  29.991595970000212
Lat out nat vis08:  40.006397985178815
```
All values are correct. 

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->