### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         include:
           # Using pythons inside a docker image to provide all the Linux
           # python-versions permutations.

--- a/continuous_integration/build-manylinux-wheels.sh
+++ b/continuous_integration/build-manylinux-wheels.sh
@@ -29,7 +29,7 @@ find /io/temp-wheels/ -type f -delete
 git config --global --add safe.directory /io
 
 # Iterate through available pythons.
-for PYBIN in /opt/python/cp3{7,8,9,10}*/bin; do
+for PYBIN in /opt/python/cp3{8,9,10}*/bin; do
     "${PYBIN}/pip" install -q -U setuptools wheel --cache-dir /io/pip-cache
     # Run the following in root of this repo.
     (cd /io/ && "${PYBIN}/pip" install -q .)

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
           package_dir={'pyresample': 'pyresample'},
           packages=find_packages(),
           package_data={'pyresample.test': ['test_files/*']},
-          python_requires='>=3.7',
+          python_requires='>=3.8',
           setup_requires=setup_requires,
           install_requires=requirements,
           extras_require=extras_require,


### PR DESCRIPTION
We were already doing 3.7-incompatible things. This just makes it official.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
