### PR TITLE
Added subpixel capability to a few projection functions

### DIFF
--- a/pyresample/grid.py
+++ b/pyresample/grid.py
@@ -94,7 +94,7 @@ def get_image_from_linesample(row_indices, col_indices, source_image,
     return target_filled.astype(target_image.dtype)
 
 
-def get_linesample(lons, lats, source_area_def, nprocs=1):
+def get_linesample(lons, lats, source_area_def, nprocs=1, subpixel=False):
     """Returns index row and col arrays for resampling
 
     Parameters
@@ -107,6 +107,9 @@ def get_linesample(lons, lats, source_area_def, nprocs=1):
         Source definition as AreaDefinition object
     nprocs : int, optional
         Number of processor cores to be used
+    subpixel : bool, optional
+        False (default) if the result should be truncated to integers,
+        True returns float values at subpixel accuracy
 
     Returns
     -------
@@ -125,10 +128,14 @@ def get_linesample(lons, lats, source_area_def, nprocs=1):
 
     # Find corresponding pixels (element by element conversion of ndarrays)
     source_pixel_x = (source_area_def.pixel_offset_x +
-                      source_x / source_area_def.pixel_size_x).astype(np.int32)
+                      source_x / source_area_def.pixel_size_x)
 
     source_pixel_y = (source_area_def.pixel_offset_y -
-                      source_y / source_area_def.pixel_size_y).astype(np.int32)
+                      source_y / source_area_def.pixel_size_y)
+
+    if not subpixel:
+        source_pixel_x = source_pixel_x.astype(np.int32)
+        source_pixel_y = source_pixel_y.astype(np.int32)
 
     return source_pixel_y, source_pixel_x
 


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

There are a few projection functions in pyresample that return pixel coordinates. These seem to truncate their outputs to produce integer coordinates, but returning float values would enable the use of the results in functions that perform interpolation. This PR changes three functions:
- `grid.py` -> `get_linesample`
- `geometry.py` -> `AreaDefinition.get_xy_from_proj_coords`
- `geometry.py` -> `AreaDefinition.get_xy_from_lonlat`
A `subpixel` option is added to each function to allow them to return floating point values instead of integers. `subpixel` is `False` by default, so the default behavior is not changed.