### PR TITLE
Fix EWA default for 'weight_delta_max' to match docstring

### DIFF
--- a/pyresample/ewa/_legacy_dask_ewa.py
+++ b/pyresample/ewa/_legacy_dask_ewa.py
@@ -223,7 +223,7 @@ class LegacyDaskEWAResampler(BaseResampler):
 
     def compute(self, data, cache_id=None, fill_value=0, weight_count=10000,
                 weight_min=0.01, weight_distance_max=1.0,
-                weight_delta_max=1.0, weight_sum_min=-1.0,
+                weight_delta_max=10.0, weight_sum_min=-1.0,
                 maximum_weight_mode=False, grid_coverage=0, chunks=None,
                 **kwargs):
         """Resample the data according to the precomputed X/Y coordinates."""

--- a/pyresample/ewa/dask_ewa.py
+++ b/pyresample/ewa/dask_ewa.py
@@ -380,7 +380,7 @@ class DaskEWAResampler(BaseResampler):
 
     def compute(self, data, cache_id=None, rows_per_scan=None, chunks=None, fill_value=None,
                 weight_count=10000, weight_min=0.01, weight_distance_max=1.0,
-                weight_delta_max=1.0, weight_sum_min=-1.0,
+                weight_delta_max=10.0, weight_sum_min=-1.0,
                 maximum_weight_mode=None, **kwargs):
         """Resample the data according to the precomputed X/Y coordinates."""
         # not used in this step
@@ -454,7 +454,7 @@ class DaskEWAResampler(BaseResampler):
     def resample(self, data, cache_dir=None, mask_area=None,
                  rows_per_scan=None, persist=False, chunks=None, fill_value=None,
                  weight_count=10000, weight_min=0.01, weight_distance_max=1.0,
-                 weight_delta_max=1.0, weight_sum_min=-1.0,
+                 weight_delta_max=10.0, weight_sum_min=-1.0,
                  maximum_weight_mode=None):
         """Resample using an elliptical weighted averaging algorithm.
 


### PR DESCRIPTION
As described in https://github.com/pytroll/python-geotiepoints/pull/38 I discovered that the default `weight_delta_max` in the dask EWA code did not match the docstring. The docstring is correct for MODIS data and matches what has been in the EWA algorithm forever (it was originally written for MODIS code).

I really don't want to add a test for this.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
