### PR TITLE
Replace depracated Numpy dtypes

### DIFF
--- a/pyresample/_spatial_mp.py
+++ b/pyresample/_spatial_mp.py
@@ -179,7 +179,7 @@ class Cartesian(object):
     def transform_lonlats(self, lons, lats):
         """Transform longitudes and latitues to cartesian coordinates."""
         if np.issubdtype(lons.dtype, np.integer):
-            lons = lons.astype(np.float)
+            lons = lons.astype(np.float64)
         coords = np.zeros((lons.size, 3), dtype=lons.dtype)
         if ne:
             deg2rad = np.pi / 180  # noqa: F841

--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -171,7 +171,7 @@ class XArrayBilinearResampler(BilinearBase):
                                    self._radius_of_influence)
         input_coords = lonlat2xyz(source_lons, source_lats)
         valid_input_index = np.ravel(valid_input_index)
-        input_coords = input_coords[valid_input_index, :].astype(np.float)
+        input_coords = input_coords[valid_input_index, :].astype(np.float64)
 
         return da.compute(valid_input_index, input_coords)
 

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -230,7 +230,7 @@ class BucketResampler(object):
         # fill missed index
         statistics = (statistics + pd.Series(np.zeros(out_size))).fillna(0)
 
-        counts = self.get_sum(np.logical_not(np.isnan(data)).astype(int)).ravel()
+        counts = self.get_sum(np.logical_not(np.isnan(data)).astype(np.int64)).ravel()
 
         # TODO remove following line in favour of weights = data when dask histogram bug (issue #6935) is fixed
         statistics = self._mask_bins_with_nan_if_not_skipna(skipna, data, out_size, statistics)
@@ -346,7 +346,7 @@ class BucketResampler(object):
             data = da.where(data == fill_value, np.nan, data)
 
         sums = self.get_sum(data, skipna=skipna)
-        counts = self.get_sum(np.logical_not(np.isnan(data)).astype(int))
+        counts = self.get_sum(np.logical_not(np.isnan(data)).astype(np.int64))
 
         average = sums / da.where(counts == 0, np.nan, counts)
         average = da.where(np.isnan(average), fill_value, average)

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -126,8 +126,8 @@ class BucketResampler(object):
         # Calculate array indices. Orient so that 0-meridian is pointing down.
         adef = self.target_area
         x_res, y_res = adef.resolution
-        x_idxs = da.floor((proj_x - adef.area_extent[0]) / x_res).astype(np.int)
-        y_idxs = da.floor((adef.area_extent[3] - proj_y) / y_res).astype(np.int)
+        x_idxs = da.floor((proj_x - adef.area_extent[0]) / x_res).astype(int)
+        y_idxs = da.floor((adef.area_extent[3] - proj_y) / y_res).astype(int)
 
         # Get valid index locations
         mask = (x_idxs >= 0) & (x_idxs < adef.width) & (y_idxs >= 0) & (y_idxs < adef.height)

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -126,8 +126,8 @@ class BucketResampler(object):
         # Calculate array indices. Orient so that 0-meridian is pointing down.
         adef = self.target_area
         x_res, y_res = adef.resolution
-        x_idxs = da.floor((proj_x - adef.area_extent[0]) / x_res).astype(int)
-        y_idxs = da.floor((adef.area_extent[3] - proj_y) / y_res).astype(int)
+        x_idxs = da.floor((proj_x - adef.area_extent[0]) / x_res).astype(np.int64)
+        y_idxs = da.floor((adef.area_extent[3] - proj_y) / y_res).astype(np.int64)
 
         # Get valid index locations
         mask = (x_idxs >= 0) & (x_idxs < adef.width) & (y_idxs >= 0) & (y_idxs < adef.height)

--- a/pyresample/future/resamplers/nearest.py
+++ b/pyresample/future/resamplers/nearest.py
@@ -192,7 +192,7 @@ class KDTreeNearestXarrayResampler(Resampler):
             query_no_distance, 'jik', tlons, 'ji', tlats, 'ji',
             valid_output_index, 'ji', *args, kdtree=resample_kdtree,
             neighbours=neighbors, epsilon=epsilon,
-            radius=radius_of_influence, dtype=int,
+            radius=radius_of_influence, dtype=np.int64,
             new_axes={'k': neighbors}, concatenate=True)
         return res
 

--- a/pyresample/future/resamplers/nearest.py
+++ b/pyresample/future/resamplers/nearest.py
@@ -192,7 +192,7 @@ class KDTreeNearestXarrayResampler(Resampler):
             query_no_distance, 'jik', tlons, 'ji', tlats, 'ji',
             valid_output_index, 'ji', *args, kdtree=resample_kdtree,
             neighbours=neighbors, epsilon=epsilon,
-            radius=radius_of_influence, dtype=np.int,
+            radius=radius_of_influence, dtype=int,
             new_axes={'k': neighbors}, concatenate=True)
         return res
 

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -965,7 +965,7 @@ class XArrayResamplerNN(object):
         res = blockwise(query_no_distance, 'jik', tlons, 'ji', tlats, 'ji',
                         valid_oi, 'ji', *args, kdtree=resample_kdtree,
                         neighbours=self.neighbours, epsilon=self.epsilon,
-                        radius=self.radius_of_influence, dtype=int,
+                        radius=self.radius_of_influence, dtype=np.int64,
                         new_axes={'k': self.neighbours}, concatenate=True)
         return res, None
 

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -965,7 +965,7 @@ class XArrayResamplerNN(object):
         res = blockwise(query_no_distance, 'jik', tlons, 'ji', tlats, 'ji',
                         valid_oi, 'ji', *args, kdtree=resample_kdtree,
                         neighbours=self.neighbours, epsilon=self.epsilon,
-                        radius=self.radius_of_influence, dtype=np.int,
+                        radius=self.radius_of_influence, dtype=int,
                         new_axes={'k': self.neighbours}, concatenate=True)
         return res, None
 

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -128,7 +128,7 @@ class Test(unittest.TestCase):
         data = np.fromfunction(lambda y, x: y * x, (50, 10))
         lons = np.fromfunction(lambda y, x: 3 + x, (50, 10))
         lats = np.fromfunction(lambda y, x: 75 - y, (50, 10))
-        mask = np.ones_like(lons, dtype=np.bool)
+        mask = np.ones_like(lons, dtype=np.bool_)
         mask[::2, ::2] = False
         swath_def = geometry.SwathDefinition(
             lons=np.ma.masked_array(lons, mask=mask),

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ extras_require = {'numexpr': ['numexpr'],
                   'tests': test_requires}
 
 setup_requires = ['numpy>=1.10.0', 'cython']
-test_requires = ['rasterio', 'dask', 'xarray', 'cartopy>=0.20.0', 'pillow', 'matplotlib', 'scipy', 'zarr']
+test_requires = ['rasterio', 'dask', 'xarray', 'cartopy>=0.20.0', 'pillow', 'matplotlib', 'scipy', 'zarr',
+                 'pytest-lazy-fixture']
 
 if sys.platform.startswith("win"):
     extra_compile_args = []


### PR DESCRIPTION
With a new production chain I noticed the following depraction warning in the logs:

```python
lib/python3.9/site-packages/pyresample/kd_tree.py:968: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  radius=self.radius_of_influence, dtype=np.int,
```

This PR replaces all the usages of `np.int`, `np.float` and `np.bool` with the preferred versions listed in the third column of the Release Notes for 1.20.0.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
