### PR TITLE
Remove python versions tested note in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ XArray objects (including dask array support) are provided in separate
 Resampler class interfaces and are in active development.
 Utility functions are available to easily plot data using Cartopy.
 
-Pyresample is tested with Python 2.7 and 3.6, but should additionally work
-on Python 3.4+. Pyresample will drop Python 2.7 at the end of 2019.
-
 [Documentation](https://pyresample.readthedocs.org/en/latest/)
 
 See [pytroll.github.io](http://pytroll.github.io/) for more information on the


### PR DESCRIPTION
The readme file has an outdated section on python versions - this PR removes that section.