### PR TITLE
Fix EWA resampling when the result is all fill values

### DIFF
--- a/pyresample/ewa/dask_ewa.py
+++ b/pyresample/ewa/dask_ewa.py
@@ -150,7 +150,9 @@ def _average_fornav(x_chunk, axis, keepdims, computing_meta=False, dtype=None,
     # if we have only "empty" arrays at this point then the target chunk
     # has no valid input data in it.
     if isinstance(res[0], tuple):
-        return np.full(res[0], fill_value, dtype)
+        # res is (weights_info, accums_info)
+        # weights_info is (shape, fill, dtype)
+        return np.full(res[0][0], fill_value, dtype)
     weights, accums = res
     out = np.full(weights.shape, fill_value, dtype=dtype)
     write_grid_image_single(out, weights, accums, fill_value,

--- a/pyresample/test/test_dask_ewa.py
+++ b/pyresample/test/test_dask_ewa.py
@@ -239,9 +239,8 @@ class TestDaskEWAResampler:
     )
     @pytest.mark.parametrize('input_dtype', [np.float32, np.float64, np.int8])
     @pytest.mark.parametrize('maximum_weight_mode', [False, True])
-    def test_xarray_ewa_empty(self,
-                              input_chunks, input_shape, input_dims, input_dtype,
-                              maximum_weight_mode):
+    def test_xarray_ewa_empty(self, input_chunks, input_shape, input_dims,
+                              input_dtype, maximum_weight_mode):
         """Test EWA with basic xarray DataArrays."""
         # projection that should result in no output pixels
         output_proj = ('+proj=lcc +datum=WGS84 +ellps=WGS84 '
@@ -257,17 +256,15 @@ class TestDaskEWAResampler:
             output_proj=output_proj
         )
 
-        with mock.patch.object(dask_ewa, 'll2cr', wraps=dask_ewa.ll2cr) as ll2cr, \
-                mock.patch.object(source_swath, 'get_lonlats', wraps=source_swath.get_lonlats) as get_lonlats:
-            resampler = DaskEWAResampler(source_swath, target_area)
-            new_data = resampler.resample(swath_data, rows_per_scan=10,
-                                          maximum_weight_mode=maximum_weight_mode)
-            _data_attrs_coords_checks(new_data, output_shape, input_dtype, target_area,
-                                      'test', 'test')
-            # make sure we can actually compute everything
-            computed_data = new_data.compute()
-            fill_value = 127 if np.issubdtype(input_dtype, np.integer) else np.nan
-            np.testing.assert_array_equal(computed_data, fill_value)
+        resampler = DaskEWAResampler(source_swath, target_area)
+        new_data = resampler.resample(swath_data, rows_per_scan=10,
+                                      maximum_weight_mode=maximum_weight_mode)
+        _data_attrs_coords_checks(new_data, output_shape, input_dtype, target_area,
+                                  'test', 'test')
+        # make sure we can actually compute everything
+        computed_data = new_data.compute()
+        fill_value = 127 if np.issubdtype(input_dtype, np.integer) else np.nan
+        np.testing.assert_array_equal(computed_data, fill_value)
 
     @pytest.mark.parametrize(
         ('input_shape', 'input_dims', 'maximum_weight_mode'),

--- a/pyresample/test/test_dask_ewa.py
+++ b/pyresample/test/test_dask_ewa.py
@@ -241,7 +241,7 @@ class TestDaskEWAResampler:
     @pytest.mark.parametrize('maximum_weight_mode', [False, True])
     def test_xarray_ewa_empty(self, input_chunks, input_shape, input_dims,
                               input_dtype, maximum_weight_mode):
-        """Test EWA with basic xarray DataArrays."""
+        """Test EWA with xarray DataArrays where the result is all fills."""
         # projection that should result in no output pixels
         output_proj = ('+proj=lcc +datum=WGS84 +ellps=WGS84 '
                        '+lon_0=-55. +lat_0=25 +lat_1=25 +units=m +no_defs')


### PR DESCRIPTION
This was a bug I discovered at the same time I found #342, but had a really difficult time reproducing. The main piece of code that is effected is *only* called when dask determines that it should call the "aggregate" function of the reduction with a specific result from the previous "combination" calls. I was able to force this by making the input one single chunk.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

