### PR TITLE
Ignore pyproj to_proj4 warning when converting an AreaDefinition to a string

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -150,7 +150,7 @@ def _read_yaml_area_file_content(area_file_name):
     """Read one or more area files in to a single dict object."""
     from pyresample.utils import recursive_dict_update
 
-    if isinstance(area_file_name, (str, pathlib.Path)):
+    if isinstance(area_file_name, (str, pathlib.Path, io.IOBase)):
         area_file_name = [area_file_name]
 
     area_dict = {}

--- a/pyresample/future/geometry/area.py
+++ b/pyresample/future/geometry/area.py
@@ -30,6 +30,7 @@ from pyresample.geometry import (  # noqa
     get_geostationary_angle_extent,
     get_geostationary_bounding_box_in_lonlats,
     get_geostationary_bounding_box_in_proj_coords,
+    ignore_pyproj_proj_warnings,
 )
 
 

--- a/pyresample/geo_filter.py
+++ b/pyresample/geo_filter.py
@@ -63,10 +63,10 @@ class GridFilter(object):
         # Get projection coords
         proj_kwargs = {}
         if self.nprocs > 1:
-            proj = _spatial_mp.Proj_MP(**self.area_def.proj_dict)
+            proj = _spatial_mp.Proj_MP(self.area_def.crs)
             proj_kwargs["nprocs"] = self.nprocs
         else:
-            proj = Proj(**self.area_def.proj_dict)
+            proj = Proj(self.area_def.crs)
 
         x_coord, y_coord = proj(lons, lats, **proj_kwargs)
 

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1281,7 +1281,6 @@ class DynamicAreaDefinition(object):
 def _invproj(data_x, data_y, proj_dict):
     """Perform inverse projection."""
     # XXX: does pyproj copy arrays? What can we do so it doesn't?
-    print(f"Running _invproj {data_x.shape}")
     target_proj = Proj(proj_dict)
     lon, lat = target_proj(data_x, data_y, inverse=True)
     return np.stack([lon.astype(data_x.dtype), lat.astype(data_y.dtype)])

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1969,7 +1969,8 @@ class AreaDefinition(_ProjectionDefinition):
         if self.crs.to_epsg() is not None:
             proj_dict = {'EPSG': self.crs.to_epsg()}
         else:
-            proj_dict = self.crs.to_dict()
+            with _ignore_pyproj_proj_warnings():
+                proj_dict = self.crs.to_dict()
 
         res = OrderedDict(description=self.description,
                           projection=OrderedDict(proj_dict),
@@ -2214,7 +2215,7 @@ class AreaDefinition(_ProjectionDefinition):
         Both scalars and arrays are supported. To be used with scarse
         data points instead of slices (see get_lonlats).
         """
-        p = Proj(self.proj_str)
+        p = Proj(self.crs)
         x = self.projection_x_coords
         y = self.projection_y_coords
         return p(x[cols], y[rows], inverse=True)

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Test AreaDefinition objects."""
-
+import io
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -520,7 +520,8 @@ class TestAreaDefinition:
                     '    width: 800\n  area_extent:\n'
                     '    lower_left_xy: [-1370912.72, -909968.64]\n'
                     '    upper_right_xy: [1029087.28, 1490031.36]\n')
-        area_def = parse_area_file(yaml_str, 'areaD')[0]
+        yaml_filelike = io.StringIO(yaml_str)
+        area_def = parse_area_file(yaml_filelike, 'areaD')[0]
         assert area_def == expected
 
         # EPSG
@@ -546,7 +547,8 @@ class TestAreaDefinition:
                         '  area_extent:\n'
                         '    lower_left_xy: [-49739, 5954123]\n'
                         '    upper_right_xy: [1350361, 7354223]'.format(epsg=epsg_yaml))
-            area_def = parse_area_file(yaml_str, 'baws300_sweref99tm')[0]
+            yaml_filelike = io.StringIO(yaml_str)
+            area_def = parse_area_file(yaml_filelike, 'baws300_sweref99tm')[0]
             assert area_def == expected
 
     def test_projection_coordinates(self, create_test_area):

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -805,7 +805,7 @@ class TestAreaDefinition:
         actual = [(np.rad2deg(coord.lon), np.rad2deg(coord.lat)) for coord in area_def.corners]
         np.testing.assert_allclose(actual, expected)
 
-    def test_get_xy_from_lonlat(self, create_test_area):
+    def test_get_array_indices_from_lonlat(self, create_test_area):
         """Test the function get_xy_from_lonlat."""
         x_size = 2
         y_size = 2
@@ -823,54 +823,50 @@ class TestAreaDefinition:
 
         eps_lonlat = 0.01
         eps_meters = 100
-        x__, y__ = area_def.get_xy_from_lonlat(lon_ul + eps_lonlat,
-                                               lat_ul - eps_lonlat)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lon_ul + eps_lonlat, lat_ul - eps_lonlat)
         x_expect, y_expect = 0, 0
         assert x__ == x_expect
         assert y__ == y_expect
-        x__, y__ = area_def.get_xy_from_lonlat(lon_ur - eps_lonlat,
-                                               lat_ur - eps_lonlat)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lon_ur - eps_lonlat, lat_ur - eps_lonlat)
         assert x__ == 1
         assert y__ == 0
-        x__, y__ = area_def.get_xy_from_lonlat(lon_ll + eps_lonlat,
-                                               lat_ll + eps_lonlat)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lon_ll + eps_lonlat, lat_ll + eps_lonlat)
         assert x__ == 0
         assert y__ == 1
-        x__, y__ = area_def.get_xy_from_lonlat(lon_lr - eps_lonlat,
-                                               lat_lr + eps_lonlat)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lon_lr - eps_lonlat, lat_lr + eps_lonlat)
         assert x__ == 1
         assert y__ == 1
 
         lon, lat = p__(1025000 - eps_meters, 25000 - eps_meters, inverse=True)
-        x__, y__ = area_def.get_xy_from_lonlat(lon, lat)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lon, lat)
         assert x__ == 0
         assert y__ == 1
 
         lon, lat = p__(1025000 + eps_meters, 25000 - eps_meters, inverse=True)
-        x__, y__ = area_def.get_xy_from_lonlat(lon, lat)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lon, lat)
         assert x__ == 1
         assert y__ == 1
 
         lon, lat = p__(1025000 - eps_meters, 25000 + eps_meters, inverse=True)
-        x__, y__ = area_def.get_xy_from_lonlat(lon, lat)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lon, lat)
         assert x__ == 0
         assert y__ == 0
 
         lon, lat = p__(1025000 + eps_meters, 25000 + eps_meters, inverse=True)
-        x__, y__ = area_def.get_xy_from_lonlat(lon, lat)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lon, lat)
         assert x__ == 1
         assert y__ == 0
 
         lon, lat = p__(999000, -10, inverse=True)
         with pytest.raises(ValueError):
-            area_def.get_xy_from_lonlat(lon, lat)
+            area_def.get_array_indices_from_lonlat(lon, lat)
         with pytest.raises(ValueError):
-            area_def.get_xy_from_lonlat(0., 0.)
+            area_def.get_array_indices_from_lonlat(0., 0.)
 
         # Test getting arrays back:
         lons = [lon_ll + eps_lonlat, lon_ur - eps_lonlat]
         lats = [lat_ll + eps_lonlat, lat_ur - eps_lonlat]
-        x__, y__ = area_def.get_xy_from_lonlat(lons, lats)
+        x__, y__ = area_def.get_array_indices_from_lonlat(lons, lats)
 
         x_expects = np.array([0, 1])
         y_expects = np.array([1, 0])
@@ -1068,7 +1064,7 @@ class TestAreaDefinition:
     def test_from_epsg(self, area_class):
         """Test the from_epsg class method."""
         sweref = area_class.from_epsg('3006', 2000)
-        assert sweref.name == 'SWEREF99 TM'
+        assert sweref.description == 'SWEREF99 TM'
         assert sweref.proj_dict == {'ellps': 'GRS80', 'no_defs': None,
                                     'proj': 'utm', 'type': 'crs', 'units': 'm',
                                     'zone': 33}

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -489,7 +489,7 @@ class TestRBGradientSearchResamplerArea2Area:
 class TestRBGradientSearchResamplerArea2Swath:
     """Test RBGradientSearchResampler for the Swath to Area case."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the test case."""
         chunks = 20
 
@@ -815,7 +815,7 @@ def test_concatenate_chunks_stack_calls(dask_da):
 class TestGradientCython():
     """Test the core gradient features."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the test case."""
         self.src_x, self.src_y = np.meshgrid(range(10), range(10))
 

--- a/pyresample/test/test_resample_blocks.py
+++ b/pyresample/test/test_resample_blocks.py
@@ -32,7 +32,7 @@ from pyresample.geometry import AreaDefinition
 class TestResampleBlocksArea2Area:
     """Test resample_block in an area to area resampling case."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the test case."""
         self.src_area = AreaDefinition(
             'omerc_otf',

--- a/pyresample/utils/cf.py
+++ b/pyresample/utils/cf.py
@@ -62,7 +62,7 @@ _valid_cf_coordinate_standardnames['geostationary']['y'] = (
 
 
 def _convert_XY_CF_to_Proj(crs, axis_info):
-    """Convert XY values from CF to PROJ convention. With CF =< 1.9 only affects geostrationary projection."""
+    """Convert XY values from CF to PROJ convention. With CF =< 1.9 only affects geostationary projection."""
     crs_dict = crs.to_dict()
     axis_units = axis_info.get('unit') or 'radians'  # unit could be None
     if crs_dict['proj'] == 'geos' and axis_units == 'radians':


### PR DESCRIPTION
This should resolve a majority of the warnings generated during pyresample and satpy tests. There are still many cases of tests using `area_def.proj_str == other_area.proj_str`, but we'll get to those later.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
