### PR TITLE
Fix SwathDefinition get_bbox_lonlats returning counter-clockwise coordinates

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1065,17 +1065,6 @@ class DynamicAreaDefinition(object):
         _ymin = np.nanmin(yarr)
         _ymax = np.nanmax(yarr)
 
-        # larger
-        # _xmin = np.nanmin(xarr) - 0.001
-        # _xmax = np.nanmax(xarr) + 0.001
-        # _ymin = np.nanmin(yarr) - 0.001
-        # _ymax = np.nanmax(yarr) + 0.001
-
-        # smaller
-        # _xmin = np.nanmin(xarr) + 0.01
-        # _xmax = np.nanmax(xarr) - 0.01
-        # _ymin = np.nanmin(yarr) + 0.01
-        # _ymax = np.nanmax(yarr) - 0.01
         xmin, xmax, ymin, ymax = da.compute(
             _xmin,
             _xmax,
@@ -1087,8 +1076,10 @@ class DynamicAreaDefinition(object):
         y_is_pole = (ymax >= 90 - epsilon) or (ymin <= -90 + epsilon)
         if crs.is_geographic and x_passes_antimeridian and not y_is_pole:
             # cross anti-meridian of projection
-            xmin = np.nanmin(xarr[xarr >= 0])
-            xmax = np.nanmax(xarr[xarr < 0]) + 360
+            xarr_pos = da.where(xarr >= 0, xarr, np.nan)
+            xarr_neg = da.where(xarr < 0, xarr, np.nan)
+            xmin = np.nanmin(xarr_pos)
+            xmax = np.nanmax(xarr_neg) + 360
             xmin, xmax = da.compute(xmin, xmax)
         return xmin, ymin, xmax, ymax
 

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -978,10 +978,6 @@ class DynamicAreaDefinition(object):
                        corners[1] - y_resolution / 2,
                        corners[2] + x_resolution / 2,
                        corners[3] + y_resolution / 2)
-        # area_extent = (corners[0] - x_resolution,
-        #                corners[1] - y_resolution,
-        #                corners[2] + x_resolution,
-        #                corners[3] + y_resolution)
         return area_extent, width, height
 
     def freeze(self, lonslats=None, resolution=None, shape=None, proj_info=None):
@@ -1064,7 +1060,6 @@ class DynamicAreaDefinition(object):
         _xmax = np.nanmax(xarr)
         _ymin = np.nanmin(yarr)
         _ymax = np.nanmax(yarr)
-
         xmin, xmax, ymin, ymax = da.compute(
             _xmin,
             _xmax,

--- a/pyresample/spherical.py
+++ b/pyresample/spherical.py
@@ -28,7 +28,11 @@ logger = logging.getLogger(__name__)
 
 
 class SCoordinate(object):
-    """Spherical coordinates."""
+    """Spherical coordinates.
+
+    The ``lon`` and ``lat`` coordinates should be provided in radians.
+
+    """
 
     def __init__(self, lon, lat):
         self.lon = lon
@@ -200,7 +204,13 @@ class Arc(object):
         return str(self.start) + " -> " + str(self.end)
 
     def angle(self, other_arc):
-        """Oriented angle between two arcs."""
+        """Oriented angle between two arcs.
+
+        Returns:
+            Angle in radians. A straight line will be 0. A clockwise path
+            will be a negative angle and counter-clockwise will be positive.
+
+        """
         if self.start == other_arc.start:
             a__ = self.start
             b__ = self.end

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2790,18 +2790,20 @@ class TestBboxLonlats:
     """Test 'get_bbox_lonlats' for various geometry cases."""
 
     @pytest.mark.parametrize(
-        ("lon_start", "lon_stop", "lat_start", "lat_stop", "exp_clockwise"),
+        ("lon_start", "lon_stop", "lat_start", "lat_stop", "exp_nonforced_clockwise"),
         [
-            (3.0, 12.0, 75.0, 26.0, True),
-            (12.0, 3.0, 75.0, 26.0, False),
-            (3.0, 12.0, 26.0, 75.0, False),
-            (12.0, 3.0, 26.0, 75.0, True),
+            (3.0, 12.0, 75.0, 26.0, True),  # [0, 0] at north-west corner
+            (12.0, 3.0, 75.0, 26.0, False),  # [0, 0] at north-east corner
+            (3.0, 12.0, 26.0, 75.0, False),  # [0, 0] at south-west corner
+            (12.0, 3.0, 26.0, 75.0, True),  # [0, 0] at south-east corner
         ]
     )
+    @pytest.mark.parametrize("force_clockwise", [False, True])
     @pytest.mark.parametrize("use_dask", [False, True])
     @pytest.mark.parametrize("use_xarray", [False, True])
     def test_swath_def_bbox(self, lon_start, lon_stop,
-                            lat_start, lat_stop, exp_clockwise,
+                            lat_start, lat_stop, exp_nonforced_clockwise,
+                            force_clockwise,
                             use_dask, use_xarray):
         from pyresample.geometry import SwathDefinition
 
@@ -2818,7 +2820,7 @@ class TestBboxLonlats:
             lats = xr.DataArray(lats, dims=('y', 'x'))
 
         swath_def = SwathDefinition(lons, lats)
-        bbox_lons, bbox_lats = swath_def.get_bbox_lonlats()
+        bbox_lons, bbox_lats = swath_def.get_bbox_lonlats(force_clockwise=force_clockwise)
         assert len(bbox_lons) == len(bbox_lats)
         assert len(bbox_lons) == 4
         for side_lons, side_lats in zip(bbox_lons, bbox_lats):
@@ -2826,7 +2828,10 @@ class TestBboxLonlats:
             assert isinstance(side_lats, np.ndarray)
             assert side_lons.shape == side_lats.shape
         is_cw = _is_clockwise(np.concatenate(bbox_lons), np.concatenate(bbox_lats))
-        assert is_cw if exp_clockwise else not is_cw
+        if exp_nonforced_clockwise or force_clockwise:
+            assert is_cw
+        else:
+            assert not is_cw
 
 
 def _is_clockwise(lons, lats):

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2362,8 +2362,8 @@ class TestDynamicAreaDefinition:
             # if we aren't at a pole then we adjust the coordinates
             # that takes a total of 2 computations
             num_computes = 1 if is_pole else 2
-            lons = da.from_array(lons)
-            lats = da.from_array(lats)
+            lons = da.from_array(lons, chunks=2)
+            lats = da.from_array(lats, chunks=2)
             with dask.config.set(scheduler=CustomScheduler(num_computes)):
                 result = area.freeze((lons, lats),
                                      resolution=0.0056)

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -166,7 +166,8 @@ class catch_warnings(warnings.catch_warnings):
 
 def create_test_longitude(start, stop, shape, twist_factor=0.0, dtype=np.float32):
     """Get basic sample of longitude data."""
-    if start > stop:
+    if start > stop and start > 0 > stop:
+        # cross anti-meridian
         stop += 360.0
 
     num_cols = 1 if len(shape) < 2 else shape[1]

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -166,7 +166,7 @@ class catch_warnings(warnings.catch_warnings):
 
 def create_test_longitude(start, stop, shape, twist_factor=0.0, dtype=np.float32):
     """Get basic sample of longitude data."""
-    if start > stop and start > 0 > stop:
+    if start > 0 > stop:
         # cross anti-meridian
         stop += 360.0
 


### PR DESCRIPTION
This is a continuation of #385. That PR originally started as a "my data isn't clockwise so things are incorrect". I then found out that the fake data I was using was actually incorrect and didn't match the real world data I was trying to work with. So switching to 64-bit floats fixed that issue.

Now I'm working with other real world data (MiRS algorithm output) where the lon/lat arrays have their first element (row 0, column 0) in the south-west corner which results in the `get_bbox_lonlats` producing coordinates in a counter-clockwise path. This PR fixes this issue in a very similar way as my original fix #385 except for a few important points:

1. I now only use the first two pixels to determine if the first and second side are in increasing in value. This should get around some of the concerns @mraspaud had from #385.
2. I discovered that the way I was using the utility `create_test_longitude` was actually not allowed. That is, requesting longitudes in decreasing order resulted in the function thinking we were crossing the anti-meridian. This is now fixed in this PR.

I also discovered that `get_edge_lonlats` was depending on the non-clockwise path of the data or at least a test it had was checking for that. So I added the `force_clockwise` keyword argument and set it to False for `get_edge_lonlats` as this makes sure the lonlats follow the data rather than provide a clockwise bbox.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
