### PR TITLE
Fix infinite coordinates failing to be equal

### DIFF
--- a/pyresample/spherical.py
+++ b/pyresample/spherical.py
@@ -42,7 +42,10 @@ class SCoordinate(object):
     """
 
     def __init__(self, lon, lat):
-        self.lon = float(_unwrap_radians(lon))
+        if np.isfinite(lon):
+            self.lon = float(_unwrap_radians(lon))
+        else:
+            self.lon = float(lon)
         self.lat = lat
 
     def cross2cart(self, point):

--- a/pyresample/test/test_spherical.py
+++ b/pyresample/test/test_spherical.py
@@ -146,6 +146,12 @@ class TestSCoordinate(unittest.TestCase):
         point_end = SCoordinate(np.pi, 0)
         assert point_start == point_end
 
+    def test_equality_of_infinites(self):
+        """Test that infinite coordinates are equal."""
+        coord1 = SCoordinate(np.inf, np.inf)
+        coord2 = SCoordinate(np.inf, np.inf)
+        assert coord1 == coord2
+
 
 class TestCCoordinate(unittest.TestCase):
     """Test SCoordinates."""


### PR DESCRIPTION
The equality between two infinite coordinates was removed in 507925926b9c2d346aad449790dc29e7bb0daeaa through the unwrapping of the longitude returning a NaN instead of Inf in that case. This PR restores the previous behaviour.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->

Example of failing script:
```python
    from satpy import Scene
    from glob import glob
    import os
    from satpy.utils import debug_on
    debug_on()
    datadir = "/home/a001673/data/satellite/Meteosat-11/seviri/lvl1.5/2018/02/28/HRIT"

    scn = Scene(filenames=glob(os.path.join(datadir, "*")),
                reader='seviri_l1b_hrit',
                )
    composite = "overview"
    scn.load([composite])
    newscn = scn.resample("moll")
    newscn.save_datasets(base_dir='/tmp', tiled=True, blockxsize=512, blockysize=512, driver='COG', overviews=[])
```
