### PR TITLE
Fix coveralls reporting from github actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = True

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          pytest --cov=pyresample pyresample/test --cov-report=xml
+          pytest --cov=pyresample pyresample/test --cov-report=xml --cov-report=
 
       - name: Test website
         shell: bash -l {0}


### PR DESCRIPTION
Coveralls keeps reporting 0. It may be that it expects a certain file format to be generated. This PR is me figuring it out.
