### PR TITLE
Add Cython classifier to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
               'Development Status :: 5 - Production/Stable',
               'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
               'Programming Language :: Python',
+              'Programming Language :: Cython',
               'Operating System :: OS Independent',
               'Intended Audience :: Science/Research',
               'Topic :: Scientific/Engineering'


### PR DESCRIPTION
A request was recently posted on the python mailing list about including Cython as the language of your package in the setup.py metadata. This PR adds that classifier.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
