### PR TITLE
Fix test-pypi deploy failing during actual deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -98,6 +98,7 @@ jobs:
           name: wheels
           path: dist
       - name: Publish package to PyPI
+        if: github.event.action != 'published'
         uses: pypa/gh-action-pypi-publish@v1.4.1
         with:
           user: __token__

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 ignore:
-  - "satpy/version.py"
+  - "pyresample/version.py"
   - "versioneer.py"


### PR DESCRIPTION
The deploy workflow runs for tags and for github releases. The job that deploys to the main PyPI is only run on github releases ("published" events). The test-pypi upload however runs for both tags and releases. This means that it always fails when we do a git tag followed by a github release as test-pypi doesn't like that we are trying to upload a package that already exists.

This PR should fix that, but I don't have a good way to test it without actually making a release.
