### PR TITLE
Update AreaDefinition equality to use pyproj CRS

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1817,7 +1817,7 @@ class AreaDefinition(_ProjectionDefinition):
     def __eq__(self, other):
         """Test for equality."""
         try:
-            return ((self.proj_str == other.proj_str) and
+            return ((self.crs == other.crs) and
                     (self.shape == other.shape) and
                     (np.allclose(self.area_extent, other.area_extent)))
         except AttributeError:

--- a/pyresample/test/test_files/areas.cfg
+++ b/pyresample/test/test_files/areas.cfg
@@ -37,7 +37,7 @@ REGION: pc_world {
 REGION: ortho {
   NAME:    Ortho globe
   PCS_ID:  ortho_globe
-  PCS_DEF: proj=ortho, a=6370997.0, lon_0=40, lat_0=-40
+  PCS_DEF: proj=ortho, lon_0=40, lat_0=-40, ellps=sphere
   XSIZE: 640
   YSIZE: 480
   AREA_EXTENT:  (-10000000, -10000000, 10000000, 10000000)

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -492,8 +492,7 @@ class TestMisc(unittest.TestCase):
         transform = Affine(300.0379266750948, 0.0, 101985.0,
                            0.0, -300.041782729805, 2826915.0)
         source = tmptiff(transform=transform)
-        proj_dict = {'init': 'epsg:3857'}
-        area_def = utils.rasterio.get_area_def_from_raster(source, proj_dict=proj_dict)
+        area_def = utils.rasterio.get_area_def_from_raster(source, projection="EPSG:3857")
         self.assertEqual(area_def.crs, CRS(3857))
 
 

--- a/pyresample/utils/rasterio.py
+++ b/pyresample/utils/rasterio.py
@@ -19,7 +19,7 @@
 from . import proj4_str_to_dict
 
 
-def _get_area_def_from_gdal(dataset, area_id=None, name=None, proj_id=None, proj_dict=None):
+def _get_area_def_from_gdal(dataset, area_id=None, name=None, proj_id=None, projection=None):
     from pyresample.geometry import AreaDefinition
 
     # a: width of a pixel
@@ -33,46 +33,44 @@ def _get_area_def_from_gdal(dataset, area_id=None, name=None, proj_id=None, proj
         raise ValueError('Rotated rasters are not supported at this time.')
     area_extent = (c, f + e * dataset.RasterYSize, c + a * dataset.RasterXSize, f)
 
-    if proj_dict is None:
+    if projection is None:
         from osgeo import osr
         proj = dataset.GetProjection()
         if proj != '':
             sref = osr.SpatialReference(wkt=proj)
-            proj_dict = proj4_str_to_dict(sref.ExportToProj4())
+            projection = proj4_str_to_dict(sref.ExportToProj4())
         else:
             raise ValueError('The source raster is not gereferenced, please provide the value of proj_dict')
 
         if proj_id is None:
             proj_id = proj.split('"')[1]
 
-    area_def = AreaDefinition(area_id, name, proj_id, proj_dict,
+    area_def = AreaDefinition(area_id, name, proj_id, projection,
                               dataset.RasterXSize, dataset.RasterYSize, area_extent)
     return area_def
 
 
-def _get_area_def_from_rasterio(dataset, area_id, name, proj_id=None, proj_dict=None):
+def _get_area_def_from_rasterio(dataset, area_id, name, proj_id=None, projection=None):
     from pyresample.geometry import AreaDefinition
 
     a, b, c, d, e, f, _, _, _ = dataset.transform
     if not (b == d == 0):
         raise ValueError('Rotated rasters are not supported at this time.')
 
-    if proj_dict is None:
-        crs = dataset.crs
-        if crs is not None:
-            proj_dict = dataset.crs.to_dict()
-        else:
+    if projection is None:
+        projection = dataset.crs
+        if projection is None:
             raise ValueError('The source raster is not gereferenced, please provide the value of proj_dict')
 
         if proj_id is None:
-            proj_id = crs.wkt.split('"')[1]
+            proj_id = projection.wkt.split('"')[1]
 
-    area_def = AreaDefinition(area_id, name, proj_id, proj_dict,
+    area_def = AreaDefinition(area_id, name, proj_id, projection,
                               dataset.width, dataset.height, dataset.bounds)
     return area_def
 
 
-def get_area_def_from_raster(source, area_id=None, name=None, proj_id=None, proj_dict=None):
+def get_area_def_from_raster(source, area_id=None, name=None, proj_id=None, projection=None):
     """Construct AreaDefinition object from raster.
 
     Parameters
@@ -86,8 +84,9 @@ def get_area_def_from_raster(source, area_id=None, name=None, proj_id=None, proj
         Name of area
     proj_id : str, optional
         ID of projection
-    proj_dict : dict, optional
-        PROJ.4 parameters
+    projection : pyproj.CRS, dict, or string, optional
+        Projection parameters as a CRS object or a dictionary or string of
+        PROJ.4 parameters.
 
     Returns
     -------
@@ -114,8 +113,8 @@ def get_area_def_from_raster(source, area_id=None, name=None, proj_id=None, proj
 
     try:
         if rasterio is not None and isinstance(source, (rasterio.io.DatasetReader, rasterio.io.DatasetWriter)):
-            return _get_area_def_from_rasterio(source, area_id, name, proj_id, proj_dict)
-        return _get_area_def_from_gdal(source, area_id, name, proj_id, proj_dict)
+            return _get_area_def_from_rasterio(source, area_id, name, proj_id, projection)
+        return _get_area_def_from_gdal(source, area_id, name, proj_id, projection)
     finally:
         if cleanup_rasterio:
             source.close()


### PR DESCRIPTION
Pyproj has issued a warning for a long time now to tell the user to avoid using PROJ.4 strings and dictionaries as they are considered inaccurate as far as completely defining a projection (where WKT is now preferred). This PR updates one usage of this in `AreaDefinition.__eq__` so it compares the pyproj CRS objects directly instead of the PROJ.4 strings. This change does make equality a lot more strict, but probably in a good way. It now fails if your ellipsoid was defined in different ways or if axis order is different. This is very common with EPSG inputs.

This PR updates a few things to improve on this in the tests. It also includes a backwards incompatible change to the rasterio utilities to bring the argument name inline with AreaDefinition and be more accurate (`projection` instead of `proj_dict`).

Note: With these changes I am able to generate an ABI true_color composite in Satpy with no PROJ warnings.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
