### PR TITLE
Add `get_min` and `get_max` to Bucket resampler (experimental)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -251,6 +251,7 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'xarray': ('https://xarray.pydata.org/en/stable', None),
     'dask': ('https://docs.dask.org/en/latest', None),
+    'pandas': ('https://pandas.pydata.org/docs', None),
     'pyresample': ('https://pyresample.readthedocs.io/en/stable', None),
     'trollsift': ('https://trollsift.readthedocs.io/en/stable', None),
     'trollimage': ('https://trollimage.readthedocs.io/en/stable', None),

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -190,7 +190,7 @@ class BucketResampler(object):
             statistic = da.where(nan_bins > 0, np.nan, statistic)
         return statistic
 
-    def _call_scipy_binned_statistics(self, scipy_method, data, fill_value=None, skipna=None):
+    def _call_pandas_groupby_statistics(self, scipy_method, data, fill_value=None, skipna=None):
         """Calculate statistics (min/max) for each bin with drop-in-a-bucket resampling."""
         import dask.dataframe as dd
         import pandas as pd
@@ -244,6 +244,12 @@ class BucketResampler(object):
     def get_min(self, data, fill_value=np.nan, skipna=True):
         """Calculate minimums for each bin with drop-in-a-bucket resampling.
 
+        .. warning::
+
+            The slow :func:`~pyresample.bucket.BucketResampler._call_pandas_groupby_statistics`
+            method is temporarily used here,
+            as the `dask_groupby <https://github.com/dcherian/dask_groupby>`_ is still under development.
+
         Parameters
         ----------
         data : Numpy or Dask array
@@ -262,10 +268,16 @@ class BucketResampler(object):
             Bin-wise minimums in the target grid
         """
         LOG.info("Get min of values in each location")
-        return self._call_scipy_binned_statistics('min', data, fill_value, skipna)
+        return self._call_pandas_groupby_statistics('min', data, fill_value, skipna)
 
     def get_max(self, data, fill_value=np.nan, skipna=True):
         """Calculate maximums for each bin with drop-in-a-bucket resampling.
+
+        .. warning::
+
+            The slow :func:`~pyresample.bucket.BucketResampler._call_pandas_groupby_statistics`
+            method is temporarily used here,
+            as the `dask_groupby <https://github.com/dcherian/dask_groupby>`_ is still under development.
 
         Parameters
         ----------
@@ -285,7 +297,7 @@ class BucketResampler(object):
             Bin-wise maximums in the target grid
         """
         LOG.info("Get max of values in each location")
-        return self._call_scipy_binned_statistics('max', data, fill_value, skipna)
+        return self._call_pandas_groupby_statistics('max', data, fill_value, skipna)
 
     def get_count(self):
         """Count the number of occurrences for each bin using drop-in-a-bucket

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -246,8 +246,7 @@ class BucketResampler(object):
 
         .. warning::
 
-            The slow :func:`~pyresample.bucket.BucketResampler._call_pandas_groupby_statistics`
-            method is temporarily used here,
+            The slow :meth:`pandas.DataFrame.groupby` method is temporarily used here,
             as the `dask_groupby <https://github.com/dcherian/dask_groupby>`_ is still under development.
 
         Parameters
@@ -275,8 +274,7 @@ class BucketResampler(object):
 
         .. warning::
 
-            The slow :func:`~pyresample.bucket.BucketResampler._call_pandas_groupby_statistics`
-            method is temporarily used here,
+            The slow :meth:`pandas.DataFrame.groupby` method is temporarily used here,
             as the `dask_groupby <https://github.com/dcherian/dask_groupby>`_ is still under development.
 
         Parameters

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -170,7 +170,7 @@ class Test(unittest.TestCase):
 
     def _get_min_result(self, data, **kwargs):
         """Compute the bucket average with kwargs and check that no dask computation is performed."""
-        with dask.config.set(scheduler=CustomScheduler(max_computes=3)):
+        with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
             result = self.resampler.get_min(data, **kwargs)
         return result.compute()
 
@@ -188,7 +188,7 @@ class Test(unittest.TestCase):
 
     def _get_max_result(self, data, **kwargs):
         """Compute the bucket average with kwargs and check that no dask computation is performed."""
-        with dask.config.set(scheduler=CustomScheduler(max_computes=3)):
+        with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
             result = self.resampler.get_max(data, **kwargs)
         return result.compute()
 


### PR DESCRIPTION
This PR adds two functions to Bucket: `get_min` and `get_max`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
