### PR TITLE
Fix dask EWA code not creating unique dask task names for different target areas

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,7 +5,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
   cancel-in-progress: true
 
-on: [push, pull_request, release]
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
 
 jobs:
   build_sdist:

--- a/pyresample/ewa/dask_ewa.py
+++ b/pyresample/ewa/dask_ewa.py
@@ -350,7 +350,7 @@ class DaskEWAResampler(BaseResampler):
         ll2cr_result = self.cache['ll2cr_result']
         ll2cr_blocks = self.cache['ll2cr_blocks'].items()
         ll2cr_numblocks = ll2cr_result.shape if isinstance(ll2cr_result, np.ndarray) else ll2cr_result.numblocks
-        fornav_task_name = "fornav-{}".format(data.name)
+        fornav_task_name = f"fornav-{data.name}-{ll2cr_result.name}"
         maximum_weight_mode = kwargs.setdefault('maximum_weight_mode', False)
         weight_sum_min = kwargs.setdefault('weight_sum_min', -1.0)
         output_stack = self._generate_fornav_dask_tasks(out_chunks,

--- a/pyresample/test/test_dask_ewa.py
+++ b/pyresample/test/test_dask_ewa.py
@@ -357,3 +357,20 @@ class TestDaskEWAResampler:
         exp_exc = ValueError if len(input_shape) != 4 else NotImplementedError
         with pytest.raises(exp_exc):
             resampler.resample(swath_data, rows_per_scan=10)
+
+    def test_multiple_targets(self):
+        """Test that multiple targets produce unique results."""
+        input_shape = (100, 50)
+        output_shape = (200, 100)
+        swath_data, source_swath, target_area1 = get_test_data(
+            input_shape=input_shape, output_shape=output_shape,
+        )
+        target_area2 = _get_test_target_area((250, 150))
+
+        resampler1 = DaskEWAResampler(source_swath, target_area1)
+        res1 = resampler1.resample(swath_data, rows_per_scan=10)
+        resampler2 = DaskEWAResampler(source_swath, target_area2)
+        res2 = resampler2.resample(swath_data, rows_per_scan=10)
+
+        assert res1.name != res2.name
+        assert res1.compute().shape != res2.compute().shape


### PR DESCRIPTION
I've always tested the new algorithm with only one target, but once it was thrown into Polar2Grid we quickly realized that multiple targets was a problem. Luckily because of my map_blocks PR last week I knew to look at the dask task names for the issue.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
