### PR TITLE
Remove mask_all_nan kwarg and handle input fill_values in average bucket resampler, introduce skipna in get_average and get_sum

### DIFF
--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -139,22 +139,20 @@ class BucketResampler(object):
         target_shape = self.target_area.shape
         self.idxs = self.y_idxs * target_shape[1] + self.x_idxs
 
-    def get_sum(self, data, mask_all_nan=False, skipna=True):
+    def get_sum(self, data, skipna=True):
         """Calculate sums for each bin with drop-in-a-bucket resampling.
 
         Parameters
         ----------
         data : Numpy or Dask array
-        mask_all_nan : boolean (optional)
-                    If True, sets a bucket to NaN if all elements in the bucket are NaN.
-                    If False, a bucket containing only NaN values will have sum 0.
-                    Default: False
+            Data to be binned and averaged.
         skipna : boolean (optional)
                 If True, skips NaN values for the sum calculation
-                    (similarly to Numpy's `nansum`).
-                    If False, sets the bucket to NaN if one or more NaN values are present in the bucket
+                    (similarly to Numpy's `nansum`). Buckets containing only NaN are set to zero.
+                If False, sets the bucket to NaN if one or more NaN values are present in the bucket
                     (similarly to Numpy's `sum`).
-                    Default: True
+                In both cases, empty buckets are set to 0.
+                Default: True
 
         Returns
         -------
@@ -166,12 +164,8 @@ class BucketResampler(object):
             data = data.data
         data = data.ravel()
 
-        if skipna:
-            # Remove NaN values from the data when used as weights
-            weights = da.where(np.isnan(data), 0, data)
-        else:
-            # Keep NaN values to make a histogram bin NaN if a NaN element is present
-            weights = data
+        # Remove NaN values from the data when used as weights
+        weights = da.where(np.isnan(data), 0, data)
 
         # Rechunk indices to match the data chunking
         if weights.chunks != self.idxs.chunks:
@@ -182,12 +176,12 @@ class BucketResampler(object):
         sums, _ = da.histogram(self.idxs, bins=out_size, range=(0, out_size),
                                weights=weights, density=False)
 
-        if mask_all_nan and skipna:
+        # TODO remove following lines in favour of weights = data when dask histogram bug (issue #6935) is fixed
+        if not skipna:
             nans = np.isnan(data)
             nan_sums, _ = da.histogram(self.idxs[nans], bins=out_size,
                                        range=(0, out_size))
-            counts = self.get_count().ravel()
-            sums = da.where(nan_sums == counts, np.nan, sums)
+            sums = da.where(nan_sums > 0, np.nan, sums)
 
         return sums.reshape(self.target_area.shape)
 
@@ -218,16 +212,17 @@ class BucketResampler(object):
         Parameters
         ----------
         data : Numpy or Dask array
-            Data to be binned and averaged
+            Data to be binned and averaged.
         fill_value : float
             Fill value to mark missing/invalid values in the input data,
             as well as in the binned and averaged output data.
             Default: np.nan
         skipna : bool
             If True, skips missing values (as marked by NaN or `fill_value`) for the average calculation
-             (similarly to Numpy's `nanmean`).
-            If False, sets the bucket to NaN if one or more missing values are present in the bucket
+             (similarly to Numpy's `nanmean`). Buckets containing only missing values are set to fill_value.
+            If False, sets the bucket to fill_value if one or more missing values are present in the bucket
             (similarly to Numpy's `mean`).
+            In both cases, empty buckets are set to NaN.
             Default: True
 
         Returns
@@ -240,9 +235,8 @@ class BucketResampler(object):
         if not np.isnan(fill_value):
             data = da.where(data == fill_value, np.nan, data)
 
-        sums = self.get_sum(data, mask_all_nan=False, skipna=skipna)
-        counts = self.get_sum(np.logical_not(np.isnan(data)).astype(int),
-                              mask_all_nan=False)
+        sums = self.get_sum(data, skipna=skipna)
+        counts = self.get_sum(np.logical_not(np.isnan(data)).astype(int))
 
         average = sums / da.where(counts == 0, np.nan, counts)
         average = da.where(np.isnan(average), fill_value, average)

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -106,44 +106,44 @@ class Test(unittest.TestCase):
         np.testing.assert_equal(resampler.x_idxs, np.array([-1, 0, 0, 1, 1, 1, -1, -1, -1]))
         np.testing.assert_equal(resampler.y_idxs, np.array([-1, 1, 1, 1, 0, 0, -1, -1, -1]))
 
+    def _get_sum_result(self, data, **kwargs):
+        """Compute the bucket average with kwargs and check that no dask computation is performed."""
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            result = self.resampler.get_sum(data, **kwargs)
+        return result.compute()
+
     def test_get_sum(self):
         """Test drop-in-a-bucket sum."""
-        data = da.from_array(np.array([[2., 2.], [2., 2.]]),
+        data = da.from_array(np.array([[2., 3.], [7., 16.]]),
                              chunks=self.chunks)
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_sum(data)
+        result = self._get_sum_result(data)
+        # first two values are in same bin
+        self.assertEqual(np.count_nonzero(result == 5), 1)
+        # others are in separate bins
+        self.assertEqual(np.count_nonzero(result == 7), 1)
+        self.assertEqual(np.count_nonzero(result == 16), 1)
 
-        result = result.compute()
-        # One bin with two hits, so max value is 2.0
-        self.assertTrue(np.max(result) == 4.)
-        # Two bins with the same value
-        self.assertEqual(np.sum(result == 2.), 2)
-        # One bin with double the value
-        self.assertEqual(np.sum(result == 4.), 1)
         self.assertEqual(result.shape, self.adef.shape)
 
-        # Test that also Xarray.DataArrays work
+        # Test that also xarray.DataArrays work
         data = xr.DataArray(data)
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_sum(data)
-        # One bin with two hits, so max value is 2.0
-        self.assertTrue(np.max(result) == 4.)
-        # Two bins with the same value
-        self.assertEqual(np.sum(result == 2.), 2)
-        # One bin with double the value
-        self.assertEqual(np.sum(result == 4.), 1)
-        self.assertEqual(result.shape, self.adef.shape)
+        np.testing.assert_array_equal(result, self._get_sum_result(data))
 
-        # Test masking all-NaN bins
-        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+        # Test skipna
+        data = da.from_array(np.array([[2., np.nan], [5., np.nan]]),
                              chunks=self.chunks)
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_sum(data, mask_all_nan=True)
-        self.assertTrue(np.all(np.isnan(result)))
-        # By default all-NaN bins have a value of 0.0
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_sum(data)
-        self.assertEqual(np.nanmax(result), 0.0)
+        result = self._get_sum_result(data, skipna=False)
+        # 2 + nan is nan, all-nan bin is nan
+        self.assertEqual(np.count_nonzero(np.isnan(result)), 2)
+        # rest is 0
+        self.assertEqual(np.nanmin(result), 0)
+
+        result = self._get_sum_result(data, skipna=True)
+        # 2 + nan is 2
+        self.assertEqual(np.count_nonzero(result == 2.), 1)
+        # all-nan and rest is 0
+        self.assertEqual(np.count_nonzero(np.isnan(result)), 0)
+        self.assertEqual(np.nanmin(result), 0)
 
     def test_get_count(self):
         """Test drop-in-a-bucket sum."""
@@ -170,7 +170,7 @@ class Test(unittest.TestCase):
         self.assertEqual(np.count_nonzero(result == 6.5), 1)
         # test single entry average
         self.assertEqual(np.count_nonzero(result == 5), 1)
-        # test that average of bucket with only nan is nan, and empty buckets are nan as default
+        # test that average of bucket with only nan is nan, and empty buckets are nan
         self.assertEqual(np.count_nonzero(~np.isnan(result)), 2)
 
         # test fill_value other than np.nan
@@ -190,6 +190,14 @@ class Test(unittest.TestCase):
         result = self._get_average_result(data, skipna=False)
         # test that average of 2 and np.nan is nan for skipna=False
         self.assertTrue(np.all(np.isnan(result)))
+
+        # test only nan input
+        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+                             chunks=self.chunks)
+        result = self._get_average_result(data, skipna=True)
+        # test that average of np.nan and np.nan is np.nan for both skipna
+        self.assertTrue(np.all(np.isnan(result)))
+        np.testing.assert_array_equal(result, self._get_average_result(data, skipna=False))
 
         # test that fill_value in input is recognised as missing value
         data = da.from_array(np.array([[2, -1], [-1, np.nan]]),
@@ -235,4 +243,4 @@ class Test(unittest.TestCase):
         # No categories given, need to compute the data once to get
         # the categories
         with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
-            result = self.resampler.get_fractions(data, categories=None)
+            _ = self.resampler.get_fractions(data, categories=None)

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -167,23 +167,23 @@ class Test(unittest.TestCase):
                              chunks=self.chunks)
         result = self._get_average_result(data)
         # test multiple entries average
-        self.assertTrue(np.count_nonzero(result == 6.5) == 1)
+        self.assertEqual(np.count_nonzero(result == 6.5), 1)
         # test single entry average
-        self.assertTrue(np.count_nonzero(result == 5) == 1)
+        self.assertEqual(np.count_nonzero(result == 5), 1)
         # test that average of bucket with only nan is nan, and empty buckets are nan as default
-        self.assertTrue(np.count_nonzero(~np.isnan(result)) == 2)
+        self.assertEqual(np.count_nonzero(~np.isnan(result)), 2)
 
         # test fill_value other than np.nan
         result = self._get_average_result(data, fill_value=-1)
         # check that all empty buckets are fill_value
-        self.assertTrue(np.count_nonzero(result != -1) == 2)
+        self.assertEqual(np.count_nonzero(result != -1), 2)
 
         # test skipna
         data = da.from_array(np.array([[2, np.nan], [np.nan, np.nan]]),
                              chunks=self.chunks)
         result = self._get_average_result(data, skipna=True)
         # test that average of 2 and np.nan is 2 for skipna=True
-        self.assertTrue(np.count_nonzero(result == 2) == 1)
+        self.assertEqual(np.count_nonzero(result == 2), 1)
 
         data = da.from_array(np.array([[2, np.nan], [np.nan, np.nan]]),
                              chunks=self.chunks)
@@ -196,9 +196,9 @@ class Test(unittest.TestCase):
                              chunks=self.chunks)
         result = self._get_average_result(data, fill_value=-1, skipna=True)
         # test that average of 2 and -1 (missing value) is 2
-        self.assertTrue(np.count_nonzero(result == 2) == 1)
+        self.assertEqual(np.count_nonzero(result == 2), 1)
         # test than all other buckets are -1
-        self.assertTrue(np.count_nonzero(result != -1) == 1)
+        self.assertEqual(np.count_nonzero(result != -1), 1)
 
     def test_resample_bucket_fractions(self):
         """Test fraction calculations for categorical data."""


### PR DESCRIPTION

 - [x] Closes #317  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
