### PR TITLE
Fix SphPolygon producing unexpected results for 32-bit float coordinates

### DIFF
--- a/pyresample/spherical.py
+++ b/pyresample/spherical.py
@@ -330,7 +330,7 @@ class SphPolygon(object):
     """
 
     def __init__(self, vertices, radius=1):
-        self.vertices = vertices
+        self.vertices = vertices.astype(np.float64, copy=False)
         self.lon = self.vertices[:, 0]
         self.lat = self.vertices[:, 1]
         self.radius = radius

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2790,23 +2790,24 @@ class TestBboxLonlats:
     """Test 'get_bbox_lonlats' for various geometry cases."""
 
     @pytest.mark.parametrize(
-        ("lat_start", "lat_stop", "force_clockwise", "exp_clockwise"),
+        ("lon_start", "lon_stop", "lat_start", "lat_stop", "exp_clockwise"),
         [
-            (75.0, 26.0, True, True),
-            (75.0, 26.0, False, True),
-            (26.0, 75.0, True, True),
-            (26.0, 75.0, False, False),
+            (3.0, 12.0, 75.0, 26.0, True),
+            (12.0, 3.0, 75.0, 26.0, False),
+            (3.0, 12.0, 26.0, 75.0, False),
+            (12.0, 3.0, 26.0, 75.0, True),
         ]
     )
     @pytest.mark.parametrize("use_dask", [False, True])
     @pytest.mark.parametrize("use_xarray", [False, True])
-    def test_swath_def_bbox(self, lat_start, lat_stop, force_clockwise, exp_clockwise,
+    def test_swath_def_bbox(self, lon_start, lon_stop,
+                            lat_start, lat_stop, exp_clockwise,
                             use_dask, use_xarray):
         from pyresample.geometry import SwathDefinition
 
         from .utils import create_test_latitude, create_test_longitude
         swath_shape = (50, 10)
-        lons = create_test_longitude(3.0, 12.0, swath_shape)
+        lons = create_test_longitude(lon_start, lon_stop, swath_shape)
         lats = create_test_latitude(lat_start, lat_stop, swath_shape)
 
         if use_dask:
@@ -2817,7 +2818,7 @@ class TestBboxLonlats:
             lats = xr.DataArray(lats, dims=('y', 'x'))
 
         swath_def = SwathDefinition(lons, lats)
-        bbox_lons, bbox_lats = swath_def.get_bbox_lonlats(force_clockwise=force_clockwise)
+        bbox_lons, bbox_lats = swath_def.get_bbox_lonlats()
         assert len(bbox_lons) == len(bbox_lats)
         assert len(bbox_lons) == 4
         for side_lons, side_lats in zip(bbox_lons, bbox_lats):

--- a/pyresample/test/test_spherical.py
+++ b/pyresample/test/test_spherical.py
@@ -373,7 +373,10 @@ class TestSphericalPolygon(unittest.TestCase):
         vertices = np.array([[1, 1, 20, 20],
                              [1, 20, 20, 1]]).T
 
-        polygon1 = SphPolygon(np.deg2rad(vertices))
+        rad_verts = np.deg2rad(vertices)
+        polygon1 = SphPolygon(rad_verts)
+        # make sure 64-bit floats don't get copied
+        assert polygon1.vertices is rad_verts
 
         vertices = np.array([[0, 0, 30, 30],
                              [0, 30, 30, 0]]).T
@@ -426,6 +429,44 @@ class TestSphericalPolygon(unittest.TestCase):
 
         self.assertFalse(polygon2._is_inside(polygon1))
         self.assertFalse(polygon1._is_inside(polygon2))
+
+    def test_is_inside_float32(self):
+        """Test that precision dependent calculations work.
+
+        Some of the precision math can fail with only 32-bit floats.
+
+        """
+        b_verts = np.array([[-1.3440281, 0.12873407],
+                            [-1.3714675, 0.17091802],
+                            [-1.5773474, 0.14104952],
+                            [-1.5913332, 0.09375837],
+                            [-1.598127, 0.12360403],
+                            [-1.7618076, 0.65335757],
+                            [-1.7746785, 0.6819248],
+                            [-1.7645605, 0.73133504],
+                            [-1.4870182, 0.77076954],
+                            [-1.4529741, 0.7284483],
+                            [-1.4474869, 0.69782615],
+                            [-1.3499607, 0.15860939]], dtype=np.float32)
+        t_verts = np.array([[-1.80760407, 0.82227004],
+                            [-1.65620456, 0.82549202],
+                            [-1.34904288, 0.81162246],
+                            [-1.2014294, 0.79483332],
+                            [-1.21090379, 0.75978692],
+                            [-1.26056844, 0.54041217],
+                            [-1.30037964, 0.31453188],
+                            [-1.33298796, 0.09364747],
+                            [-1.33784689, 0.05810091],
+                            [-1.44211119, 0.07002157],
+                            [-1.656768, 0.07992753],
+                            [-1.76233241, 0.07762154],
+                            [-1.7639324, 0.11370358],
+                            [-1.77469158, 0.33765409],
+                            [-1.78788255, 0.5660454],
+                            [-1.8044336, 0.78705058]], dtype=np.float32)
+        b_poly = SphPolygon(b_verts)
+        t_poly = SphPolygon(t_verts)
+        assert b_poly._is_inside(t_poly)
 
     def test_union_polygons_overlap_partially(self):
         """Test the union method."""


### PR DESCRIPTION
After a lot of debugging this PR has had a change of purpose/fix. The original thought was that `.get_bbox_lonlats` was returning counter-clockwise coordinates, but it turned out that my test data was wrong and didn't represent real world data. I eventually discovered (see #384) that the main original issue is due to small precision issues when 32-bit floating point data is provided to the math in the `Arc` class. This PR fixes that by forcing all SphPolygon vertices to 64-bit floats. Any performance issues this may cause are negligible in real-world cases as the number of points that SphPolygon/Arc have to go through is the bigger time suck than copying data. 

~It is possible for SwathDefinitions to be flipped in the north-south orientation which results in `.get_bbox_lonlats` returning coordinates in a counter-clockwise orientation. CW coordinates are required for use with Boundary objects. Flipped north-south SwathDefinitions are fairly common for any polar-orbiting data in a "downward" part of their orbit.~

 - [x] Closes #384  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
