### PR TITLE
Fix geocentric_resolution method not working for lat/lon projections

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2346,7 +2346,7 @@ class AreaDefinition(_ProjectionDefinition):
         # need some altitude, go with the surface (0)
         alt_x = np.zeros(x.size)
         alt_y = np.zeros(y.size)
-        transformer = Transformer.from_crs(src.crs, dst.crs)
+        transformer = Transformer.from_crs(src.crs, dst.crs, always_xy=True)
         # convert our midlines to (X, Y, Z) geocentric coordinates
         hor_xyz = np.stack(transformer.transform(x, mid_row_y, alt_x), axis=1)
         vert_xyz = np.stack(transformer.transform(mid_col_x, y, alt_y), axis=1)

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1400,6 +1400,18 @@ class Test(unittest.TestCase):
         geo_res = area_def.geocentric_resolution()
         np.testing.assert_allclose(298.647232, geo_res)
 
+    def test_area_def_geocentric_resolution_latlong(self):
+        """Test the AreaDefinition.geocentric_resolution method on a latlong projection."""
+        from pyresample import get_area_def
+        area_extent = (-110.0, 45.0, -95.0, 55.0)
+        # metered projection
+        area_def = get_area_def('orig', 'Test area', 'test',
+                                {"EPSG": "4326"},
+                                3712, 3712,
+                                area_extent)
+        geo_res = area_def.geocentric_resolution()
+        np.testing.assert_allclose(299.411133, geo_res)
+
     def test_from_epsg(self):
         """Test the from_epsg class method."""
         from pyresample.geometry import AreaDefinition


### PR DESCRIPTION
It is possible to create an AreaDefinition with a PROJ CRS where latitude is the first axis and longitude the second. The common EPSG:4326 is this way depending on how you create it. The geocentric_resolution method was not forcing the order of the axes which meant it was passing longitude as latitude and latitude as longitude. I only noticed this because my data was far enough that it considered the values I was passing as being invalid (latitude beyond -90 when it was actually a longitude value). This PR specifies `always_xy` on the transformer object to avoid this.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
