### PR TITLE
Fix EWA resampling not ignoring fill values with maximum_weight_mode

### DIFF
--- a/pyresample/ewa/_fornav_templates.cpp
+++ b/pyresample/ewa/_fornav_templates.cpp
@@ -292,13 +292,9 @@ int compute_ewa(size_t chan_count, int maximum_weight_mode,
               for (chan = 0; chan < chan_count; chan+=1) {
                 this_val = ((images[chan])[swath_offset]);
                 if (maximum_weight_mode) {
-                  if (weight > grid_weights[chan][grid_offset]) {
+                  if (weight > grid_weights[chan][grid_offset] & !((this_val == img_fill) || (__isnan(this_val)))) {
                     ((grid_weights[chan])[grid_offset]) = weight;
-                    if ((this_val == img_fill) || (__isnan(this_val))) {
-                      ((grid_accums[chan])[grid_offset]) = (accum_type)NPY_NANF;
-                    } else {
-                      ((grid_accums[chan])[grid_offset]) = (accum_type)this_val;
-                    }
+                    ((grid_accums[chan])[grid_offset]) = (accum_type)this_val;
                   }
                 } else {
                   if ((this_val != img_fill) && !(__isnan(this_val))) {
@@ -405,13 +401,9 @@ int compute_ewa_single(int maximum_weight_mode,
 
               this_val = (image[swath_offset]);
               if (maximum_weight_mode) {
-                if (weight > grid_weight[grid_offset]) {
+                if (weight > grid_weight[grid_offset] & !((this_val == img_fill) || (__isnan(this_val)))) {
                   grid_weight[grid_offset] = weight;
-                  if ((this_val == img_fill) || (__isnan(this_val))) {
-                    grid_accum[grid_offset] = (accum_type)NPY_NANF;
-                  } else {
-                    grid_accum[grid_offset] = (accum_type)this_val;
-                  }
+                  grid_accum[grid_offset] = (accum_type)this_val;
                 }
               } else {
                 if ((this_val != img_fill) && !(__isnan(this_val))) {

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -1286,7 +1286,7 @@ class Test(unittest.TestCase):
         proj_dict['proj'] = 'omerc'
         proj_dict['lat_0'] = 50.0
         proj_dict['alpha'] = proj_dict.pop('lat_ts')
-        proj_dict['no_rot'] = ''
+        proj_dict['no_rot'] = True
         area = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',
                                        proj_dict, 10, 10,
                                        [-1370912.72, -909968.64, 1029087.28,


### PR DESCRIPTION
This hit us in a real world case recently and as far as I remember this was by design, but we have no idea why. It makes bad images. We (@kathys and myself) have decided to change the behavior to produce better images.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

