### PR TITLE
Fix deprecated numpy data type usage in bilinear resampling

### DIFF
--- a/pyresample/bilinear/_base.py
+++ b/pyresample/bilinear/_base.py
@@ -217,7 +217,7 @@ class BilinearBase(object):
                                    self._radius_of_influence)
         input_coords = lonlat2xyz(source_lons, source_lats)
         valid_input_index = np.ravel(valid_input_index)
-        input_coords = input_coords[valid_input_index, :].astype(np.float)
+        input_coords = input_coords[valid_input_index, :].astype(np.float64)
 
         return valid_input_index, input_coords
 


### PR DESCRIPTION
This fixes a DeprecationWarning coming from numpy:

```python
/root/mambaforge/envs/ci_env/lib/python3.10/site-packages/pyresample/bilinear/_base.py:220
`np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here. Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
