### PR TITLE
Fix dask ewa issues with newer versions of dask

### DIFF
--- a/pyresample/ewa/dask_ewa.py
+++ b/pyresample/ewa/dask_ewa.py
@@ -53,8 +53,12 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def _call_ll2cr(lons, lats, target_geo_def):
+def _call_ll2cr(lons, lats, target_geo_def, computing_meta=False):
     """Wrap ll2cr() for handling dask delayed calls better."""
+    if computing_meta:
+        # produce a representative meta array in the best case
+        # avoids errors when we return our "empty" tuples below
+        return np.zeros((2, *lons.shape), dtype=lons.dtype)
     new_src = SwathDefinition(lons, lats)
     swath_points_in_grid, cols, rows = ll2cr(new_src, target_geo_def)
     if swath_points_in_grid == 0:
@@ -107,7 +111,8 @@ def _chunk_callable(x_chunk, axis, keepdims, **kwargs):
 
 def _combine_fornav(x_chunk, axis, keepdims, computing_meta=False,
                     maximum_weight_mode=False):
-    if isinstance(x_chunk, tuple) and len(x_chunk) == 2 and isinstance(x_chunk[0], tuple):
+    is_empty_chunk = isinstance(x_chunk, tuple) and len(x_chunk) == 2 and isinstance(x_chunk[0], tuple)
+    if computing_meta or is_empty_chunk:
         # single "empty" chunk
         return x_chunk
     if not isinstance(x_chunk, list):

--- a/pyresample/ewa/dask_ewa.py
+++ b/pyresample/ewa/dask_ewa.py
@@ -111,8 +111,7 @@ def _chunk_callable(x_chunk, axis, keepdims, **kwargs):
 
 def _combine_fornav(x_chunk, axis, keepdims, computing_meta=False,
                     maximum_weight_mode=False):
-    is_empty_chunk = isinstance(x_chunk, tuple) and len(x_chunk) == 2 and isinstance(x_chunk[0], tuple)
-    if computing_meta or is_empty_chunk:
+    if computing_meta or _is_empty_chunk(x_chunk):
         # single "empty" chunk
         return x_chunk
     if not isinstance(x_chunk, list):
@@ -141,6 +140,10 @@ def _combine_fornav(x_chunk, axis, keepdims, computing_meta=False,
     # NOTE: We use the builtin "sum" function below because it does not copy
     #       the numpy arrays. Using numpy.sum would do that.
     return sum(weights), sum(accums)
+
+
+def _is_empty_chunk(x_chunk):
+    return isinstance(x_chunk, tuple) and len(x_chunk) == 2 and isinstance(x_chunk[0], tuple)
 
 
 def _average_fornav(x_chunk, axis, keepdims, computing_meta=False, dtype=None,


### PR DESCRIPTION
As mentioned in #368, tests are now failing with newer versions of dask. The root cause is that dask now accepts/understands receiving a tuple when computing "meta" information. This PR fixes this by explicitly detecting when meta calculations are being done and returning a specific result so dask knows what it is doing.

Since the existing tests were failing, no addiitional tests should be needed.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
