### PR TITLE
Remove unsupported Python 3.6 from wheel building

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,9 @@
 name: CI
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+# https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types#pullrequestevent
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
+  cancel-in-progress: true
 
 on: [push, pull_request]
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         include:
           # Using pythons inside a docker image to provide all the Linux
           # python-versions permutations.

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,5 @@
 name: Deploy sdist and wheels
- 
+
 on: [push, pull_request, release]
 
 jobs:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,17 +33,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
           # Using pythons inside a docker image to provide all the Linux
           # python-versions permutations.
           - name: manylinux 64-bit
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: '3.8'
             docker-image: manylinux1_x86_64
           - name: manylinux 32-bit
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: '3.8'
             docker-image: manylinux1_i686
 
     steps:
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          python-version: '${{ matrix.python-version }}'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '${{ matrix.python-version }}'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,9 @@
 name: Deploy sdist and wheels
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+# https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types#pullrequestevent
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
+  cancel-in-progress: true
 
 on: [push, pull_request, release]
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,12 +1,6 @@
 name: Deploy sdist and wheels
-
-on:
-  push:
-    tags:
-      - v*
-  release:
-    types:
-      - published
+ 
+on: [push, pull_request, release]
 
 jobs:
   build_sdist:
@@ -94,6 +88,8 @@ jobs:
   upload_test_pypi:
     needs: [build_sdist, build_wheels]
     runs-on: ubuntu-latest
+    # upload to Test PyPI for every commit on main branch
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
       - name: Download sdist artifact
         uses: actions/download-artifact@v2


### PR DESCRIPTION
We no longer support Python 3.6  but wheels were being attempted. This PR removes Python 3.6 and tries Python 3.10. Let's see what happens...