### PR TITLE
Improve compatibility with new pyproj

### DIFF
--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -522,7 +522,11 @@ class TestMisc(unittest.TestCase):
         crs = CRS(init='epsg:3857')
         source = tmptiff(crs=crs)
         area_def = utils.rasterio.get_area_def_from_raster(source)
-        self.assertEqual(area_def.proj_id, 'WGS 84 / Pseudo-Mercator')
+        epsg3857_names = (
+            'WGS_1984_Web_Mercator_Auxiliary_Sphere', # gdal>=3.0 + proj>=6.0
+            'WGS 84 / Pseudo-Mercator',               # proj<6.0
+        )
+        self.assertIn(area_def.proj_id, epsg3857_names)
 
     def test_get_area_def_from_raster_rotated_value_err(self):
         from pyresample import utils

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -523,8 +523,8 @@ class TestMisc(unittest.TestCase):
         source = tmptiff(crs=crs)
         area_def = utils.rasterio.get_area_def_from_raster(source)
         epsg3857_names = (
-            'WGS_1984_Web_Mercator_Auxiliary_Sphere', # gdal>=3.0 + proj>=6.0
-            'WGS 84 / Pseudo-Mercator',               # proj<6.0
+            'WGS_1984_Web_Mercator_Auxiliary_Sphere',  # gdal>=3.0 + proj>=6.0
+            'WGS 84 / Pseudo-Mercator',                # proj<6.0
         )
         self.assertIn(area_def.proj_id, epsg3857_names)
 


### PR DESCRIPTION
Recent pyproj introduced a different naming for the web-mercator projection.
The patch takes into account of the different naming and make all tests pass properly also with new versions of pyproj.
 
 - [ ] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff``

**Edit**: see also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=949274
