### PR TITLE
Allow rows_per_scan=0 convenience in EWA resampler

### DIFF
--- a/docs/source/swath.rst
+++ b/docs/source/swath.rst
@@ -521,6 +521,13 @@ an xarray DataArray object.
     rows_per_scan = 5
     result = resampler.resample(data, rows_per_scan=rows_per_scan)
 
+.. note::
+
+    As a convenience, you can set rows_per_scan to 0 to have it set to the
+    number of rows in the input data. This can be helpful when testing EWA
+    on data that is not necessarily scan based, but still has nice results
+    with EWA.
+
 Legacy Dask Resampler
 *********************
 

--- a/pyresample/ewa/dask_ewa.py
+++ b/pyresample/ewa/dask_ewa.py
@@ -214,6 +214,8 @@ class DaskEWAResampler(BaseResampler):
             raise ValueError("'rows_per_scan' keyword argument required if "
                              "not found in geolocation (i.e. "
                              "DataArray.attrs['rows_per_scan']).")
+        if rows_per_scan == 0:
+            rows_per_scan = self.source_geo_def.shape[0]
         return rows_per_scan
 
     def _fill_block_cache_with_ll2cr_results(self, ll2cr_result,
@@ -472,7 +474,8 @@ class DaskEWAResampler(BaseResampler):
                 is checked for this value if they are DataArray objects.
                 Otherwise, this value must be provided. Decent results may be
                 possible if this value is set to the total number of rows in
-                the array.
+                the array. As a convenience, providing ``0`` will result in
+                the total number of rows being used.
             persist (bool): Whether to persist (as in dask) the computations
                 during precompute or compute them on the fly during compute.
                 Persisting allows the resampler to determine which input


### PR DESCRIPTION
This sets rows_per_scan to the number of rows in the input data. In my original development of the EWA algorithm in pyresample I made it so if you didn't specify rows_per_scan it would default to the total number of rows in the input data. This means EWA treats the data as one large scan line. This is not how the algorithm is really meant to work, but it seems to produce decent results in some cases. As I rewrote the EWA algorithm to be more dask-friendly, I didn't like this implicit "magic" setting of the parameter when there may be a more optimal value if only the user knew about it. So I made the choice in previous PRs to require the rows_per_scan if the value couldn't be pulled from a `DataArray`s `.attrs` (and it wasn't specified by the user).

This is fine, except it turns out there are a lot of use cases in my CSPP Polar2Grid project where non-scan-based data is used with EWA resampling and produces perfectly fine results. In those cases it would be nice to say "rows_per_scan=<num rows in data>". This PR solves that by making `rows_per_scan=0` automatically replace 0 with the number of rows in the data. This means that `None` will still fail if the rows_per_scan is not provided in the `.attrs` of the data, but provides an easily configurable option of `rows_per_scan=0`.

FYI @joleenf

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
