### PR TITLE
Add configuration for readthedocs to fail on warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,37 +8,6 @@ concurrency:
 on: [push, pull_request]
 
 jobs:
-  website:
-    name: build website
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
-          python-version: "3.11"
-          environment-file: continuous_integration/environment.yaml
-          activate-environment: test-environment
-
-      - name: Install Satpy
-        shell: bash -l {0}
-        run: |
-          pip install sphinx sphinx_rtd_theme sphinxcontrib-apidoc sphinx-reredirects
-          pip install --no-deps -e .
-
-      - name: Run Sphinx Build
-        shell: bash -l {0}
-        run: |
-          cd docs
-          make html SPHINXOPTS="-W"
-
   test:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@ build:
   tools:
     python: "mambaforge-4.10"
 
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: true
+
 conda:
     environment: docs/environment.yml
 


### PR DESCRIPTION
I noticed that some of the RTD builds had warnings due to bad formatting, but the builds weren't failing. I'd like to know as soon as possible that something isn't building as expected. This sets the proper option for RTD.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
