### PR TITLE
Fix handling of geostationary x/y units in CF conversion

### DIFF
--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -610,12 +610,13 @@ def _prepare_cf_goes():
     area_id = 'GOES-East'
     description = '2km at nadir'
     proj_id = 'abi_fixed_grid'
-    projection = {'ellps': 'GRS80', 'h': '35786023', 'lon_0': '-75', 'no_defs': 'None',
+    h = 35786023
+    projection = {'ellps': 'GRS80', 'h': h, 'lon_0': '-75', 'no_defs': 'None',
                   'proj': 'geos', 'sweep': 'x', 'type': 'crs',
                   'units': 'm', 'x_0': '0', 'y_0': '0'}
     width = 2500
     height = 1500
-    area_extent = (-3627271.2913, 1583173.6575, 1382771.9287, 4589199.5895)
+    area_extent = (-3627271.2913/h, 1583173.6575/h, 1382771.9287/h, 4589199.5895/h)
     goes_area = AreaDefinition(area_id, description, proj_id, projection,
                                width, height, area_extent)
     x = np.linspace(goes_area.area_extent[0], goes_area.area_extent[2], goes_area.shape[1])
@@ -624,9 +625,9 @@ def _prepare_cf_goes():
                              {'grid_mapping': 'GOES-East'})},
                     coords={'y': y, 'x': x})
 
-    ds['x'].attrs['units'] = 'm'
+    ds['x'].attrs['units'] = 'radians'
     ds['x'].attrs['standard_name'] = 'projection_x_coordinate'
-    ds['y'].attrs['units'] = 'm'
+    ds['y'].attrs['units'] = 'radians'
     ds['y'].attrs['standard_name'] = 'projection_y_coordinate'
 
     ds['GOES-East'] = 0

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -619,7 +619,7 @@ def _prepare_cf_goes():
     goes_area = AreaDefinition(area_id, description, proj_id, projection,
                                width, height, area_extent)
     x = np.linspace(goes_area.area_extent[0], goes_area.area_extent[2], goes_area.shape[1])
-    y = np.linspace(goes_area.area_extent[1], goes_area.area_extent[3], goes_area.shape[0])
+    y = np.linspace(goes_area.area_extent[3], goes_area.area_extent[1], goes_area.shape[0])
     ds = xr.Dataset({'C13': (('y', 'x'), np.ma.masked_all((height, width)),
                              {'grid_mapping': 'GOES-East'})},
                     coords={'y': y, 'x': x})
@@ -785,9 +785,9 @@ class TestLoadCFArea_Public(unittest.TestCase):
             self.assertEqual(cf_info['grid_mapping_variable'], 'GOES-East')
             self.assertEqual(cf_info['type_of_grid_mapping'], 'geostationary')
             self.assertEqual(cf_info['x']['varname'], 'x')
-            self.assertEqual(cf_info['x']['first'], -129805613857701.5)
+            self.assertEqual(cf_info['x']['first'], -3627271.2913)
             self.assertEqual(cf_info['y']['varname'], 'y')
-            self.assertEqual(cf_info['y']['last'], 164229202061437.56)
+            self.assertEqual(cf_info['y']['last'], 1583173.6575)
 
         # prepare xarray Dataset
         cf_file = _prepare_cf_goes()

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -781,7 +781,7 @@ class TestLoadCFArea_Public(unittest.TestCase):
     def test_load_cf_goes(self):
         from pyresample.utils import load_cf_area
 
-        def validate_goes(adef, cfinfo, y='y', x='x'):
+        def validate_goes(adef, cfinfo):
             # test some of the fields
             self.assertEqual(cf_info['grid_mapping_variable'], 'GOES-East')
             self.assertEqual(cf_info['type_of_grid_mapping'], 'geostationary')

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -793,10 +793,6 @@ class TestLoadCFArea_Public(unittest.TestCase):
         # prepare xarray Dataset
         cf_file = _prepare_cf_goes()
 
-        # load using a variable= that is a valid grid_mapping container
-        adef, cf_info = load_cf_area(cf_file)
-        validate_goes(adef, cf_info, y=None, x=None)
-
         # load using a variable=temp
         adef, cf_info = load_cf_area(cf_file, 'C13')
         validate_goes(adef, cf_info)

--- a/pyresample/utils/cf.py
+++ b/pyresample/utils/cf.py
@@ -64,7 +64,7 @@ _valid_cf_coordinate_standardnames['geostationary']['y'] = (
 def _convert_XY_CF_to_Proj(crs, axis_info):
     """Convert XY values from CF to PROJ convention. With CF =< 1.9 only affects geostrationary projection."""
     crs_dict = crs.to_dict()
-    if crs_dict['proj'] == 'geos' and crs_dict.get('units', 'meters') in ['radians', 'rads']:
+    if axis_info.get('unit') or 'radians' == 'radians':
         # for geostationary projection, the values stored as x/y in CF are not directly
         #  the x/y along the projection axes, but are rather the scanning angles from
         #  the satellite. We must multiply them by the height of the satellite.

--- a/pyresample/utils/cf.py
+++ b/pyresample/utils/cf.py
@@ -72,7 +72,7 @@ def _convert_XY_CF_to_Proj(crs, axis_info):
         for k in ('first', 'last', 'spacing'):
             axis_info[k] *= satellite_height
         # the unit is now the default (meters)
-        axis_info['units'] = 'meters'
+        axis_info['units'] = 'm'
 
     return axis_info
 

--- a/pyresample/utils/cf.py
+++ b/pyresample/utils/cf.py
@@ -64,7 +64,7 @@ _valid_cf_coordinate_standardnames['geostationary']['y'] = (
 def _convert_XY_CF_to_Proj(crs, axis_info):
     """Convert XY values from CF to PROJ convention. With CF =< 1.9 only affects geostrationary projection."""
     crs_dict = crs.to_dict()
-    if crs_dict['proj'] == 'geos':
+    if crs_dict['proj'] == 'geos' and crs_dict.get('units', 'meters') in ['radians', 'rads']:
         # for geostationary projection, the values stored as x/y in CF are not directly
         #  the x/y along the projection axes, but are rather the scanning angles from
         #  the satellite. We must multiply them by the height of the satellite.
@@ -72,7 +72,7 @@ def _convert_XY_CF_to_Proj(crs, axis_info):
         for k in ('first', 'last', 'spacing'):
             axis_info[k] *= satellite_height
         # the unit is now the default (meters)
-        axis_info['units'] = None
+        axis_info['units'] = 'meters'
 
     return axis_info
 

--- a/pyresample/utils/cf.py
+++ b/pyresample/utils/cf.py
@@ -64,7 +64,7 @@ _valid_cf_coordinate_standardnames['geostationary']['y'] = (
 def _convert_XY_CF_to_Proj(crs, axis_info):
     """Convert XY values from CF to PROJ convention. With CF =< 1.9 only affects geostrationary projection."""
     crs_dict = crs.to_dict()
-    if axis_info.get('unit') or 'radians' == 'radians':
+    if (crs_dict['proj'] == 'geos') and (axis_info.get('unit') or 'radians' == 'radians'):
         # for geostationary projection, the values stored as x/y in CF are not directly
         #  the x/y along the projection axes, but are rather the scanning angles from
         #  the satellite. We must multiply them by the height of the satellite.


### PR DESCRIPTION
The geostationary projections can be radians, microradians or meters. We need to handle these in `_convert_XY_CF_to_Proj`.

 - [ ] Closes #355, [satpy issue 1688](https://github.com/pytroll/satpy/issues/1688)
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
