### PR TITLE
Move bilinear import to avoid unnecessary warning

### DIFF
--- a/pyresample/image.py
+++ b/pyresample/image.py
@@ -23,7 +23,7 @@ import warnings
 
 import numpy as np
 
-from pyresample import bilinear, geometry, grid, kd_tree
+from pyresample import geometry, grid, kd_tree
 
 
 class ImageContainer(object):
@@ -368,6 +368,10 @@ class ImageContainerBilinear(ImageContainer):
         image_container : object
             ImageContainerBilinear object of resampled geometry
         """
+        # import here, instead of the top of the script, to avoid xarray/zarr warning msg
+        # while import the top level pyresample module
+        from pyresample import bilinear
+
         image_data = self.image_data
 
         try:


### PR DESCRIPTION
This PR moves the `bilinear` module import from the top of `image.py` to the function body of `ImageContainerBilinear.resample()`. 

`conda install -c conda-forge pyresample` does not install `xarray` and `zarr`. Thus, if one did not install `xarray` and `zarr` manually, running `import pyresample` will print out the following warning message:

```bash
(test) yunjunz:~>$ python -c "import pyresample"
/Users/yunjunz/tools/miniconda3/envs/test/lib/python3.10/site-packages/pyresample/bilinear/__init__.py:50: UserWarning: XArray and/or zarr not found, XArrayBilinearResampler won't be available.
  warnings.warn("XArray and/or zarr not found, XArrayBilinearResampler won't be available.")
```

With this change, the top-level `import pyresample`, which calls `from pyresample import image`, won't call the `bilinear` module, thus, avoid the warning msg.

 - [x] Closes #375  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->