### PR TITLE
Fix EWA resampling when input data is larger than the output area

### DIFF
--- a/pyresample/ewa/_fornav_templates.cpp
+++ b/pyresample/ewa/_fornav_templates.cpp
@@ -245,7 +245,7 @@ int compute_ewa(size_t chan_count, int maximum_weight_mode,
       u0 = uimg[swath_offset];
       v0 = vimg[swath_offset];
 
-      if (u0 < 0.0 || v0 < 0.0 || __isnan(u0) || __isnan(v0)) {
+      if (u0 < -this_ewap->u_del || v0 < -this_ewap->v_del || __isnan(u0) || __isnan(v0)) {
         continue;
       }
 
@@ -352,7 +352,6 @@ int compute_ewa_single(int maximum_weight_mode,
   IMAGE_TYPE this_val;
   unsigned int swath_offset;
   unsigned int grid_offset;
-  size_t chan;
 
   got_point = 0;
   for (row = 0, swath_offset=0; row < swath_rows; row+=1) {
@@ -360,7 +359,7 @@ int compute_ewa_single(int maximum_weight_mode,
       u0 = uimg[swath_offset];
       v0 = vimg[swath_offset];
 
-      if (u0 < 0.0 || v0 < 0.0 || __isnan(u0) || __isnan(v0)) {
+      if (u0 < -this_ewap->u_del || v0 < -this_ewap->v_del || __isnan(u0) || __isnan(v0)) {
         continue;
       }
 

--- a/pyresample/ewa/dask_ewa.py
+++ b/pyresample/ewa/dask_ewa.py
@@ -351,8 +351,8 @@ class DaskEWAResampler(BaseResampler):
         ll2cr_blocks = self.cache['ll2cr_blocks'].items()
         ll2cr_numblocks = ll2cr_result.shape if isinstance(ll2cr_result, np.ndarray) else ll2cr_result.numblocks
         fornav_task_name = "fornav-{}".format(data.name)
-        maximum_weight_mode = kwargs.get('maximum_weight_mode', False)
-        weight_sum_min = kwargs.get('weight_sum_min', -1.0)
+        maximum_weight_mode = kwargs.setdefault('maximum_weight_mode', False)
+        weight_sum_min = kwargs.setdefault('weight_sum_min', -1.0)
         output_stack = self._generate_fornav_dask_tasks(out_chunks,
                                                         ll2cr_blocks,
                                                         fornav_task_name,

--- a/pyresample/test/test_ewa_fornav.py
+++ b/pyresample/test/test_ewa_fornav.py
@@ -54,6 +54,28 @@ class TestFornav(unittest.TestCase):
         self.assertTrue(((out == 1) | np.isnan(out)).all(),
                         msg="Unexpected interpolation values were returned")
 
+    def test_fornav_swath_wide_input(self):
+        """Test that a swath with large input pixels on the left edge of the output."""
+        from pyresample.ewa import _fornav
+        swath_shape = (400, 800)
+        data_type = np.float32
+        # Create a fake row and cols array
+        rows = np.empty(swath_shape, dtype=np.float32)
+        rows[:] = np.linspace(-500, 500, 400)[:, None]
+        cols = np.empty(swath_shape, dtype=np.float32)
+        cols[:] = np.linspace(-500, 500, 800) + 0.5
+        rows_per_scan = 16
+        # Create a fake data swath
+        data = np.ones(swath_shape, dtype=data_type)
+        out = np.empty((800, 1000), dtype=data_type)
+
+        grid_points_covered = _fornav.fornav_wrapper(cols, rows, (data,), (out,),
+                                                     np.nan, np.nan, rows_per_scan)
+        one_grid_points_covered = grid_points_covered[0]
+        # the upper-left 500x500 square should be filled with 1s at least
+        assert 500 * 500 <= one_grid_points_covered <= 505 * 505
+        np.testing.assert_allclose(out[:500, :500], 1)
+
     def test_fornav_swath_smaller(self):
         """Test that a swath smaller than the output grid is entirely used."""
         from pyresample.ewa import _fornav


### PR DESCRIPTION
This PR fixes a bug that was only obvious with the new dask implementation of the EWA resampler and only with data that had a very large input size. In my Polar2Grid use cases this showed up with the MiRS reader where we set the weight delta max to 100.0 (that's 100 output grid cells). We expect an image like:

![image](https://user-images.githubusercontent.com/1828519/142347612-293f4a9e-2e3e-4d15-a572-acf299f5c3ce.png)

But were getting this:

![image](https://user-images.githubusercontent.com/1828519/142347629-70906c20-2737-47d4-910f-8dd6cc65b9f5.png)

The "feathering" near the top is expected as this data gets to high latitudes and this is a latlong output AreaDefinition. However, the vertical line in the second image is not expected. What is actually happening is that the EWA algorithm was discarding any input pixels that were to the left or below the output grid. The way the dask implementation works means that there are a lot more of these "edge" cases in the middle of the final output image. These pixels could still have an effect on the final image due to them have an elliptical weight that they apply. So even a pixel that is 1 pixel to the left of the output grid might have an effect on a lot of pixels if the weight delta max (the extent to which an input pixel has an effect) is larger than 1 (1 pixel). Although this issue was more obvious with the dask EWA implementation it does actually effect the first and last columns of all EWA output.

While fixing this I also noticed another small possible bug with how kwargs were handled in the dask EWA implementation and have fixed that. I will try to add a test tomorrow. This was definitely not TDD as I didn't even know what was causing the problem in order to write a failing test.

This fix may interest @owenlittlejohns who I think had issues with vertical lines over the anti-meridian too.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
