### PR TITLE
Update EWA ll2cr_static to handle swaths crossing the anti-meridian.

### DIFF
--- a/pyresample/ewa/_ll2cr.pyx
+++ b/pyresample/ewa/_ll2cr.pyx
@@ -232,7 +232,6 @@ def ll2cr_static(numpy.ndarray[cr_dtype, ndim=2] lon_arr, numpy.ndarray[cr_dtype
     cdef tuple projected_tuple = p(lon_arr, lat_arr)
     cdef cr_dtype [:, ::1] rows_out = projected_tuple[1]
     cdef cr_dtype [:, ::1] cols_out = projected_tuple[0]
-    cdef double proj_circum = projection_circumference(p)
 
     # indexes
     cdef unsigned int row
@@ -252,9 +251,6 @@ def ll2cr_static(numpy.ndarray[cr_dtype, ndim=2] lon_arr, numpy.ndarray[cr_dtype
                 lon_arr[row, col] = fill_in
                 lat_arr[row, col] = fill_in
                 continue
-            elif proj_circum != 0 and abs(x_tmp - origin_x) >= (0.75 * proj_circum):
-                # if x is more than 75% around the projection space, it is probably crossing the anti-meridian
-                x_tmp += proj_circum
 
             x_tmp = (x_tmp - origin_x) / cell_width
             y_tmp = (y_tmp - origin_y) / cell_height

--- a/pyresample/test/test_ewa_ll2cr.py
+++ b/pyresample/test/test_ewa_ll2cr.py
@@ -50,6 +50,17 @@ static_lcc = {
     "proj4_definition": "+proj=lcc +a=6371200 +b=6371200 +lat_0=25 +lat_1=25 +lon_0=-95 +units=m +no_defs",
 }
 
+static_geo_whole_earth = {
+    "grid_name": "test_geo",
+    "origin_x": -180.0,
+    "origin_y": 40,
+    "width": 361,
+    "height": 181,
+    "cell_width": 1.0,
+    "cell_height": 1.0,
+    "proj4_definition": "+proj=longlat +datum=WGS84 +no_defs +type=crs",
+}
+
 
 class TestLL2CRStatic(unittest.TestCase):
     def test_lcc_basic1(self):
@@ -66,8 +77,31 @@ class TestLL2CRStatic(unittest.TestCase):
         w = grid_info["width"]
         h = grid_info["height"]
         points_in_grid = _ll2cr.ll2cr_static(lon_arr, lat_arr, fill_in, proj_str,
-                                                               cw, ch, w, h, ox, oy)
+                                             cw, ch, w, h, ox, oy)
         self.assertEqual(points_in_grid, lon_arr.size, "all these test points should fall in this grid")
+
+    def test_geo_antimeridian(self):
+        """ Ensure output for anti-meridian crossing input includes all points. """
+        from pyresample.ewa import _ll2cr
+        lon_arr = create_test_longitude(160.0, 200.0, (50, 100), dtype=np.float64)
+        lat_arr = create_test_latitude(40.0, 60.0, (50, 100), dtype=np.float64)
+
+        # wrap values in lon_arr so -180 ≤ longitude (degrees east) ≤ 180
+        lon_arr[lon_arr > 180] -= 360.0
+
+        grid_info = static_geo_whole_earth.copy()
+        fill_in = np.nan
+        proj_str = grid_info['proj4_definition']
+        cw = grid_info['cell_width']
+        ch = grid_info['cell_height']
+        ox = grid_info['origin_x']
+        oy = grid_info['origin_y']
+        w = grid_info['width']
+        h = grid_info['height']
+        points_in_grid = _ll2cr.ll2cr_static(lon_arr, lat_arr, fill_in, proj_str,
+                                             cw, ch, w, h, ox, oy)
+        self.assertEqual(points_in_grid, lon_arr.size,
+                         'all these test points should fall in this grid')
 
     def test_lcc_fail1(self):
         from pyresample.ewa import _ll2cr


### PR DESCRIPTION
This PR removes an `elif` condition in the `ll2cr_static` method, which would identify when source pixels were at least three quarters of the circumference of the target projection away from the target grid origin x coordinate. Data that satisfied this condition were then incremented by the projection circumference.

For swaths that cross the anti-meridian, this meant data with longitudes greater than three quarters of the target projection circumference were being shifted out of the target grid, and therefore the data were being omitted.

 - [x] Closes #374 
 - [x] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff``