### PR TITLE
Fix DynamicAreaDefinition not handling lons over antimeridian

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -967,13 +967,13 @@ class DynamicAreaDefinition(object):
         shape = None if None in shape else shape
         area_extent = self.area_extent
         if not area_extent or not width or not height:
-            corners = self._compute_corners(proj_dict, lonslats)
+            corners = self._compute_bound_centers(proj_dict, lonslats)
             area_extent, width, height = self.compute_domain(corners, resolution, shape)
         return AreaDefinition(self.area_id, self.description, '',
                               projection, width, height,
                               area_extent, self.rotation)
 
-    def _compute_corners(self, proj_dict, lonslats):
+    def _compute_bound_centers(self, proj_dict, lonslats):
         proj4 = Proj(proj_dict)
         lons, lats = self._extract_lons_lats(lonslats)
         # TODO: Do more dask-friendly things here

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -838,7 +838,8 @@ class DynamicAreaDefinition(object):
         pixel_size_y:
             Pixel height in projection units
         resolution:
-            Resolution of the resulting area as (pixel_size_x, pixel_size_y) or a scalar if pixel_size_x == pixel_size_y.
+            Resolution of the resulting area as (pixel_size_x, pixel_size_y)
+            or a scalar if pixel_size_x == pixel_size_y.
         optimize_projection:
             Whether the projection parameters have to be optimized.
         rotation:

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -976,8 +976,8 @@ class DynamicAreaDefinition(object):
         xmax = np.nanmax(xarr)
         ymin = np.nanmin(yarr)
         ymax = np.nanmax(yarr)
+        x_passes_antimeridian = (xmax - xmin) > 355
         epsilon = 0.1
-        x_passes_antimeridian = (xmax - xmin) > 360 - epsilon
         y_is_pole = (ymax >= 90 - epsilon) or (ymin <= -90 + epsilon)
         if proj4.crs.is_geographic and x_passes_antimeridian and not y_is_pole:
             # cross anti-meridian of projection

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -816,6 +816,14 @@ class DynamicAreaDefinition(object):
     of the area to a given set of longitudes and latitudes, such that e.g.
     polar satellite granules can be resampled optimally to a given projection.
 
+    Note that if the provided projection is geographic (lon/lat degrees) and
+    the provided longitude and latitude data crosses the anti-meridian
+    (-180/180), the resulting area will be the smallest possible in order to
+    contain that data and avoid a large area spanning from -180 to 180
+    longitude. This means the resulting AreaDefinition will have a right-most
+    X extent greater than 180 degrees. This does not apply to data crossing
+    the north or south pole as there is no "smallest" area in this case.
+
     Attributes:
         area_id:
             The name of the area.

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2328,6 +2328,36 @@ class TestDynamicAreaDefinition:
         assert result.width == 395
         assert result.height == 539
 
+    @pytest.mark.parametrize(
+        ('lats',),
+        [
+            (np.linspace(-25.0, -10.0, 10),),
+            (np.linspace(10.0, 25.0, 10),),
+            (np.linspace(75, 90.0, 10),),
+            (np.linspace(-75, -90.0, 10),),
+        ],
+    )
+    def test_freeze_longlat_antimeridian(self, lats):
+        """Test geographic areas over the antimeridian."""
+        area = geometry.DynamicAreaDefinition('test_area', 'A test area',
+                                              'EPSG:4326')
+        lons = np.linspace(175, 185, 10)
+        lons[lons > 180] -= 360
+        result = area.freeze((lons, lats),
+                             resolution=0.0056)
+
+        is_pole = (np.abs(lats) > 88).any()
+        extent = result.area_extent
+        if is_pole:
+            assert extent[0] < -178
+            assert extent[2] > 178
+            assert result.width == 64088
+        else:
+            assert extent[0] > 0
+            assert extent[2] > 0
+            assert result.width == 1787
+        assert result.height == 2680
+
     def test_freeze_with_bb(self):
         """Test freezing the area with bounding box computation."""
         area = geometry.DynamicAreaDefinition('test_area', 'A test area', {'proj': 'omerc'},

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2291,7 +2291,7 @@ def _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks):
     np.testing.assert_array_equal(lats, lats_c)
 
 
-class TestDynamicAreaDefinition(unittest.TestCase):
+class TestDynamicAreaDefinition:
     """Test the DynamicAreaDefinition class."""
 
     def test_freeze(self):
@@ -2308,10 +2308,10 @@ class TestDynamicAreaDefinition(unittest.TestCase):
                                                         -872594.690447,
                                                         432079.38952,
                                                         904633.303964))
-        self.assertEqual(result.proj_dict['lon_0'], 16)
-        self.assertEqual(result.proj_dict['lat_0'], 58)
-        self.assertEqual(result.width, 288)
-        self.assertEqual(result.height, 592)
+        assert result.proj_dict['lon_0'] == 16
+        assert result.proj_dict['lat_0'] == 58
+        assert result.width == 288
+        assert result.height == 592
 
         # make sure that setting `proj_info` once doesn't
         # set it in the dynamic area
@@ -2322,11 +2322,11 @@ class TestDynamicAreaDefinition(unittest.TestCase):
                                                         5380808.879250369,
                                                         1724415.6519203288,
                                                         6998895.701001488))
-        self.assertEqual(result.proj_dict['lon_0'], 0)
+        assert result.proj_dict['lon_0'] == 0
         # lat_0 could be provided or not depending on version of pyproj
-        self.assertEqual(result.proj_dict.get('lat_0', 0), 0)
-        self.assertEqual(result.width, 395)
-        self.assertEqual(result.height, 539)
+        assert result.proj_dict.get('lat_0', 0) == 0
+        assert result.width == 395
+        assert result.height == 539
 
     def test_freeze_with_bb(self):
         """Test freezing the area with bounding box computation."""
@@ -2345,36 +2345,36 @@ class TestDynamicAreaDefinition(unittest.TestCase):
                                    [-335439.956533, 5502125.451125,
                                     191991.313351, 7737532.343683])
 
-        self.assertEqual(result.width, 4)
-        self.assertEqual(result.height, 18)
+        assert result.width == 4
+        assert result.height == 18
         # Test for properties and shape usage in freeze.
         area = geometry.DynamicAreaDefinition('test_area', 'A test area', {'proj': 'merc'},
                                               width=4, height=18)
-        self.assertEqual((18, 4), area.shape)
+        assert (18, 4) == area.shape
         result = area.freeze(sdef)
         np.testing.assert_allclose(result.area_extent,
                                    (996309.4426, 6287132.757981, 1931393.165263, 10837238.860543))
         area = geometry.DynamicAreaDefinition('test_area', 'A test area', {'proj': 'merc'},
                                               resolution=1000)
-        self.assertEqual(1000, area.pixel_size_x)
-        self.assertEqual(1000, area.pixel_size_y)
+        assert 1000 == area.pixel_size_x
+        assert 1000 == area.pixel_size_y
 
     def test_compute_domain(self):
         """Test computing size and area extent."""
         area = geometry.DynamicAreaDefinition('test_area', 'A test area',
                                               {'proj': 'laea'})
         corners = [1, 1, 9, 9]
-        self.assertRaises(ValueError, area.compute_domain, corners, 1, 1)
+        pytest.raises(ValueError, area.compute_domain, corners, 1, 1)
 
         area_extent, x_size, y_size = area.compute_domain(corners, shape=(5, 5))
-        self.assertTupleEqual(area_extent, (0, 0, 10, 10))
-        self.assertEqual(x_size, 5)
-        self.assertEqual(y_size, 5)
+        assert area_extent == (0, 0, 10, 10)
+        assert x_size == 5
+        assert y_size == 5
 
         area_extent, x_size, y_size = area.compute_domain(corners, resolution=2)
-        self.assertTupleEqual(area_extent, (0, 0, 10, 10))
-        self.assertEqual(x_size, 5)
-        self.assertEqual(y_size, 5)
+        assert area_extent == (0, 0, 10, 10)
+        assert x_size == 5
+        assert y_size == 5
 
 
 class TestCrop(unittest.TestCase):


### PR DESCRIPTION
I had some swath data that crossed over the anti-meridian (-180/180) and when I pass these to a DynamicAreaDefinition with a latlong projection, the result goes around the whole projection (from -180 to 180). My fix checks if we cross the anti-meridian and recalculates the extents of the area so we produce the smallest area possible. It only does this if we aren't going over the poles. So if we original calculate that xmin/xmax is -179.9/179.9, then we recalculate to produce something like 165.0/225.0.

I'm torn on whether or not my fix should be added; either as-is, not at all, or with an extra keyword argument to allow it. On one hand, a projection like `+proj=longlat +datum=WGS84` (your basic EPSG:4326) is defined from -180 to 180 degrees longitude. In my opinion, a coordinate reference system doesn't just wrap around. You should only be able to have your X coordinates be monotonic increasing and only be in the defined space of the CRS (-180/180). On the other hand, this isn't something easy for a user to check themselves and produce the area that they want. Usability-wise, it is annoying that going over the anti-meridian would produce this huge output AreaDefinition.

Another solution/option would be to have a keyword argument that let's the DynamicAreaDefinition change `+proj=longlat +datum=WGS84` to `+proj=longlat +pm=180 +ellps=WGS84` (I think this is valid). This would mean that we could essentially use longitudes from 0 to 360 *but* this is now not a valid EPSG:4326 CRS and would therefore not meet some users standards/expectations.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
