### PR TITLE
Improve docs for dump and load_area_from_string

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -97,6 +97,9 @@ def load_area_from_string(area_strs, *regions):
     Like :func:`~pyresample.area_config.load_area`, but load from string
     directly.
 
+    For the opposite (i.e. to create a YAML string from an area), use
+    :meth:`~pyresample.geometry.AreaDefinition.dump`.
+
     Parameters
     ----------
     area_strs : str or List[str]

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1754,7 +1754,10 @@ class AreaDefinition(_ProjectionDefinition):
         return self.crs.to_proj4()
 
     def create_areas_def(self):
-        """Generate YAML formatted representation of this area."""
+        """Generate YAML formatted representation of this area.
+
+        Deprecated.  Use :meth:`dump` instead.
+        """
         warnings.warn("'create_areas_def' is deprecated. Please use `dump` instead, which also "
                       "supports writing directly to a file.", DeprecationWarning)
 
@@ -1762,6 +1765,9 @@ class AreaDefinition(_ProjectionDefinition):
 
     def dump(self, filename=None):
         """Generate YAML formatted representation of this area.
+
+        For the opposite (i.e. to get an AreaDefinition from a YAML-formatted
+        representation), see :func:`~pyresample.area_config.load_area_from_string`.
 
         Args:
             filename (str or pathlib.Path or file-like object): Yaml file location to dump the area to.


### PR DESCRIPTION
Improve the documentation for dump, create_areas_def (deprecated), and
load_area_from_string, by referring to the opposite function.

<!-- Describe what your PR does, and why -->

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
