### PR TITLE
Fix version number not being preserved in wheels

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -77,6 +77,14 @@ jobs:
             quay.io/pypa/${{ matrix.docker-image }} \
             /io/continuous_integration/build-manylinux-wheels.sh
 
+      - name: Check version number from inside wheel
+        if:  matrix.docker-image != 'manylinux1_i686'
+        run: |
+          mv pyresample unused_src_to_prevent_local_import
+          python -m pip install --find-links=./dist/ pyresample
+          python -c "import pyresample; print(pyresample.__file__, pyresample.__version__)"
+          python -c "import pyresample; assert 'unknown' not in pyresample.__version__, 'incorrect version found'"
+
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ max-line-length = 120
 VCS = git
 style = pep440
 versionfile_source = pyresample/version.py
-versionfile_build =
+versionfile_build = pyresample/version.py
 tag_prefix = v
 
 [coverage:run]


### PR DESCRIPTION
Make sure that the wheel distributions include the versioneer details correctly. 

 - [x] Closes #361  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added - added test in deploy to install and check internal version
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented 
       N/A ?


Tests for this need to be local for now, 
```bash
python -m build -w
pip install dist/pyresample*.whl
python -c "import pyresample; print(pyresample.__version__)"
```

