### PR TITLE
Fix data type handling (complex) in nearest neighbor resampling

### DIFF
--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -820,7 +820,7 @@ def get_sample_from_neighbour_info(resample_type, output_shape, data,
     else:  # One channel
         output_raw_shape = output_size
 
-    full_result = np.ones(output_raw_shape, dtype=data.dtype) * fill_value
+    full_result = np.full(output_raw_shape, fill_value, dtype=result.dtype)
     full_result[valid_output_index] = result
     result = full_result
 

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -820,7 +820,7 @@ def get_sample_from_neighbour_info(resample_type, output_shape, data,
     else:  # One channel
         output_raw_shape = output_size
 
-    full_result = np.ones(output_raw_shape) * fill_value
+    full_result = np.ones(output_raw_shape, dtype=data.dtype) * fill_value
     full_result[valid_output_index] = result
     result = full_result
 

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -123,6 +123,18 @@ class Test(unittest.TestCase):
         expected = 15874591.0
         self.assertEqual(cross_sum, expected)
 
+    def test_nearest_complex(self):
+        data = np.fromfunction(lambda y, x: y + complex("j") * x, (50, 10), dtype=np.complex_)
+        lons = np.fromfunction(lambda y, x: 3 + x, (50, 10))
+        lats = np.fromfunction(lambda y, x: 75 - y, (50, 10))
+        swath_def = geometry.SwathDefinition(lons=lons, lats=lats)
+        res = kd_tree.resample_nearest(swath_def, data.ravel(),
+                                       self.area_def, 50000, segments=1)
+        assert np.issubdtype(res.dtype, np.complex_)
+        cross_sum = res.sum()
+        assert cross_sum.real == 3530219.0
+        assert cross_sum.imag == 688723.0
+
     def test_nearest_masked_swath_target(self):
         """Test that a masked array works as a target."""
         data = np.fromfunction(lambda y, x: y * x, (50, 10))


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
There is something wrong while geocoding a wrapped interferograms in complex type due to `ComplexWarning`. The change would fix it as below.
https://github.com/insarlab/MintPy/issues/955#issuecomment-1423716672

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
