### PR TITLE
Fix gradient search for single band data

### DIFF
--- a/pyresample/gradient/__init__.py
+++ b/pyresample/gradient/__init__.py
@@ -271,6 +271,9 @@ class GradientSearchResampler(BaseResampler):
 
         if fill_value is not None:
             res = da.where(np.isnan(res), fill_value, res)
+        if res.ndim > len(data_dims):
+            res = res.squeeze()
+
         res = xr.DataArray(res, dims=data_dims, coords=coords)
 
         return res
@@ -400,6 +403,6 @@ def _concatenate_chunks(chunks):
         prev_y = y
     res.append(da.concatenate(col, axis=1))
 
-    res = da.concatenate(res, axis=2).squeeze()
+    res = da.concatenate(res, axis=2)
 
     return res


### PR DESCRIPTION
Helping out a colleague, I noticed that gradient search resampler doesn't work if a single-channel dataset (shape `(1, y, x)`) are used.

The error message was:
```python
Traceback (most recent call last):
  File "/home/lahtinep/bin/test_akun_resamplays.py", line 40, in <module>
    main()
  File "/home/lahtinep/bin/test_akun_resamplays.py", line 31, in main
    scn2 = scn.resample(suomi, resampler='gradient_search', fill_value=0)
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/scene.py", line 906, in resample
    self._resampled_scene(new_scn, destination, resampler=resampler,
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/scene.py", line 822, in _resampled_scene
    res = resample_dataset(dataset, destination_area, **kwargs)
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/resample.py", line 1395, in resample_dataset
    new_data = resample(source_area, dataset, destination_area, fill_value=fill_value, **kwargs)
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/resample.py", line 1358, in resample
    res = resampler_instance.resample(data, **kwargs)
  File "/home/lahtinep/Software/pytroll/pytroll_packages/pyresample/pyresample/resampler.py", line 126, in resample
    return self.compute(data, cache_id=cache_id, **kwargs)
  File "/home/lahtinep/Software/pytroll/pytroll_packages/pyresample/pyresample/gradient/__init__.py", line 274, in compute
    res = xr.DataArray(res, dims=data_dims, coords=coords)
  File "/home/lahtinep/mambaforge/envs/pytroll/lib/python3.9/site-packages/xarray/core/dataarray.py", line 406, in __init__
    coords, dims = _infer_coords_and_dims(data.shape, coords, dims)
  File "/home/lahtinep/mambaforge/envs/pytroll/lib/python3.9/site-packages/xarray/core/dataarray.py", line 102, in _infer_coords_and_dims
    raise ValueError(
ValueError: coords is not dict-like, but it has 3 items, which does not match the 2 dimensions of the data
```

This PR fixes this by only applying `.squeeze()` in the case of result being of higher dimensionality than the `dims`/`coords` would indicate.


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
