### PR TITLE
Fix gradient resampling to same area not working

### DIFF
--- a/pyresample/gradient/__init__.py
+++ b/pyresample/gradient/__init__.py
@@ -501,6 +501,8 @@ class ResampleBlocksGradientSearchResampler(BaseResampler):
 
     def precompute(self, **kwargs):
         """Precompute resampling parameters."""
+        if self.source_geo_def == self.target_geo_def:
+            return
         if self.indices_xy is None:
             self.indices_xy = resample_blocks(gradient_resampler_indices_block,
                                               self.source_geo_def, [], self.target_geo_def,
@@ -509,6 +511,8 @@ class ResampleBlocksGradientSearchResampler(BaseResampler):
     @ensure_data_array
     def compute(self, data, method="bilinear", cache_id=None, **kwargs):
         """Perform the resampling."""
+        if self.source_geo_def == self.target_geo_def:
+            return data
         if method == "bilinear":
             fun = block_bilinear_interpolator
         elif method in ["nearest_neighbour", "nn"]:

--- a/pyresample/gradient/__init__.py
+++ b/pyresample/gradient/__init__.py
@@ -501,8 +501,6 @@ class ResampleBlocksGradientSearchResampler(BaseResampler):
 
     def precompute(self, **kwargs):
         """Precompute resampling parameters."""
-        if self.source_geo_def == self.target_geo_def:
-            return
         if self.indices_xy is None:
             self.indices_xy = resample_blocks(gradient_resampler_indices_block,
                                               self.source_geo_def, [], self.target_geo_def,
@@ -511,8 +509,6 @@ class ResampleBlocksGradientSearchResampler(BaseResampler):
     @ensure_data_array
     def compute(self, data, method="bilinear", cache_id=None, **kwargs):
         """Perform the resampling."""
-        if self.source_geo_def == self.target_geo_def:
-            return data
         if method == "bilinear":
             fun = block_bilinear_interpolator
         elif method in ["nearest_neighbour", "nn"]:

--- a/pyresample/resampler.py
+++ b/pyresample/resampler.py
@@ -121,6 +121,8 @@ class BaseResampler:
         Returns (xarray.DataArray): Data resampled to the target area
 
         """
+        if self.source_geo_def == self.target_geo_def:
+            return data
         # default is to mask areas for SwathDefinitions
         if mask_area is None and isinstance(
                 self.source_geo_def, SwathDefinition):

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -288,12 +288,6 @@ class TestRBGradientSearchResamplerArea2Area:
         self.resampler.precompute()
         assert self.resampler.indices_xy.shape == (2, ) + self.dst_area.shape
 
-    def test_precompute_does_nothing_when_src_equals_dst(self):
-        """Test that precomputing does nothing when src and dst areas are equal."""
-        resampler = ResampleBlocksGradientSearchResampler(self.src_area, self.src_area)
-        resampler.precompute()
-        assert self.resampler.indices_xy is None
-
     def test_resampler_accepts_only_dataarrays_if_not_2d(self):
         data = da.ones(self.src_area.shape + (1,), dtype=np.float64, chunks=40)
         self.resampler.precompute()
@@ -490,15 +484,6 @@ class TestRBGradientSearchResamplerArea2Area:
         print(res)
         np.testing.assert_allclose(res, expected_resampled_data)
         assert res.shape == dst_area.shape
-
-    def test_resample_does_nothing_when_src_equals_dst(self):
-        """Test that resampling does nothing when src and dst areas are equal."""
-        data = xr.DataArray(da.arange(np.prod(self.src_area.shape), dtype=np.float64).reshape(self.src_area.shape),
-                            dims=['y', 'x'])
-
-        resampler = ResampleBlocksGradientSearchResampler(self.src_area, self.src_area)
-        result = resampler.resample(data)
-        assert result.data is data.data
 
 
 class TestRBGradientSearchResamplerArea2Swath:

--- a/pyresample/test/test_resamplers/test_resampler.py
+++ b/pyresample/test/test_resamplers/test_resampler.py
@@ -25,6 +25,8 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 from pyresample.future.resamplers.resampler import Resampler
+from pyresample.geometry import AreaDefinition
+from pyresample.resampler import BaseResampler
 
 
 class FakeResampler(Resampler):
@@ -72,3 +74,15 @@ def test_resampler(src, dst):
     resample_results = rs.resample(some_data)
     rs.precompute.assert_called_once()
     assert resample_results.shape == dst.shape
+
+
+def test_base_resampler_does_nothing_when_src_and_dst_areas_are_equal():
+    """Test that the BaseResampler does nothing when the source and target areas are the same."""
+    src_area = AreaDefinition('src', 'src area', None,
+                              {'ellps': 'WGS84', 'h': '35785831', 'proj': 'geos'},
+                              100, 100,
+                              (5550000.0, 5550000.0, -5550000.0, -5550000.0))
+
+    resampler = BaseResampler(src_area, src_area)
+    some_data = np.zeros(src_area.shape, dtype=np.float64)
+    assert resampler.resample(some_data) is some_data


### PR DESCRIPTION
This implements a noop when source and destination areas are the same for gradient search instead of raising an error.

 - [x] Closes #507 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

