### PR TITLE
Introduce the GCPDefinition

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -744,7 +744,7 @@ class SwathDefinition(CoordinateDefinition):
         if not isinstance(lons, (np.ndarray, DataArray)):
             lons = np.asanyarray(lons)
             lats = np.asanyarray(lats)
-        super(SwathDefinition, self).__init__(lons, lats, nprocs)
+        super().__init__(lons, lats, nprocs)
         if lons.shape != lats.shape:
             raise ValueError('lon and lat arrays must have same shape')
         elif lons.ndim > 2:
@@ -3001,3 +3001,31 @@ def enclose_areas(*areas, area_id="joint-area"):
 
 def _numpy_values_to_native(values):
     return [n.item() if isinstance(n, np.number) else n for n in values]
+
+
+class GCPDefinition(SwathDefinition):
+    """Swath definition with added support for GCPs.
+
+    GCPs should contain longitudes and latitudes.
+    """
+
+    def __init__(self, lons, lats, gcps):
+        """Instantiate the GCPDefinition.
+
+        Arguments:
+            lons: longitudes
+            lats: latitudes
+            gcps: Array of ground control points
+        """
+        super().__init__(lons, lats)
+        self.gcps = gcps
+
+    def get_coarse_bbox_lonlats(self):
+        """Get a coarse bounding box from the gcps.
+
+        Assumes gcps are a 2d array.
+        """
+        return np.hstack((self.gcps[0, :-1],
+                          self.gcps[:-1, -1],
+                          self.gcps[-1, -1:0:-1],
+                          self.gcps[-1:0:-1, 0]))

--- a/pyresample/test/test_gcp_def.py
+++ b/pyresample/test/test_gcp_def.py
@@ -1,0 +1,30 @@
+"""Test the GCPDefinition class."""
+import numpy as np
+import pytest
+
+from pyresample.geometry import GCPDefinition
+
+gcp_dtype = np.dtype([("longitude", float),
+                      ("latitude", float),
+                      ("altitude", float),
+                      ("x", float),
+                      ("y", float)])
+
+
+def test_coarse_bounding_box(gcp_definition):
+    """Test the coarse bounding box method."""
+    bblons = np.hstack((np.arange(10), np.arange(19, 99, 10), np.arange(99, 90, -1), np.arange(90, 0, -10)))
+    np.testing.assert_array_equal(bblons, gcp_definition.get_coarse_bbox_lonlats()["longitude"])
+
+
+@pytest.fixture
+def gcp_definition():
+    """Create a GCPDefinition instance."""
+    lons = None
+    lats = None
+    gcps = np.zeros(100, dtype=gcp_dtype)
+    gcps["longitude"] = np.arange(100)
+    gcps["latitude"] = np.arange(100, 200)
+    gcps = gcps.reshape((10, 10))
+    gdef = GCPDefinition(lons, lats, gcps)
+    return gdef


### PR DESCRIPTION
Add a new class called GCPDefinition (inherits from SwathDefinition) which provides access to the underlying gcps.

Use cases:
 - faster loading of coarse lon/lats (for the boundary)
 - if you want to write data with tiepoints
 - interpolate a fraction of what is needed.


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
