### PR TITLE
Fix get_area_slices for flipped areas

### DIFF
--- a/docs/source/geometry_utils.rst
+++ b/docs/source/geometry_utils.rst
@@ -615,15 +615,17 @@ Converting Coordinates
 ----------------------
 
 The ``AreaDefinition`` have a few handy coordinate conversion methods available:
-* :meth:`~pyresample.geometry.AreaDefinition.get_array_coordinates_from_lonlat`
-* :meth:`~pyresample.geometry.AreaDefinition.get_array_coordinates_from_projection_coordinates`
-* :meth:`~pyresample.geometry.AreaDefinition.get_projection_coordinates_from_lonlat`
-* :meth:`~pyresample.geometry.AreaDefinition.get_lonlat_from_array_coordinates`
-* :meth:`~pyresample.geometry.AreaDefinition.get_lonlat_from_projection_coordinates`
-* :meth:`~pyresample.geometry.AreaDefinition.get_projection_coordinates_from_array_coordinates`
+
+- :meth:`~pyresample.geometry.AreaDefinition.get_array_coordinates_from_lonlat`
+- :meth:`~pyresample.geometry.AreaDefinition.get_array_coordinates_from_projection_coordinates`
+- :meth:`~pyresample.geometry.AreaDefinition.get_projection_coordinates_from_lonlat`
+- :meth:`~pyresample.geometry.AreaDefinition.get_lonlat_from_array_coordinates`
+- :meth:`~pyresample.geometry.AreaDefinition.get_lonlat_from_projection_coordinates`
+- :meth:`~pyresample.geometry.AreaDefinition.get_projection_coordinates_from_array_coordinates`
 
 And for backwards compatibility, we have two returning integers:
-* :meth:`~pyresample.geometry.AreaDefinition.get_array_indices_from_lonlat`
-* :meth:`~pyresample.geometry.AreaDefinition.get_array_indices_from_projection_coordinates`
+
+- :meth:`~pyresample.geometry.AreaDefinition.get_array_indices_from_lonlat`
+- :meth:`~pyresample.geometry.AreaDefinition.get_array_indices_from_projection_coordinates`
 
 These two raise a ``ValueError`` if the scalar input coordinates are oustide the extent of the area.

--- a/docs/source/geometry_utils.rst
+++ b/docs/source/geometry_utils.rst
@@ -551,7 +551,7 @@ Consider the following netCDF/CF file: ::
    // global attributes:
                 :Conventions = "CF-1.7"
 
-   } 
+   }
 
 The three call forms are:
 
@@ -580,7 +580,7 @@ This will look through the whole netCDF/CF file, and guess all information neede
 
    The CF convention allows that a single file defines several different `grid_mappings`. At present,
    the 3rd call form of ``load_cf_area()`` will raise a ``ValueError`` exception when this happens.
-   
+
    If you have several `grid_mappings` in your CF file, be specific which one you want to access with the 1st or 2nd call form.
 
 
@@ -609,3 +609,21 @@ variable and its coordinate axes.
 
 
 .. _CF: http://cfconventions.org/cf-conventions/cf-conventions.html
+
+
+Converting Coordinates
+----------------------
+
+The ``AreaDefinition`` have a few handy coordinate conversion methods available:
+* :meth:`~pyresample.geometry.AreaDefinition.get_array_coordinates_from_lonlat`
+* :meth:`~pyresample.geometry.AreaDefinition.get_array_coordinates_from_projection_coordinates`
+* :meth:`~pyresample.geometry.AreaDefinition.get_projection_coordinates_from_lonlat`
+* :meth:`~pyresample.geometry.AreaDefinition.get_lonlat_from_array_coordinates`
+* :meth:`~pyresample.geometry.AreaDefinition.get_lonlat_from_projection_coordinates`
+* :meth:`~pyresample.geometry.AreaDefinition.get_projection_coordinates_from_array_coordinates`
+
+And for backwards compatibility, we have two returning integers:
+* :meth:`~pyresample.geometry.AreaDefinition.get_array_indices_from_lonlat`
+* :meth:`~pyresample.geometry.AreaDefinition.get_array_indices_from_projection_coordinates`
+
+These two raise a ``ValueError`` if the scalar input coordinates are oustide the extent of the area.

--- a/docs/source/geometry_utils.rst
+++ b/docs/source/geometry_utils.rst
@@ -623,7 +623,7 @@ The ``AreaDefinition`` have a few handy coordinate conversion methods available:
 - :meth:`~pyresample.geometry.AreaDefinition.get_lonlat_from_projection_coordinates`
 - :meth:`~pyresample.geometry.AreaDefinition.get_projection_coordinates_from_array_coordinates`
 
-And for backwards compatibility, we have two returning integers:
+We also have two methods returning integers for array indices:
 
 - :meth:`~pyresample.geometry.AreaDefinition.get_array_indices_from_lonlat`
 - :meth:`~pyresample.geometry.AreaDefinition.get_array_indices_from_projection_coordinates`

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1646,7 +1646,7 @@ class AreaDefinition(_ProjectionDefinition):
         return the_hash
 
     @daskify_2in_2out
-    def get_array_coordinates_from_lonlat(self, lon, lat) -> (int, int):
+    def get_array_coordinates_from_lonlat(self, lon, lat):
         """Retrieve the array coordinates (float) for a given lon/lat.
 
         If lon,lat is a tuple of sequences of longitudes and latitudes, a tuple

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1616,7 +1616,7 @@ class AreaDefinition(BaseDefinition):
         lon : point or sequence (list or array) of longitudes
         lat : point or sequence (list or array) of latitudes
 
-        :Returns:
+        Returns:
 
         (x, y) : tuple of points/arrays
         """

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1694,7 +1694,7 @@ class AreaDefinition(BaseDefinition):
             if ((x__ < 0 or x__ >= self.width) or
                     (y__ < 0 or y__ >= self.height)):
                 raise ValueError('Point outside area:( %f %f)' % (x__, y__))
-            return int(x__), int(y__)
+            return x__, y__
 
     def get_lonlat(self, row, col):
         """Retrieve lon and lat values of single point in area grid.

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1667,7 +1667,7 @@ class AreaDefinition(_ProjectionDefinition):
     def get_array_coordinates_from_projection_coordinates(self, xm, ym):
         """Find the floating-point grid cell index for a specified projection coordinate.
 
-        If cols, rows is a tuple of sequences of projection coordinates, a tuple
+        If xm, ym is a tuple of sequences of projection coordinates, a tuple
         of arrays are returned.
 
         Args:
@@ -1721,8 +1721,8 @@ class AreaDefinition(_ProjectionDefinition):
     def get_array_indices_from_projection_coordinates(self, xm, ym):
         """Find the closest integer grid cell index for a specified projection coordinate.
 
-        If cols, rows is a point, a ValueError is raised if it is outside the area
-        domain. If cols, rows is a tuple of sequences of projection coordinates, a
+        If xm, ym is a point, a ValueError is raised if it is outside the area
+        domain. If xm, ym is a tuple of sequences of projection coordinates, a
         tuple of masked arrays are returned.
 
         Args:

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1790,7 +1790,7 @@ class AreaDefinition(_ProjectionDefinition):
     def get_xy_from_lonlat(self, lon, lat):
         """Retrieve closest x and y coordinates.
 
-        Retrieve x and y coordinates (column, row indices) for the
+        Retrieve the closest x and y coordinates (column, row indices) for the
         specified geolocation (lon,lat) if inside area. If lon,lat is a point a
         ValueError is raised if the return point is outside the area domain. If
         lon,lat is a tuple of sequences of longitudes and latitudes, a tuple of

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1862,7 +1862,7 @@ class AreaDefinition(_ProjectionDefinition):
     def get_xy_from_proj_coords(self, xm, ym):
         """Find closest grid cell index for a specified projection coordinate.
 
-        If cols, rows is a tuple of sequences of projection coordinates, a tuple
+        If xm, ym is a tuple of sequences of projection coordinates, a tuple
         of masked arrays are returned.
 
         Args:
@@ -2153,7 +2153,7 @@ class AreaDefinition(_ProjectionDefinition):
             ystart = max(0,  round(y[1]))
             ystop = min(self.height, round(y[0]) + 1)
 
-        return int(xstart), int(xstop), int(ystart), int(ystop)
+        return xstart, xstop, ystart, ystop
 
     def get_area_slices(self, area_to_cover, shape_divisible_by=None):
         """Compute the slice to read based on an `area_to_cover`."""
@@ -2193,8 +2193,8 @@ class AreaDefinition(_ProjectionDefinition):
             raise NotImplementedError
         x, y = self.get_xy_from_lonlat(np.rad2deg(intersection.lon),
                                        np.rad2deg(intersection.lat))
-        x_slice = slice(int(np.ma.min(x)), int(np.ma.max(x)) + 1)
-        y_slice = slice(int(np.ma.min(y)), int(np.ma.max(y)) + 1)
+        x_slice = slice(np.ma.min(x), np.ma.max(x) + 1)
+        y_slice = slice(np.ma.min(y), np.ma.max(y) + 1)
         if shape_divisible_by is not None:
             x_slice = _make_slice_divisible(x_slice, self.width,
                                             factor=shape_divisible_by)

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1843,9 +1843,8 @@ class AreaDefinition(_ProjectionDefinition):
         -------
         (lon, lat) : tuple of floats
         """
-        warnings.warn("'get_lonlat' is deprecated, please use "
-                      "'get_lonlat_from_array_coordinates' instead.", DeprecationWarning)
-        return self.get_lonlat_from_array_coordinates(row, col)
+        lon, lat = self.get_lonlats(nprocs=None, data_slice=(row, col))
+        return lon.item(), lat.item()
 
     @staticmethod
     def _do_rotation(xspan, yspan, rot_deg=0):

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1048,6 +1048,27 @@ class Test(unittest.TestCase):
         np.testing.assert_allclose(lons, lon)
         np.testing.assert_allclose(lats, lat)
 
+    def test_area_corners_around_south_pole(self):
+        """Test corner values for the ease-sh area."""
+        import numpy as np
+        from pyresample.geometry import AreaDefinition
+        area_id = 'ease_sh'
+        description = 'Antarctic EASE grid'
+        proj_id = 'ease_sh'
+        projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+        width = 425
+        height = 425
+        area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
+        area_def = AreaDefinition(area_id, description, proj_id, projection,
+                                  width, height, area_extent)
+
+        expected = [(-45.0, -17.713517415148853),
+                    (45.000000000000014, -17.71351741514884),
+                    (135.0, -17.713517415148825),
+                    (-135.00000000000003, -17.71351741514884)]
+        actual = [(np.rad2deg(coord.lon), np.rad2deg(coord.lat)) for coord in area_def.corners]
+        np.testing.assert_allclose(actual, expected)
+
     def test_get_xy_from_lonlat(self):
         """Test the function get_xy_from_lonlat."""
         from pyresample import utils

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -774,17 +774,17 @@ class Test(unittest.TestCase):
         # Imatra, Wiesbaden
         longitudes = np.array([28.75242, 8.24932])
         latitudes = np.array([61.17185, 50.08258])
-        cols__, rows__ = area.lonlat2colrow(longitudes, latitudes)
+        cols__, rows__ = area.get_array_indices_from_lonlat(longitudes, latitudes)
 
         # test arrays
         cols_expects = np.array([2304, 2040])
         rows_expects = np.array([186, 341])
-        self.assertTrue((cols__.astype(int) == cols_expects).all())
-        self.assertTrue((rows__.astype(int) == rows_expects).all())
+        np.testing.assert_array_equal(cols__, cols_expects)
+        np.testing.assert_array_equal(rows__, rows_expects)
 
         # test scalars
         lon, lat = (-8.125547604568746, -14.345524111874646)
-        self.assertTrue(area.lonlat2colrow(lon, lat) == (1567, 2375))
+        self.assertEqual(area.get_array_indices_from_lonlat(lon, lat), (1567, 2375))
 
     def test_colrow2lonlat(self):
         """Test colrow2lonlat."""
@@ -2640,14 +2640,14 @@ class TestAreaDefGetAreaSlices(unittest.TestCase):
                                   {'ellps': 'WGS84', 'h': '35785831', 'proj': 'geos'},
                                   100, 100,
                                   (5550000.0, 5550000.0, -5550000.0, -5550000.0))
-        expected_slice_lines = slice(60, 90)
+        expected_slice_lines = slice(60, 91)
         expected_slice_cols = slice(90, 100)
         cropped_area = src_area[expected_slice_lines, expected_slice_cols]
         slice_cols, slice_lines = src_area.get_area_slices(cropped_area)
         assert slice_lines == expected_slice_lines
         assert slice_cols == expected_slice_cols
 
-        expected_slice_cols = slice(30, 60)
+        expected_slice_cols = slice(30, 61)
         cropped_area = src_area[expected_slice_lines, expected_slice_cols]
         slice_cols, slice_lines = src_area.get_area_slices(cropped_area)
         assert slice_lines == expected_slice_lines

--- a/pyresample/utils/__init__.py
+++ b/pyresample/utils/__init__.py
@@ -21,7 +21,6 @@ try:
 except ImportError:
     from collections import Mapping
 import numpy as np
-import pyproj
 import warnings
 
 from .proj4 import (proj4_dict_to_str, proj4_str_to_dict, convert_proj_floats,  # noqa
@@ -31,32 +30,38 @@ from .cf import load_cf_area  # noqa
 
 
 def get_area_def(*args, **kwargs):
+    """Get an area definition."""
     from pyresample.area_config import get_area_def
-    warnings.warn("'get_area_def' has moved, import it with 'from pyresample import get_area_def'")
+    warnings.warn("'get_area_def' has moved, import it with 'from pyresample import get_area_def'", stacklevel=2)
     return get_area_def(*args, **kwargs)
 
 
 def create_area_def(*args, **kwargs):
+    """Create an area definition."""
     from pyresample.area_config import create_area_def
-    warnings.warn("'create_area_def' has moved, import it with 'from pyresample import create_area_def'")
+    warnings.warn("'create_area_def' has moved, import it with 'from pyresample import create_area_def'", stacklevel=2)
     return create_area_def(*args, **kwargs)
 
 
 def load_area(*args, **kwargs):
+    """Load an area."""
     from pyresample.area_config import load_area
-    warnings.warn("'load_area' has moved, import it with 'from pyresample import load_area'")
+    warnings.warn("'load_area' has moved, import it with 'from pyresample import load_area'", stacklevel=2)
     return load_area(*args, **kwargs)
 
 
 def convert_def_to_yaml(*args, **kwargs):
+    """Convert an area definition to yaml representation."""
     from pyresample.area_config import convert_def_to_yaml
-    warnings.warn("'convert_def_to_yaml' has moved, import it with 'from pyresample import convert_def_to_yaml'")
+    warnings.warn("'convert_def_to_yaml' has moved, import it with 'from pyresample import convert_def_to_yaml'",
+                  stacklevel=2)
     return convert_def_to_yaml(*args, **kwargs)
 
 
 def parse_area_file(*args, **kwargs):
+    """Parse an area file."""
     from pyresample.area_config import parse_area_file
-    warnings.warn("'parse_area_file' has moved, import it with 'from pyresample import parse_area_file'")
+    warnings.warn("'parse_area_file' has moved, import it with 'from pyresample import parse_area_file'", stacklevel=2)
     return parse_area_file(*args, **kwargs)
 
 
@@ -112,7 +117,6 @@ def generate_nearest_neighbour_linesample_arrays(source_area_def,
     -------
     (row_indices, col_indices) : tuple of numpy arrays
     """
-
     from pyresample.kd_tree import get_neighbour_info
     valid_input_index, valid_output_index, index_array, distance_array = \
         get_neighbour_info(source_area_def,
@@ -152,7 +156,7 @@ def generate_nearest_neighbour_linesample_arrays(source_area_def,
 
 
 def fwhm2sigma(fwhm):
-    """Calculate sigma for gauss function from FWHM (3 dB level)
+    """Calculate sigma for gauss function from FWHM (3 dB level).
 
     Parameters
     ----------
@@ -164,7 +168,6 @@ def fwhm2sigma(fwhm):
     sigma : float
         sigma for use in resampling gauss function
     """
-
     return fwhm / (2 * np.sqrt(np.log(2)))
 
 
@@ -178,7 +181,7 @@ def _downcast_index_array(index_array, size):
 
 
 def wrap_longitudes(lons):
-    """Wrap longitudes to the [-180:+180[ validity range (preserves dtype)
+    """Wrap longitudes to the [-180:+180[ validity range (preserves dtype).
 
     Parameters
     ----------
@@ -221,7 +224,7 @@ def check_and_wrap(lons, lats):
 
 
 def recursive_dict_update(d, u):
-    """Recursive dictionary update using
+    """Update dictionary recursively.
 
     Copied from:
 


### PR DESCRIPTION
Flipped areas didn't play well with get_area_slices. This PR takes care of it.

This also makes get_xy_from_proj_coords and get_xy_from_lonlats return floats instead of ints, which I think makes more sense. The user can then choose what to do with the results.

<!-- Please make the PR against the `master` branch. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
