### PR TITLE
Fix wrong varname in bucket doc

### DIFF
--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -51,7 +51,7 @@ class BucketResampler(object):
 
     Initialize the resampler
 
-    >>> resampler = BucketResampler(adef, lons, lats)
+    >>> resampler = BucketResampler(target_area, lons, lats)
 
     Calculate the sum of all the data in each grid location:
 


### PR DESCRIPTION
A simple fix of the wrong varname used in bucket doc.