### PR TITLE
Fix fill value for integer datasets, fix band assignment

### DIFF
--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -321,8 +321,11 @@ def _check_fill_value(fill_value, dtype):
             fill_value = 0
         else:
             fill_value = np.nan
-    if np.issubdtype(dtype, np.integer):
-        fill_value = 0
+    elif np.issubdtype(dtype, np.integer):
+        if np.isnan(fill_value):
+            fill_value = 0
+        elif np.issubdtype(type(fill_value), np.floating):
+            fill_value = int(fill_value)
 
     return fill_value
 

--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -209,15 +209,14 @@ class XArrayResamplerBilinear(object):
                     self.out_coords[dim] = data.coords[dim]
                 except KeyError:
                     pass
-        self._adjust_bands(data.coords)
+        self._adjust_bands_coordinates_to_match_data(data.coords)
 
     def _add_x_and_y_coordinates(self):
         if self.out_coords['x'] is None and self.out_coords_x is not None:
             self.out_coords['x'] = self.out_coords_x
             self.out_coords['y'] = self.out_coords_y
 
-    def _adjust_bands(self, data_coords):
-        """Adjust output band coordinates to match the data."""
+    def _adjust_bands_coordinates_to_match_data(self, data_coords):
         if 'bands' in data_coords:
             self.out_coords['bands'] = data_coords['bands']
 

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -984,3 +984,23 @@ class TestXarrayBilinear(unittest.TestCase):
         self.assertEqual(res.shape, (self.target_def.size, 3))
         vals = [3188578.91069278, -612099.36103276, 5481596.63569999]
         self.assertTrue(np.allclose(res.compute()[0, :], vals))
+
+
+def test_check_fill_value():
+    """Test that fill_value replacement/adjustment works."""
+    from pyresample.bilinear.xarr import _check_fill_value
+
+    # None + integer dtype -> 0
+    assert _check_fill_value(None, np.uint8) == 0
+    # None + float dtype -> np.nan
+    assert _check_fill_value(None, np.double)
+
+    # integer fill value + integer dtype -> no change
+    assert _check_fill_value(3, np.uint8) == 3
+    # np.nan + integer dtype -> 0
+    assert _check_fill_value(np.nan, np.uint8) == 0
+    # float fill value + integer dtype -> int(fill_value)
+    assert _check_fill_value(3.3, np.uint16) == 3
+
+    # float fill value + float dtype -> no change
+    assert _check_fill_value(3.3, np.float32)

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -558,6 +558,14 @@ class TestXarrayBilinear(unittest.TestCase):
         self.assertTrue('bands' in resampler.out_coords)
         self.assertTrue(np.all(resampler.out_coords['bands'] == bands))
 
+        # Available coordinates from self.out_coords_x and self.out_coords_y
+        # should be set to self.out_coords
+        resampler.out_coords_x = [1]
+        resampler.out_coords_y = [2]
+        resampler._add_missing_coordinates(data)
+        self.assertEqual(resampler.out_coords['x'], resampler.out_coords_x)
+        self.assertEqual(resampler.out_coords['y'], resampler.out_coords_y)
+
     def test_slice_data(self):
         """Test slicing the data."""
         import dask.array as da

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -1001,7 +1001,7 @@ def test_check_fill_value():
     # None + integer dtype -> 0
     assert _check_fill_value(None, np.uint8) == 0
     # None + float dtype -> np.nan
-    assert _check_fill_value(None, np.double)
+    assert np.isnan(_check_fill_value(None, np.double))
 
     # integer fill value + integer dtype -> no change
     assert _check_fill_value(3, np.uint8) == 3


### PR DESCRIPTION
Since some recent changes in Satpy resampling a of mix of float and integer datasets (e.g. when using `BackgroundCompositor`) in to one output was broken in two ways in `XArrayResamplerBilinear`.

1. `fill_value` was set to `np.nan` even for the integer dataset
2. if one of these datasets had `RGBA` and another `RGB` bands, **sometimes** there were problems assigning the correct bands to the output dataset after resampling.

I'm not entirely sure why this happens, but this fixes it.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
