### PR TITLE
Fix SwathDefinition causing unnecessary dask computes when used as a dict key

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -139,3 +139,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
+          skip_existing: true
+

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -146,14 +146,14 @@ class BaseDefinition:
             self_lons = self.lons
             self_lats = self.lats
 
-        if self_lons is other_lons and self_lats is other_lats:
-            return True
         if isinstance(self_lons, DataArray) and np.ndarray is not DataArray:
             self_lons = self_lons.data
             self_lats = self_lats.data
         if isinstance(other_lons, DataArray) and np.ndarray is not DataArray:
             other_lons = other_lons.data
             other_lats = other_lats.data
+        if self_lons is other_lons and self_lats is other_lats:
+            return True
 
         arrs_to_comp = (self_lons, self_lats, other_lons, other_lats)
         all_dask_arrays = da is not None and all(isinstance(x, da.Array) for x in arrs_to_comp)
@@ -169,7 +169,7 @@ class BaseDefinition:
                 return False
             lats_close = np.allclose(self_lats, other_lats, atol=1e-6, rtol=5e-9, equal_nan=True)
             return lats_close
-        except (AttributeError, ValueError):
+        except ValueError:
             return False
 
     def __ne__(self, other):


### PR DESCRIPTION
While debugging some performance issues in my own software that uses pyresample I noticed that using a SwathDefinition in a dict can sometimes causes computation of the underlying dask arrays. This was unknown behavior to me but turns out to be expected. When a dict key hash matches one that already exists, Python's dict will do an `__eq__` check between the two keys to make sure they are actually the same object as it is possible for two different objects to produce the same hash. In our case, SwathDefinition hashes are based on the underlying dask arrays (in the case that dask arrays are used) to avoid hashing them as numpy arrays. In the cases where `__eq__` is called the entire dask array for lon and lat for both swath definitions are computed when compared to each other.

Side note: While working on this I found out that numpy-based arrays were actually being computed as dask arrays. Probably an unnecessary overhead.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
