### PR TITLE
Deprecate AreaDefinition 'rotation' argument

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -212,7 +212,6 @@ def _create_area_def_from_dict(area_name, params):
                                                                           'upper_right_xy', 'units'])
     params['resolution'] = _capture_subarguments(params, 'resolution', ['resolution', 'dx', 'dy', 'units'])
     params['radius'] = _capture_subarguments(params, 'radius', ['radius', 'dx', 'dy', 'units'])
-    params['rotation'] = _capture_subarguments(params, 'rotation', ['rotation', 'units'])
     area_def = create_area_def(**params)
     return area_def
 
@@ -354,10 +353,10 @@ def _create_area(area_id, area_content):
     config['PCS_DEF'] = _get_proj4_args(config['PCS_DEF'])
     return create_area_def(config['REGION'], config['PCS_DEF'], description=config['NAME'], proj_id=config['PCS_ID'],
                            shape=(config['YSIZE'], config['XSIZE']), area_extent=config['AREA_EXTENT'],
-                           rotation=config['ROTATION'])
+                           )
 
 
-def get_area_def(area_id, area_name, proj_id, proj4_args, width, height, area_extent, rotation=0):
+def get_area_def(area_id, area_name, proj_id, proj4_args, width, height, area_extent):
     """Construct AreaDefinition object from arguments.
 
     Parameters
@@ -374,8 +373,6 @@ def get_area_def(area_id, area_name, proj_id, proj4_args, width, height, area_ex
         Number of pixel in x dimension
     height : int
         Number of pixel in y dimension
-    rotation: float
-        Rotation in degrees (negative is cw)
     area_extent : list | tuple
         Area extent as a list of ints (LL_x, LL_y, UR_x, UR_y)
 
@@ -445,8 +442,6 @@ def create_area_def(area_id, projection, width=None, height=None, area_extent=No
         Size of pixels: (dx, dy)
     radius : list or float, optional
         Length from the center to the edges of the projection (dx, dy)
-    rotation: float, optional
-        rotation in degrees(negative is cw)
     nprocs : int, optional
         Number of processor cores to be used
     lons : numpy array, optional
@@ -550,7 +545,7 @@ def _make_area(
         return AreaDefinition(area_id, description, proj_id, projection, width, height, area_extent, **kwargs)
 
     return DynamicAreaDefinition(area_id=area_id, description=description, projection=projection, width=width,
-                                 height=height, area_extent=area_extent, rotation=kwargs.get('rotation'),
+                                 height=height, area_extent=area_extent,
                                  resolution=resolution, optimize_projection=optimize_projection)
 
 

--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -331,19 +331,11 @@ def _create_area(area_id, area_content):
     config = config_obj.dict()
     config['REGION'] = area_id
 
-    try:
-        string_types = basestring
-    except NameError:
-        string_types = str
-    if not isinstance(config['NAME'], string_types):
+    if not isinstance(config['NAME'], str):
         config['NAME'] = ', '.join(config['NAME'])
 
     config['XSIZE'] = int(config['XSIZE'])
     config['YSIZE'] = int(config['YSIZE'])
-    if 'ROTATION' in config.keys():
-        config['ROTATION'] = float(config['ROTATION'])
-    else:
-        config['ROTATION'] = 0
     config['AREA_EXTENT'][0] = config['AREA_EXTENT'][0].replace('(', '')
     config['AREA_EXTENT'][3] = config['AREA_EXTENT'][3].replace(')', '')
 

--- a/pyresample/test/test_files/areas.yaml
+++ b/pyresample/test/test_files/areas.yaml
@@ -141,7 +141,6 @@ test_meters:
   radius:
     radius: 3309.9505528339496
     units: mi
-  rotation: 45
 
 test_degrees:
   projection:
@@ -169,9 +168,6 @@ test_degrees:
   radius:
     dx: 49.4217406986
     dy: 49.4217406986
-    units: degrees
-  rotation:
-    rotation: 45
     units: degrees
 
 ease_sh:

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1350,7 +1350,6 @@ class TestCreateAreaDef:
             radius=essentials[1],
             description=description,
             units=units,
-            rotation=45,
         )
 
         should_fail = isinstance(center, str) or len(center) != 2

--- a/pyresample/test/test_geometry_legacy.py
+++ b/pyresample/test/test_geometry_legacy.py
@@ -22,7 +22,6 @@ DEPRECATED: Don't add new tests to this file. Put them in a module in ``test/tes
 
 """
 import random
-import unittest
 from unittest.mock import MagicMock, patch
 
 import dask

--- a/pyresample/test/test_geometry_legacy.py
+++ b/pyresample/test/test_geometry_legacy.py
@@ -80,40 +80,6 @@ class TestBaseDefinition:
             f"BaseDefinition did not maintain dtype of longitudes (in:{lons2_ints.dtype} out:{lons.dtype})"
 
 
-class Test(unittest.TestCase):
-    """Unit testing the geometry and geo_filter modules."""
-
-    def test_get_proj_coords_rotation(self):
-        """Test basic get_proj_coords usage with rotation specified."""
-        from pyresample.geometry import AreaDefinition
-        area_id = 'test'
-        area_name = 'Test area with 2x2 pixels'
-        proj_id = 'test'
-        x_size = 10
-        y_size = 10
-        area_extent = [1000000, 0, 1050000, 50000]
-        proj_dict = {"proj": 'laea', 'lat_0': '60', 'lon_0': '0', 'a': '6371228.0', 'units': 'm'}
-        area_def = AreaDefinition(area_id, area_name, proj_id, proj_dict, x_size, y_size, area_extent, rotation=45)
-
-        xcoord, ycoord = area_def.get_proj_coords()
-        np.testing.assert_allclose(xcoord[0, :],
-                                   np.array([742462.120246, 745997.654152, 749533.188058, 753068.721964,
-                                             756604.25587, 760139.789776, 763675.323681, 767210.857587,
-                                             770746.391493, 774281.925399]))
-        np.testing.assert_allclose(ycoord[:, 0],
-                                   np.array([-675286.976033, -678822.509939, -682358.043845, -685893.577751,
-                                             -689429.111657, -692964.645563, -696500.179469, -700035.713375,
-                                             -703571.247281, -707106.781187]))
-
-        xcoord, ycoord = area_def.get_proj_coords(data_slice=(slice(None, None, 2), slice(None, None, 2)))
-        np.testing.assert_allclose(xcoord[0, :],
-                                   np.array([742462.120246, 749533.188058, 756604.25587, 763675.323681,
-                                             770746.391493]))
-        np.testing.assert_allclose(ycoord[:, 0],
-                                   np.array([-675286.976033, -682358.043845, -689429.111657, -696500.179469,
-                                             -703571.247281]))
-
-
 def assert_np_dict_allclose(dict1, dict2):
     """Check allclose on dicts."""
     assert set(dict1.keys()) == set(dict2.keys())

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -20,7 +20,6 @@
 import os
 import unittest
 import uuid
-from tempfile import NamedTemporaryFile
 
 import numpy as np
 from pyproj import CRS
@@ -298,99 +297,6 @@ class TestMisc(unittest.TestCase):
         self.assertEqual(area_def.crs, CRS(3857))
 
 
-class TestProjRotation(unittest.TestCase):
-    """Test loading areas with rotation specified."""
-
-    def test_rotation_legacy(self):
-        """Basic rotation in legacy format."""
-        from pyresample.area_config import load_area
-        legacyDef = """REGION: regionB {
-        NAME:          regionB
-        PCS_ID:        regionB
-        PCS_DEF:       proj=merc, lon_0=-34, k=1, x_0=0, y_0=0, a=6378137, b=6378137
-        XSIZE:         800
-        YSIZE:         548
-        ROTATION:      -45
-        AREA_EXTENT:   (-7761424.714818418, -4861746.639279127, 11136477.43264252, 8236799.845095873)
-        };"""
-        with NamedTemporaryFile(mode="w", suffix='.cfg', delete=False) as f:
-            f.write(legacyDef)
-        test_area = load_area(f.name, 'regionB')
-        self.assertEqual(test_area.rotation, -45)
-        os.remove(f.name)
-
-    def test_rotation_yaml(self):
-        """Basic rotation in yaml format."""
-        from pyresample.area_config import load_area
-        yamlDef = """regionB:
-          description: regionB
-          projection:
-            a: 6378137.0
-            b: 6378137.0
-            lon_0: -34
-            proj: merc
-            x_0: 0
-            y_0: 0
-            k_0: 1
-          shape:
-            height: 548
-            width: 800
-          rotation: -45
-          area_extent:
-            lower_left_xy: [-7761424.714818418, -4861746.639279127]
-            upper_right_xy: [11136477.43264252, 8236799.845095873]
-          units: m"""
-        with NamedTemporaryFile(mode="w", suffix='.yaml', delete=False) as f:
-            f.write(yamlDef)
-        test_area = load_area(f.name, 'regionB')
-        self.assertEqual(test_area.rotation, -45)
-        os.remove(f.name)
-
-    def test_norotation_legacy(self):
-        """No rotation specified in legacy format."""
-        from pyresample.area_config import load_area
-        legacyDef = """REGION: regionB {
-        NAME:          regionB
-        PCS_ID:        regionB
-        PCS_DEF:       proj=merc, lon_0=-34, k=1, x_0=0, y_0=0, a=6378137, b=6378137
-        XSIZE:         800
-        YSIZE:         548
-        AREA_EXTENT:   (-7761424.714818418, -4861746.639279127, 11136477.43264252, 8236799.845095873)
-        };"""
-        with NamedTemporaryFile(mode="w", suffix='.cfg', delete=False) as f:
-            f.write(legacyDef)
-        test_area = load_area(f.name, 'regionB')
-        self.assertEqual(test_area.rotation, 0)
-        os.remove(f.name)
-
-    def test_norotation_yaml(self):
-        """No rotation specified in yaml format."""
-        from pyresample.area_config import load_area
-        yamlDef = """regionB:
-          description: regionB
-          projection:
-            a: 6378137.0
-            b: 6378137.0
-            lon_0: -34
-            proj: merc
-            x_0: 0
-            y_0: 0
-            k_0: 1
-          shape:
-            height: 548
-            width: 800
-          area_extent:
-            lower_left_xy: [-7761424.714818418, -4861746.639279127]
-            upper_right_xy: [11136477.43264252, 8236799.845095873]
-          units: m"""
-        with NamedTemporaryFile(mode="w", suffix='.yaml', delete=False) as f:
-            f.write(yamlDef)
-        test_area = load_area(f.name, 'regionB')
-        self.assertEqual(test_area.rotation, 0)
-        os.remove(f.name)
-
-
-# helper routines for the CF test cases
 def _prepare_cf_nh10km():
     import xarray as xr
     nx = 760


### PR DESCRIPTION
After talking with @loreclem on slack, we decided that it should be OK to deprecate the functionality added by him via the `rotation` keyword argument in the AreaDefinition. As far as I know this functionality was not used by anyone (even Lorenzo doesn't use it anymore) and should be replaced by parameters to the CRS (projection) being defined for the area. Overall, I wanted to remove this to cleanup code that was/is likely not being used by anyone and only makes the code harder to maintain.

Note: This PR is based on #464 so it has a lot of commits and changes that will go away when that PR is merged.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
