### PR TITLE
Fix bilinear resampler for 1D data

### DIFF
--- a/pyresample/bilinear/_base.py
+++ b/pyresample/bilinear/_base.py
@@ -188,7 +188,7 @@ class BilinearBase(object):
                                       np.arange(shp[0]))
             data = (np.ravel(lines), np.ravel(cols))
         except IndexError:
-            data = (np.zeros(shp[0]), np.arange(shp[0]))
+            data = (np.zeros(shp[0], dtype=np.uint32), np.arange(shp[0]))
 
         valid_lines_and_columns = array_slice_for_multiple_arrays(
             self._valid_input_index,

--- a/pyresample/bilinear/_base.py
+++ b/pyresample/bilinear/_base.py
@@ -183,13 +183,17 @@ class BilinearBase(object):
 
     def _get_slices(self):
         shp = self._source_geo_def.shape
-        cols, lines = np.meshgrid(np.arange(shp[1]),
-                                  np.arange(shp[0]))
+        try:
+            cols, lines = np.meshgrid(np.arange(shp[1]),
+                                      np.arange(shp[0]))
+            data = (np.ravel(lines), np.ravel(cols))
+        except IndexError:
+            data = (np.zeros(shp[0]), np.arange(shp[0]))
 
         valid_lines_and_columns = array_slice_for_multiple_arrays(
             self._valid_input_index,
-            (np.ravel(lines), np.ravel(cols))
-        )
+            data)
+
         self.slices_y, self.slices_x = array_slice_for_multiple_arrays(
             self._index_array,
             valid_lines_and_columns

--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -116,8 +116,8 @@ class XArrayBilinearResampler(BilinearBase):
         res = self._reshape_to_target_area(res, data.ndim)
 
         self._add_missing_coordinates(data)
-
-        return DataArray(res, dims=data.dims, coords=self._out_coords)
+        dims = self._get_output_dims(data, res)
+        return DataArray(res, dims=dims, coords=self._out_coords)
 
     def _add_missing_coordinates(self, data):
         self._add_x_and_y_coordinates()
@@ -138,6 +138,11 @@ class XArrayBilinearResampler(BilinearBase):
             self._out_coords['bands'] = data_coords['bands']
         elif 'bands' in self._out_coords:
             del self._out_coords['bands']
+
+    def _get_output_dims(self, data, res):
+        if data.ndim == res.ndim:
+            return data.dims
+        return list(self._out_coords.keys())
 
     def _slice_data(self, data, fill_value):
         def from_delayed(delayeds, shp):

--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -117,6 +117,7 @@ class XArrayBilinearResampler(BilinearBase):
 
         self._add_missing_coordinates(data)
         dims = self._get_output_dims(data, res)
+
         return DataArray(res, dims=dims, coords=self._out_coords)
 
     def _add_missing_coordinates(self, data):

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -745,6 +745,8 @@ class TestXarrayBilinear(unittest.TestCase):
         # Sample from 1D data
         data = DataArray(da.ones(self.source_def_1d.shape), dims=('y'))
         res = resampler.get_sample_from_bil_info(data)  # noqa
+        assert 'x' in res.dims
+        assert 'y' in res.dims
 
     @mock.patch('pyresample.bilinear.xarr.np.meshgrid')
     def test_get_slices(self, meshgrid):

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -732,6 +732,20 @@ class TestXarrayBilinear(unittest.TestCase):
         self.assertTrue(np.all(p_1 == 1.0) and np.all(p_2 == 1.0) and
                         np.all(p_3 == 1.0) and np.all(p_4 == 1.0))
 
+    def test_get_sample_from_bil_info_1d(self):
+        """Test resampling using resampling indices for 1D data."""
+        import dask.array as da
+        from xarray import DataArray
+        from pyresample.bilinear import XArrayBilinearResampler
+
+        resampler = XArrayBilinearResampler(self.source_def_1d, self.target_def,
+                                            self.radius)
+        resampler.get_bil_info()
+
+        # Sample from 1D data
+        data = DataArray(da.ones(self.source_def_1d.shape), dims=('y'))
+        res = resampler.get_sample_from_bil_info(data)  # noqa
+
     @mock.patch('pyresample.bilinear.xarr.np.meshgrid')
     def test_get_slices(self, meshgrid):
         """Test slice array creation."""

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -739,7 +739,7 @@ class TestXarrayBilinear(unittest.TestCase):
         from pyresample.bilinear import XArrayBilinearResampler
 
         resampler = XArrayBilinearResampler(self.source_def_1d, self.target_def,
-                                            self.radius)
+                                            50e5)
         resampler.get_bil_info()
 
         # Sample from 1D data
@@ -747,6 +747,9 @@ class TestXarrayBilinear(unittest.TestCase):
         res = resampler.get_sample_from_bil_info(data)  # noqa
         assert 'x' in res.dims
         assert 'y' in res.dims
+
+        # Four pixels are outside of the data
+        self.assertEqual(np.isnan(res).sum().compute(), 4)
 
     @mock.patch('pyresample.bilinear.xarr.np.meshgrid')
     def test_get_slices(self, meshgrid):

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -718,6 +718,7 @@ class TestXarrayBilinear(unittest.TestCase):
         """Test slicing 1D data."""
         import dask.array as da
         from xarray import DataArray
+
         from pyresample.bilinear import XArrayBilinearResampler
 
         resampler = XArrayBilinearResampler(self.source_def_1d, self.target_def,
@@ -736,6 +737,7 @@ class TestXarrayBilinear(unittest.TestCase):
         """Test resampling using resampling indices for 1D data."""
         import dask.array as da
         from xarray import DataArray
+
         from pyresample.bilinear import XArrayBilinearResampler
 
         resampler = XArrayBilinearResampler(self.source_def_1d, self.target_def,


### PR DESCRIPTION
Resampling of 1D data with the Numpy-based bilinear resampler got broken when I did the big refactoring with common base for Numpy and XArray resamplers. This PR will eventually allow 1D data to be resampled with both.

 - [x] Closes #316 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
