### PR TITLE
Fix hashing of definitions for non contiguous arrays

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -708,7 +708,7 @@ def get_array_hashable(arr):
         try:
             return arr.name.encode('utf-8')  # dask array
         except AttributeError:
-            return np.asarray(arr).view(np.uint8)  # np array
+            return np.ascontiguousarray(arr).view(np.uint8)  # np array
 
 
 class SwathDefinition(CoordinateDefinition):

--- a/pyresample/test/test_geometry.py
+++ b/pyresample/test/test_geometry.py
@@ -471,6 +471,16 @@ class Test(unittest.TestCase):
         swath_def = geometry.SwathDefinition(xrlons, xrlats)
         self.assertIsInstance(hash(swath_def), int)
 
+    def test_non_contiguous_swath_hash(self):
+        """Test swath hash."""
+        lons = np.array([[1.2, 1.3, 1.4, 1.5],
+                         [1.2, 1.3, 1.4, 1.5]])
+        lats = np.array([[65.9, 65.86, 65.82, 65.78],
+                         [65.9, 65.86, 65.82, 65.78]])
+        swath_def = geometry.SwathDefinition(lons, lats)
+        swath_def_subset = swath_def[:, slice(0, 2)]
+        self.assertIsInstance(hash(swath_def_subset), int)
+
     def test_area_equal(self):
         """Test areas equality."""
         area_def = geometry.AreaDefinition('areaD', 'Europe (3km, HRV, VTC)', 'areaD',


### PR DESCRIPTION
This PR fixes the hashing of definitions based on non contiguous arrays

 - [x] Closes #439 
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->

