### PR TITLE
Optimize AreaDefinition.get_proj_coords when requesting dask arrays

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1130,24 +1130,22 @@ def _generate_2d_coords(pixel_size_x, pixel_size_y, pixel_upper_left_x, pixel_up
     start_x_idx = block_info[None]["array-location"][2][0]
     end_x_idx = block_info[None]["array-location"][2][1]
     dtype = block_info[None]["dtype"]
-    x, y = _generate_1d_proj_vectors(start_x_idx, end_x_idx,
-                                     start_y_idx, end_y_idx,
-                                     pixel_size_x, pixel_size_y,
-                                     pixel_upper_left_x, pixel_upper_left_y,
+    x, y = _generate_1d_proj_vectors((start_x_idx, end_x_idx),
+                                     (start_y_idx, end_y_idx),
+                                     (pixel_size_x, pixel_size_y),
+                                     (pixel_upper_left_x, pixel_upper_left_y),
                                      dtype)
     x_2d, y_2d = np.meshgrid(x, y)
     res = np.stack([x_2d, y_2d])
     return res
 
 
-def _generate_1d_proj_vectors(start_x, end_x,
-                              start_y, end_y,
-                              pixel_size_x, pixel_size_y,
-                              upper_left_x, upper_left_y,
+def _generate_1d_proj_vectors(col_range, row_range,
+                              pixel_size_xy, offset_xy,
                               dtype, chunks=None):
     x_kwargs, y_kwargs, arange = _get_vector_arange_args(dtype, chunks)
-    x = arange(start_x, end_x, **x_kwargs) * pixel_size_x + upper_left_x
-    y = arange(start_y, end_y, **y_kwargs) * -pixel_size_y + upper_left_y
+    x = arange(*col_range, **x_kwargs) * pixel_size_xy[0] + offset_xy[0]
+    y = arange(*row_range, **y_kwargs) * -pixel_size_xy[1] + offset_xy[1]
     return x, y
 
 
@@ -2114,10 +2112,10 @@ class AreaDefinition(_ProjectionDefinition):
             warnings.warn("Projection vectors will not be accurate because rotation is not 0", RuntimeWarning)
         if dtype is None:
             dtype = self.dtype
-        x, y = _generate_1d_proj_vectors(0, self.width,
-                                         0, self.height,
-                                         self.pixel_size_x, self.pixel_size_y,
-                                         self.pixel_upper_left[0], self.pixel_upper_left[1],
+        x, y = _generate_1d_proj_vectors((0, self.width),
+                                         (0, self.height),
+                                         (self.pixel_size_x, self.pixel_size_y),
+                                         (self.pixel_upper_left[0], self.pixel_upper_left[1]),
                                          dtype, chunks=chunks)
         return x, y
 

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -2048,18 +2048,20 @@ class TestStackedAreaDefinition:
         np.testing.assert_allclose(lats[464:, :], lats1)
 
         # check that get_lonlats with chunks definition doesn't cause errors and output arrays are equal
-        # too many chunks
-        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((200, 264, 464), (5570,)))
+        with pytest.raises(ValueError):
+            # too many chunks
+            _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((200, 264, 464), (5570,)))
+        # right amount of chunks, different shape
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((464, 470), (5568,)))
+        # only one chunk value
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=464)
+
+        # only one set of chunks in a tuple
+        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=(464, 5568))
         # too few chunks
         _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((464,), (5568,)))
         # right amount of chunks, same shape
         _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((464, 464), (5568,)))
-        # right amount of chunks, different shape
-        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=((464, 470), (5568,)))
-        # only one set of chunks in a tuple
-        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=(464, 5568))
-        # only one chunk value
-        _check_final_area_lon_lat_with_chunks(final_area, lons, lats, chunks=464)
 
     def test_combine_area_extents(self):
         """Test combination of area extents."""

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -982,6 +982,11 @@ class Test(unittest.TestCase):
         area_def = get_area_def(area_id, area_name, proj_id, proj_dict, x_size, y_size, area_extent)
 
         xcoord, ycoord = area_def.get_proj_coords(chunks=4096)
+        # make sure different chunk size provides a different dask name
+        xcoord2, ycoord2 = area_def.get_proj_coords(chunks=2048)
+        assert xcoord2.name != xcoord.name
+        assert ycoord2.name != ycoord.name
+
         xcoord = xcoord.compute()
         ycoord = ycoord.compute()
         self.assertTrue(np.allclose(xcoord[0, :],


### PR DESCRIPTION
This is part of my work on the Satpy issue https://github.com/pytroll/satpy/issues/1902. As described in some of the docstrings in this PR, these changes make it so that `get_proj_coords`, the method that returns a 2D X and a 2D Y coordinate array for each pixel of an AreaDefinition, generates the data usings a `map_blocks` call. Previously this data was generated by getting the 1D vectors via `np.arange` and some other math, then passing them to `np.meshgrid` to turn them into 2D vectors. Those series of steps produce an odd series of tasks for dask when the coordinates are used for future work like converting to lon/lat arrays and then using those lon/lats to generate solar zenith angles (for example). The result is that dask has trouble scheduling the future tasks because it sees the complicated set of tasks and series of linked tasks required to turn two 1D arrays into two 2D arrays.

This PR switches to using `map_blocks` to generate the 2D coordinate arrays from the scalar properties of the AreaDefinition which essentially shows up as 1 task in the dask graph. As shown in the satpy issue referenced above this reduces memory usage of processing (specifically AHI) by a lot.

 - [x] Closes https://github.com/pytroll/satpy/issues/1902 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

