### PR TITLE
Add pre-allocation option to `get_neighbour_info` to improve performance on large raster data

### DIFF
--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -34,6 +34,7 @@ from pyresample import CHUNK_SIZE, _spatial_mp, data_reduce, geometry
 
 from .future.resamplers._transform_utils import lonlat2xyz
 from .future.resamplers.nearest import _my_index, query_no_distance
+from .utils.row_appendable_array import RowAppendableArray
 
 logger = getLogger(__name__)
 
@@ -277,7 +278,7 @@ def _resample(source_geo_def, data, target_geo_def, resample_type,
 
 def get_neighbour_info(source_geo_def, target_geo_def, radius_of_influence,
                        neighbours=8, epsilon=0, reduce_data=True,
-                       nprocs=1, segments=None):
+                       nprocs=1, segments=None, preallocate_size=0):
     """Return neighbour info.
 
     Parameters
@@ -301,7 +302,9 @@ def get_neighbour_info(source_geo_def, target_geo_def, radius_of_influence,
     segments : int or None
         Number of segments to use when resampling.
         If set to None an estimate will be calculated
-
+    preallocate_size: int
+        Size to preallocate result arrays with.
+        This can be useful if appending segments becomes costly for large target areas
     Returns
     -------
     (valid_input_index, valid_output_index,
@@ -339,8 +342,11 @@ def get_neighbour_info(source_geo_def, target_geo_def, radius_of_influence,
 
     if segments > 1:
         # Iterate through segments
-        for i, target_slice in enumerate(geometry._get_slice(segments,
-                                                             target_geo_def.shape)):
+        appendable_valid_output_index = RowAppendableArray(preallocate_size)
+        appendable_index_array = RowAppendableArray(preallocate_size)
+        appendable_distance_array = RowAppendableArray(preallocate_size)
+
+        for target_slice in geometry._get_slice(segments, target_geo_def.shape):
 
             # Query on slice of target coordinates
             next_voi, next_ia, next_da = \
@@ -352,20 +358,12 @@ def get_neighbour_info(source_geo_def, target_geo_def, radius_of_influence,
                                        reduce_data=reduce_data,
                                        nprocs=nprocs)
 
-            # Build result iteratively
-            if i == 0:
-                # First iteration
-                valid_output_index = next_voi
-                index_array = next_ia
-                distance_array = next_da
-            else:
-                valid_output_index = np.append(valid_output_index, next_voi)
-                if neighbours > 1:
-                    index_array = np.row_stack((index_array, next_ia))
-                    distance_array = np.row_stack((distance_array, next_da))
-                else:
-                    index_array = np.append(index_array, next_ia)
-                    distance_array = np.append(distance_array, next_da)
+            appendable_valid_output_index.append_row(next_voi)
+            appendable_index_array.append_row(next_ia)
+            appendable_distance_array.append_row(next_da)
+        valid_output_index = appendable_valid_output_index.to_array()
+        index_array = appendable_index_array.to_array()
+        distance_array = appendable_distance_array.to_array()
     else:
         # Query kd-tree with full target coordinate set
         full_slice = slice(None)

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -278,7 +278,7 @@ def _resample(source_geo_def, data, target_geo_def, resample_type,
 
 def get_neighbour_info(source_geo_def, target_geo_def, radius_of_influence,
                        neighbours=8, epsilon=0, reduce_data=True,
-                       nprocs=1, segments=None, preallocate_size=0):
+                       nprocs=1, segments=None):
     """Return neighbour info.
 
     Parameters
@@ -302,9 +302,6 @@ def get_neighbour_info(source_geo_def, target_geo_def, radius_of_influence,
     segments : int or None
         Number of segments to use when resampling.
         If set to None an estimate will be calculated
-    preallocate_size: int
-        Size to preallocate result arrays with.
-        This can be useful if appending segments becomes costly for large target areas
     Returns
     -------
     (valid_input_index, valid_output_index,
@@ -342,9 +339,9 @@ def get_neighbour_info(source_geo_def, target_geo_def, radius_of_influence,
 
     if segments > 1:
         # Iterate through segments
-        appendable_valid_output_index = RowAppendableArray(preallocate_size)
-        appendable_index_array = RowAppendableArray(preallocate_size)
-        appendable_distance_array = RowAppendableArray(preallocate_size)
+        appendable_valid_output_index = RowAppendableArray(segments)
+        appendable_index_array = RowAppendableArray(segments)
+        appendable_distance_array = RowAppendableArray(segments)
 
         for target_slice in geometry._get_slice(segments, target_geo_def.shape):
 

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -339,9 +339,9 @@ def get_neighbour_info(source_geo_def, target_geo_def, radius_of_influence,
 
     if segments > 1:
         # Iterate through segments
-        appendable_valid_output_index = RowAppendableArray(segments)
-        appendable_index_array = RowAppendableArray(segments)
-        appendable_distance_array = RowAppendableArray(segments)
+        appendable_valid_output_index = RowAppendableArray(target_geo_def.size)
+        appendable_index_array = RowAppendableArray(target_geo_def.size)
+        appendable_distance_array = RowAppendableArray(target_geo_def.size)
 
         for target_slice in geometry._get_slice(segments, target_geo_def.shape):
 

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -731,38 +731,38 @@ def test_check_slice_orientation():
 class TestRowAppendableArray(unittest.TestCase):
     """Test appending numpy arrays to possible pre-allocated buffer."""
 
-    def test_append_1d_arrays_but_stop_before_expected_number_of_segments(self):
-        appendable = RowAppendableArray(3)
+    def test_append_1d_arrays_and_trim_remaining_buffer(self):
+        appendable = RowAppendableArray(7)
         appendable.append_row(np.zeros(3))
         appendable.append_row(np.ones(3))
         self.assertTrue(np.array_equal(appendable.to_array(), np.array([0, 0, 0, 1, 1, 1])))
 
-    def test_append_rows_of_nd_arrays_but_stop_before_expected_number_of_segments(self):
-        appendable = RowAppendableArray(3)
+    def test_append_rows_of_nd_arrays_and_trim_remaining_buffer(self):
+        appendable = RowAppendableArray(7)
         appendable.append_row(np.zeros((3, 2)))
         appendable.append_row(np.ones((3, 2)))
         self.assertTrue(np.array_equal(appendable.to_array(), np.vstack([np.zeros((3, 2)), np.ones((3, 2))])))
 
     def test_append_more_1d_arrays_than_expected(self):
-        appendable = RowAppendableArray(1)
+        appendable = RowAppendableArray(5)
         appendable.append_row(np.zeros(3))
         appendable.append_row(np.ones(3))
         self.assertTrue(np.array_equal(appendable.to_array(), np.array([0, 0, 0, 1, 1, 1])))
 
     def test_append_more_rows_of_nd_arrays_than_expected(self):
-        appendable = RowAppendableArray(1)
+        appendable = RowAppendableArray(2)
         appendable.append_row(np.zeros((3, 2)))
         appendable.append_row(np.ones((3, 2)))
         self.assertTrue(np.array_equal(appendable.to_array(), np.vstack([np.zeros((3, 2)), np.ones((3, 2))])))
 
     def test_append_1d_arrays_pre_allocated_appendable_array(self):
-        appendable = RowAppendableArray(2)
+        appendable = RowAppendableArray(6)
         appendable.append_row(np.zeros(3))
         appendable.append_row(np.ones(3))
         self.assertTrue(np.array_equal(appendable.to_array(), np.array([0, 0, 0, 1, 1, 1])))
 
     def test_append_rows_of_nd_arrays_to_pre_allocated_appendable_array(self):
-        appendable = RowAppendableArray(2)
+        appendable = RowAppendableArray(6)
         appendable.append_row(np.zeros((3, 2)))
         appendable.append_row(np.ones((3, 2)))
         self.assertTrue(np.array_equal(appendable.to_array(), np.vstack([np.zeros((3, 2)), np.ones((3, 2))])))

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -729,6 +729,7 @@ def test_check_slice_orientation():
 
 
 class TestRowAppendableArray(unittest.TestCase):
+    """Test appending numpy arrays to possible pre-allocated buffer."""
     def test_append_1d_arrays_unallocated_appendable_array(self):
         appendable = RowAppendableArray()
         appendable.append_row(np.zeros(3))
@@ -760,4 +761,3 @@ class TestRowAppendableArray(unittest.TestCase):
         unallocated_performance = timeit(lambda: unallocated.append_row(np.array([42])), number=10000)
         pre_allocated_performance = timeit(lambda: pre_allocated.append_row(np.array([42])), number=10000)
         self.assertGreater(unallocated_performance / pre_allocated_performance, 2)
-

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -266,7 +266,7 @@ class TestMisc(unittest.TestCase):
         area_def = utils.rasterio.get_area_def_from_raster(source)
         epsg3857_names = (
             'WGS_1984_Web_Mercator_Auxiliary_Sphere',  # gdal>=3.0 + proj>=6.0
-            'WGS 84 / Pseudo-Mercator',  # proj<6.0
+            'WGS 84 / Pseudo-Mercator',                # proj<6.0
         )
         self.assertIn(area_def.proj_id, epsg3857_names)
 
@@ -310,7 +310,7 @@ def _prepare_cf_nh10km():
                      'yc': ('yc', np.linspace(+5845, -5345, num=ny),
                             {'standard_name': 'projection_y_coordinate', 'units': 'km'})},
                     coords={'lat': (('yc', 'xc'), np.ma.masked_all((ny, nx))),
-                            'lon': (('yc', 'xc'), np.ma.masked_all((ny, nx)))}, )
+                            'lon': (('yc', 'xc'), np.ma.masked_all((ny, nx)))},)
     ds['lat'].attrs['units'] = 'degrees_north'
     ds['lat'].attrs['standard_name'] = 'latitude'
     ds['lon'].attrs['units'] = 'degrees_east'
@@ -438,14 +438,14 @@ class TestLoadCFArea_Public(unittest.TestCase):
         self.assertRaises(KeyError, load_cf_area, cf_file, 'doesNotExist')
 
         # try to load from a variable= that is itself is a grid_mapping, but without y= or x=
-        self.assertRaises(ValueError, load_cf_area, cf_file, 'Polar_Stereographic_Grid', )
+        self.assertRaises(ValueError, load_cf_area, cf_file, 'Polar_Stereographic_Grid',)
 
         # try to load using a variable= that is a valid grid_mapping container, but use wrong x= and y=
-        self.assertRaises(KeyError, load_cf_area, cf_file, 'Polar_Stereographic_Grid', y='doesNotExist', x='xc', )
-        self.assertRaises(ValueError, load_cf_area, cf_file, 'Polar_Stereographic_Grid', y='time', x='xc', )
+        self.assertRaises(KeyError, load_cf_area, cf_file, 'Polar_Stereographic_Grid', y='doesNotExist', x='xc',)
+        self.assertRaises(ValueError, load_cf_area, cf_file, 'Polar_Stereographic_Grid', y='time', x='xc',)
 
         # try to load using a variable= that does not define a grid mapping
-        self.assertRaises(ValueError, load_cf_area, cf_file, 'lat', )
+        self.assertRaises(ValueError, load_cf_area, cf_file, 'lat',)
 
     def test_load_cf_nh10km(self):
         from pyresample.utils import load_cf_area
@@ -463,7 +463,7 @@ class TestLoadCFArea_Public(unittest.TestCase):
         cf_file = _prepare_cf_nh10km()
 
         # load using a variable= that is a valid grid_mapping container
-        adef, _ = load_cf_area(cf_file, 'Polar_Stereographic_Grid', y='yc', x='xc', )
+        adef, _ = load_cf_area(cf_file, 'Polar_Stereographic_Grid', y='yc', x='xc',)
         validate_nh10km_adef(adef)
 
         # load using a variable= that has a :grid_mapping attribute
@@ -606,16 +606,16 @@ class TestLoadCFArea_Private(unittest.TestCase):
         from pyresample.utils.cf import _guess_cf_lonlat_varname
 
         # nominal
-        self.assertEqual(_guess_cf_lonlat_varname(self.nc_handles['nh10km'], 'ice_conc', 'lat'), 'lat', )
-        self.assertEqual(_guess_cf_lonlat_varname(self.nc_handles['nh10km'], 'ice_conc', 'lon'), 'lon', )
+        self.assertEqual(_guess_cf_lonlat_varname(self.nc_handles['nh10km'], 'ice_conc', 'lat'), 'lat',)
+        self.assertEqual(_guess_cf_lonlat_varname(self.nc_handles['nh10km'], 'ice_conc', 'lon'), 'lon',)
         self.assertEqual(_guess_cf_lonlat_varname(self.nc_handles['llwgs84'], 'temp', 'lat'), 'lat')
         self.assertEqual(_guess_cf_lonlat_varname(self.nc_handles['llwgs84'], 'temp', 'lon'), 'lon')
         self.assertEqual(_guess_cf_lonlat_varname(self.nc_handles['llnocrs'], 'temp', 'lat'), 'lat')
         self.assertEqual(_guess_cf_lonlat_varname(self.nc_handles['llnocrs'], 'temp', 'lon'), 'lon')
 
         # error cases
-        self.assertRaises(ValueError, _guess_cf_lonlat_varname, self.nc_handles['nh10km'], 'ice_conc', 'wrong', )
-        self.assertRaises(KeyError, _guess_cf_lonlat_varname, self.nc_handles['nh10km'], 'doesNotExist', 'lat', )
+        self.assertRaises(ValueError, _guess_cf_lonlat_varname, self.nc_handles['nh10km'], 'ice_conc', 'wrong',)
+        self.assertRaises(KeyError, _guess_cf_lonlat_varname, self.nc_handles['nh10km'], 'doesNotExist', 'lat',)
 
     def test_cf_guess_axis_varname(self):
         from pyresample.utils.cf import _guess_cf_axis_varname

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -730,6 +730,7 @@ def test_check_slice_orientation():
 
 class TestRowAppendableArray(unittest.TestCase):
     """Test appending numpy arrays to possible pre-allocated buffer."""
+
     def test_append_1d_arrays_unallocated_appendable_array(self):
         appendable = RowAppendableArray()
         appendable.append_row(np.zeros(3))

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -22,7 +22,6 @@ This mostly takes from astropy's method for checking collected_warnings during
 tests.
 """
 import sys
-import time
 import types
 import warnings
 from contextlib import contextmanager
@@ -279,18 +278,3 @@ def assert_warnings_contain(collected_warnings: list, message: str, count: int =
     msgs = [msg.message.args[0].lower() for msg in collected_warnings]
     msgs_with = [msg for msg in msgs if message in msg]
     assert len(msgs_with) == count
-
-
-class PerformanceClock:
-    def __init__(self):
-        self.measures = []
-
-    @property
-    def median(self):
-        return np.median(self.measures).item()
-
-    @contextmanager
-    def measure(self):
-        start = time.perf_counter_ns()
-        yield
-        self.measures.append((time.perf_counter_ns() - start) / 1e9)

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -22,6 +22,7 @@ This mostly takes from astropy's method for checking collected_warnings during
 tests.
 """
 import sys
+import time
 import types
 import warnings
 from contextlib import contextmanager
@@ -278,3 +279,18 @@ def assert_warnings_contain(collected_warnings: list, message: str, count: int =
     msgs = [msg.message.args[0].lower() for msg in collected_warnings]
     msgs_with = [msg for msg in msgs if message in msg]
     assert len(msgs_with) == count
+
+
+class PerformanceClock:
+    def __init__(self):
+        self.measures = []
+
+    @property
+    def median(self):
+        return np.median(self.measures).item()
+
+    @contextmanager
+    def measure(self):
+        start = time.perf_counter_ns()
+        yield
+        self.measures.append((time.perf_counter_ns() - start) / 1e9)

--- a/pyresample/utils/row_appendable_array.py
+++ b/pyresample/utils/row_appendable_array.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+
+class RowAppendableArray:
+    def __init__(self, reserve=0):
+        self._reserve_size = reserve
+        self._data = None
+        self._cursor = 0
+
+    def append_row(self, next_array):
+        if self._data is None:
+            self._data = np.empty((self._reserve_size, *next_array.shape[1:]), dtype=next_array.dtype)
+        cursor_end = self._cursor + next_array.shape[0]
+        if cursor_end > self._data.shape[0]:
+            if len(next_array.shape) == 1:
+                self._data = np.append(self._data, next_array)
+            else:
+                self._data = np.row_stack((self._data, next_array))
+        else:
+            self._data[self._cursor:cursor_end] = next_array
+        self._cursor = cursor_end
+
+    def to_array(self):
+        return self._data[:self._cursor]

--- a/pyresample/utils/row_appendable_array.py
+++ b/pyresample/utils/row_appendable_array.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Appendable numpy array with allows for efficient pre-allocation."""
+"""Appendable numpy array which allows for efficient pre-allocation."""
 
 import numpy as np
 

--- a/pyresample/utils/row_appendable_array.py
+++ b/pyresample/utils/row_appendable_array.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2010-2020 Pyresample developers
+# Copyright (C) 2010-2023 Pyresample developers
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/pyresample/utils/row_appendable_array.py
+++ b/pyresample/utils/row_appendable_array.py
@@ -21,13 +21,13 @@ import numpy as np
 
 
 class RowAppendableArray:
-    """ Helper class which allows efficient concatenation of numpy arrays bey pre-allocating buffers
+    """Helper class which allows efficient concatenation of numpy arrays bey pre-allocating buffers.
 
     By default, this class behaves the same as subsequent array concatenations.
     """
 
     def __init__(self, reserve=0):
-        """ Create an appendable array by pre-allocating the bytes specified by reserve."""
+        """Create an appendable array by pre-allocating the bytes specified by reserve."""
         self._reserve_size = reserve
         self._data = None
         self._cursor = 0

--- a/pyresample/utils/row_appendable_array.py
+++ b/pyresample/utils/row_appendable_array.py
@@ -29,7 +29,8 @@ class RowAppendableArray:
     def __init__(self, expected_segments):
         """Create an appendable array by lazily pre-allocating the array buffer.
 
-        The size of the buffer depends on the expected number of segments and the size of the first segment."""
+        The size of the buffer depends on the expected number of segments and the size of the first segment.
+        """
         self._expected_segments = expected_segments
         self._data = None
         self._cursor = 0

--- a/pyresample/utils/row_appendable_array.py
+++ b/pyresample/utils/row_appendable_array.py
@@ -26,16 +26,19 @@ class RowAppendableArray:
     By default, this class behaves the same as subsequent array concatenations.
     """
 
-    def __init__(self, reserve=0):
-        """Create an appendable array by pre-allocating the bytes specified by reserve."""
-        self._reserve_size = reserve
+    def __init__(self, expected_segments):
+        """Create an appendable array by lazily pre-allocating the array buffer.
+
+        The size of the buffer depends on the expected number of segments and the size of the first segment."""
+        self._expected_segments = expected_segments
         self._data = None
         self._cursor = 0
 
     def append_row(self, next_array):
         """Append the specified array."""
         if self._data is None:
-            self._data = np.empty((self._reserve_size, *next_array.shape[1:]), dtype=next_array.dtype)
+            self._data = np.empty((self._expected_segments * next_array.shape[0], *next_array.shape[1:]),
+                                  dtype=next_array.dtype)
         cursor_end = self._cursor + next_array.shape[0]
         if cursor_end > self._data.shape[0]:
             if len(next_array.shape) == 1:

--- a/pyresample/utils/row_appendable_array.py
+++ b/pyresample/utils/row_appendable_array.py
@@ -1,13 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2010-2020 Pyresample developers
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Appendable numpy array with allows for efficient pre-allocation."""
+
 import numpy as np
 
 
 class RowAppendableArray:
+    """ Helper class which allows efficient concatenation of numpy arrays bey pre-allocating buffers
+
+    By default, this class behaves the same as subsequent array concatenations.
+    """
+
     def __init__(self, reserve=0):
+        """ Create an appendable array by pre-allocating the bytes specified by reserve."""
         self._reserve_size = reserve
         self._data = None
         self._cursor = 0
 
     def append_row(self, next_array):
+        """Append the specified array."""
         if self._data is None:
             self._data = np.empty((self._reserve_size, *next_array.shape[1:]), dtype=next_array.dtype)
         cursor_end = self._cursor + next_array.shape[0]
@@ -21,4 +47,5 @@ class RowAppendableArray:
         self._cursor = cursor_end
 
     def to_array(self):
+        """Return the numpy array with all the data appended until now."""
         return self._data[:self._cursor]


### PR DESCRIPTION
When applying `get_neighbour_info` to large target arrays with many segments it significantly slows down due to memcpys performed when concatenating segments. By allowing the user to pre-allocate result arrays these can be avoided resulting in significant speed ups. See also the linked issue.

 - [ ] Closes #504<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
