### PR TITLE
Add Python 3.9 to CI runs and use it for the experimental run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,10 +41,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
         experimental: [false]
         include:
-          - python-version: "3.8"
+          - python-version: "3.9"
             os: "ubuntu-latest"
             experimental: true
 


### PR DESCRIPTION
Python 3.9 wasn't used to run the unit tests. This'll add it, and swap the experimental test runs to it.

 - [x] Tests passed <!-- for all non-documentation changes -->
