### PR TITLE
FIX: Update pyproj min version to 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools import Extension, find_packages, setup
 
 import versioneer
 
-requirements = ['setuptools>=3.2', 'pyproj>=2.2', 'configobj',
+requirements = ['setuptools>=3.2', 'pyproj>=3.0', 'configobj',
                 'pykdtree>=1.3.1', 'pyyaml', 'numpy>=1.10.0',
                 ]
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

 - [x] Closes #486  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

This PR update the min version of pyproj to 3.0 as pyresample relies on it already.

The only test that I did was to manually install pyproj 3.0 and to make sure `import pyresample` does throw an error.