### PR TITLE
Fix chunks assignment for stacked areadefs in StackedAreaDefinition.get_lonlats()

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2342,12 +2342,20 @@ class StackedAreaDefinition(BaseDefinition):
             row_slice = slice(0, self.height)
             col_slice = slice(0, self.width)
         offset = 0
-        for definition in self.defs:
+        for def_idx, definition in enumerate(self.defs):
+            # handle case of stacked area definitions where chunks need to be assigned to each areadef
+            if isinstance(chunks, tuple) and len(chunks[0]) != len(self.defs):
+                chunks_for_definition = (definition.shape[0], chunks[1])
+            elif isinstance(chunks, tuple) and len(chunks[0]) == len(self.defs):
+                chunks_for_definition = (chunks[0][def_idx], chunks[1])
+            else:
+                chunks_for_definition = chunks
+
             local_row_slice = slice(max(row_slice.start - offset, 0),
                                     min(max(row_slice.stop - offset, 0), definition.height),
                                     row_slice.step)
             lons, lats = definition.get_lonlats(nprocs=nprocs, data_slice=(local_row_slice, col_slice),
-                                                cache=cache, dtype=dtype, chunks=chunks)
+                                                cache=cache, dtype=dtype, chunks=chunks_for_definition)
 
             llons.append(lons)
             llats.append(lats)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2350,7 +2350,7 @@ class StackedAreaDefinition(BaseDefinition):
                                     min(max(row_slice.stop - offset, 0), areadef.height),
                                     row_slice.step)
             lons, lats = areadef.get_lonlats(nprocs=nprocs, data_slice=(local_row_slice, col_slice),
-                                                cache=cache, dtype=dtype, chunks=chunks_for_areadef)
+                                             cache=cache, dtype=dtype, chunks=chunks_for_areadef)
 
             llons.append(lons)
             llats.append(lats)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2344,7 +2344,9 @@ class StackedAreaDefinition(BaseDefinition):
         offset = 0
         for def_idx, definition in enumerate(self.defs):
             # handle case of stacked area definitions where chunks need to be assigned to each areadef
-            if isinstance(chunks, tuple) and len(chunks[0]) != len(self.defs):
+            if isinstance(chunks, tuple) and isinstance(chunks[0], int):
+                chunks_for_definition = chunks
+            elif isinstance(chunks, tuple) and len(chunks[0]) != len(self.defs):
                 chunks_for_definition = (definition.shape[0], chunks[1])
             elif isinstance(chunks, tuple) and len(chunks[0]) == len(self.defs):
                 chunks_for_definition = (chunks[0][def_idx], chunks[1])

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2054,6 +2054,14 @@ class TestStackedAreaDefinition(unittest.TestCase):
         lons_c, lats_c = final_area.get_lonlats(chunks=((5568, 7000), (464,)))
         np.testing.assert_array_equal(lons, lons_c)
         np.testing.assert_array_equal(lats, lats_c)
+        # only one set of chunks in a tuple
+        lons_c, lats_c = final_area.get_lonlats(chunks=(5568, 464))
+        np.testing.assert_array_equal(lons, lons_c)
+        np.testing.assert_array_equal(lats, lats_c)
+        # only one chunk value
+        lons_c, lats_c = final_area.get_lonlats(chunks=5568)
+        np.testing.assert_array_equal(lons, lons_c)
+        np.testing.assert_array_equal(lats, lats_c)
 
     def test_combine_area_extents(self):
         """Test combination of area extents."""

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2037,31 +2037,19 @@ class TestStackedAreaDefinition(unittest.TestCase):
         np.testing.assert_allclose(lats[:464, :], lats0)
         np.testing.assert_allclose(lats[464:, :], lats1)
 
-        # check get_lonlats with chunks definition doesn't cause errors and arrays are equal
+        # check that get_lonlats with chunks definition doesn't cause errors and output arrays are equal
         # too many chunks
-        lons_c, lats_c = final_area.get_lonlats(chunks=((2000, 3568, 5568), (464,)))
-        np.testing.assert_array_equal(lons, lons_c)
-        np.testing.assert_array_equal(lats, lats_c)
-        # too few chunk
-        lons_c, lats_c = final_area.get_lonlats(chunks=((5568,), (464,)))
-        np.testing.assert_array_equal(lons, lons_c)
-        np.testing.assert_array_equal(lats, lats_c)
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((200, 264, 464), (5570,)))
+        # too few chunks
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((464,), (5568,)))
         # right amount of chunks, same shape
-        lons_c, lats_c = final_area.get_lonlats(chunks=((5568, 5568), (464,)))
-        np.testing.assert_array_equal(lons, lons_c)
-        np.testing.assert_array_equal(lats, lats_c)
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((464, 464), (5568,)))
         # right amount of chunks, different shape
-        lons_c, lats_c = final_area.get_lonlats(chunks=((5568, 7000), (464,)))
-        np.testing.assert_array_equal(lons, lons_c)
-        np.testing.assert_array_equal(lats, lats_c)
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((464, 470), (5568,)))
         # only one set of chunks in a tuple
-        lons_c, lats_c = final_area.get_lonlats(chunks=(5568, 464))
-        np.testing.assert_array_equal(lons, lons_c)
-        np.testing.assert_array_equal(lats, lats_c)
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=(464, 5568))
         # only one chunk value
-        lons_c, lats_c = final_area.get_lonlats(chunks=5568)
-        np.testing.assert_array_equal(lons, lons_c)
-        np.testing.assert_array_equal(lats, lats_c)
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=464)
 
     def test_combine_area_extents(self):
         """Test combination of area extents."""
@@ -2226,6 +2214,13 @@ class TestStackedAreaDefinition(unittest.TestCase):
 
         area_def = cad('omerc_bb', {'ellps': 'WGS84', 'proj': 'omerc'})
         self.assertTrue(isinstance(area_def, DynamicAreaDefinition))
+
+
+def _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks):
+    """Compute the lons and lats with chunk definition and check that they are as expected."""
+    lons_c, lats_c = final_area.get_lonlats(chunks=chunks)
+    np.testing.assert_array_equal(lons, lons_c)
+    np.testing.assert_array_equal(lats, lats_c)
 
 
 class TestDynamicAreaDefinition(unittest.TestCase):

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2037,6 +2037,24 @@ class TestStackedAreaDefinition(unittest.TestCase):
         np.testing.assert_allclose(lats[:464, :], lats0)
         np.testing.assert_allclose(lats[464:, :], lats1)
 
+        # check get_lonlats with chunks definition doesn't cause errors and arrays are equal
+        # too many chunks
+        lons_c, lats_c = final_area.get_lonlats(chunks=((2000, 3568, 5568), (464,)))
+        np.testing.assert_array_equal(lons, lons_c)
+        np.testing.assert_array_equal(lats, lats_c)
+        # too few chunk
+        lons_c, lats_c = final_area.get_lonlats(chunks=((5568,), (464,)))
+        np.testing.assert_array_equal(lons, lons_c)
+        np.testing.assert_array_equal(lats, lats_c)
+        # right amount of chunks, same shape
+        lons_c, lats_c = final_area.get_lonlats(chunks=((5568, 5568), (464,)))
+        np.testing.assert_array_equal(lons, lons_c)
+        np.testing.assert_array_equal(lats, lats_c)
+        # right amount of chunks, different shape
+        lons_c, lats_c = final_area.get_lonlats(chunks=((5568, 7000), (464,)))
+        np.testing.assert_array_equal(lons, lons_c)
+        np.testing.assert_array_equal(lats, lats_c)
+
     def test_combine_area_extents(self):
         """Test combination of area extents."""
         area1 = MagicMock()


### PR DESCRIPTION
This PR fixes a bug occurring when `StackedAreaDefinition.get_lonlats()` is called with `chunks` being defined. 

If multiple chunk sizes are defined for the vertical dimension inside a tuple, each chunk size needs to be assigned to each `AreaDefinition` inside the `StackedAreaDefinition`. 

This was previously not implemented and untested, and was causing errors with stacked channels such as the SEVIRI HRV, e.g. as reported in https://github.com/pytroll/satpy/issues/1440 .

Thanks to @djhoese for the discussion about this in Slack this summer (https://pytroll.slack.com/archives/C0LNH7LMB/p1595520556054400)  and the solution proposal, and sorry for the delayed PR!

Closes https://github.com/pytroll/satpy/issues/1440

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
