### PR TITLE
Add builtin 'config' object and 'features.future_geometry' toggle

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -79,10 +79,14 @@ jobs:
 
       - name: Check version number from inside wheel
         if:  matrix.docker-image != 'manylinux2014_i686'
+        # install dependencies
+        # uninstall source installation
+        # move source to make sure it isn't include in checks
         run: |
+          python -m pip install pip-tools
+          python -m piptools compile -o requirements.txt
           mv pyresample unused_src_to_prevent_local_import
-          python -m pip install pyresample
-          python -m pip uninstall -y pyresample
+          python -m pip install -r requirements.txt
           python -m pip install --force-reinstall --no-index --no-cache-dir --no-deps --find-links=./dist/ pyresample
           python -c "import pyresample; print(pyresample.__file__, pyresample.__version__)"
           python -c "import pyresample; assert 'unknown' not in pyresample.__version__, 'incorrect version found'"

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -5,6 +5,7 @@ dependencies:
   - xarray
   - dask
   - distributed
+  - donfig
   - toolz
   - Cython
   - sphinx

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - xarray
   - zarr
   - dask
+  - donfig
   - toolz
   - numpy
   - cython

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -253,4 +253,5 @@ intersphinx_mapping = {
     'pyproj': ('https://pyproj4.github.io/pyproj/dev/', None),
     'proj': ('https://proj.org', None),
     'satpy': ('https://satpy.readthedocs.io/en/stable', None),
+    'donfig': ('https://donfig.readthedocs.io/en/latest', None),
 }

--- a/docs/source/howtos/configuration.rst
+++ b/docs/source/howtos/configuration.rst
@@ -1,0 +1,116 @@
+Configuration
+=============
+
+Pyresample allows certain functionality to be controlled at a global level.
+This allows users to quickly modify behavior at potentially very low levels
+of pyresample without having to specify new arguments throughout their code.
+Configuration is controlled through a central ``config`` object and allows
+setting parameters in one of three ways:
+
+1. Environment variable
+2. YAML file
+3. At runtime with ``pyresample.config``
+
+This functionality is provided by the :doc:`donfig <donfig:configuration>`
+library. The currently available settings are described below.
+Each option is available from all three methods. If specified as an
+environment variable or specified in the YAML file on disk, it must be set
+**before** Satpy is imported.
+
+**YAML Configuration**
+
+YAML files that include these parameters can be in any of the following
+locations:
+
+1. ``<python environment prefix>/etc/pyresample/pyresample.yaml``
+2. ``<user_config_dir>/pyresample.yaml`` (see below)
+3. ``~/.pyresample/pyresample.yaml``
+
+The above ``user_config_dir`` is provided by the ``platformdirs`` package and
+differs by operating system. Typical user config directories are:
+
+* Mac OSX: ``~/Library/Preferences/pyresample``
+* Unix/Linux: ``~/.config/pyresample``
+* Windows: ``C:\\Users\\<username>\\AppData\\Local\\pytroll\\pyresample``
+
+All YAML files found from the above paths will be merged into one
+configuration object (accessed via ``pyresample.config``).
+The YAML contents should be a simple mapping of configuration key to its
+value. For example:
+
+.. code-block:: yaml
+
+    some_key: "some_value"
+
+In some cases, keys may be grouped into sub-dictionaries:
+
+.. code-block:: yaml
+
+    features:
+        future_geometries: true
+
+Lastly, it is possible to specify an additional config path to the above
+options by setting the environment variable ``PYRESAMPLE_CONFIG``. The file
+specified with this environment variable will be added last after all of the
+above paths have been merged together.
+
+**At runtime**
+
+After import, the values can be customized at runtime by doing:
+
+.. code-block:: python
+
+    import pyresample
+    pyresamle.config.set(some_key="some_value")
+    # ... normal pyresample code ...
+
+Or for specific blocks of code:
+
+.. code-block:: python
+
+    import pyresample
+    with pyresample.config.set(some_key="some_value):
+        # ... some satpy code ...
+    # ... code using the original cache_dir
+
+Similarly, if you need to access one of the values you can
+use the ``satpy.config.get`` method.
+
+Feature Flags
+-------------
+
+The below configuration options control whether certain features are made
+available or used by default or overwrite existing behavior. In most cases
+these are used for future changes to pyresample or experimental functionality
+that may change later. These flags are all under the ``features``
+sub-dictionary which requires some extra work to identify the substructure.
+For example:
+
+.. code-block:: python
+
+    import pyresample
+    pyresample.config.set({"features.future_geometries": True})
+
+If using environment variables not the use of double underscores ``__`` in
+parts of the variable name.
+
+Future Geometries
+^^^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``PYRESAMPLE_FEATURES__FUTURE_GEOMETRIES``
+* **YAML/Config Key**: ``features: future_geometries``
+* **Default**: False
+
+Enable the use of future geometry objects (``AreaDefinition``,
+``SwathDefinition``, etc) and overwrite any internal use of the old geometry
+objects. This flag is meant to simplify the switch to future pyresample in
+user code when utility methods like ``create_area_def`` are used. When enabled
+the returned geometry instance will be of the future geometry class. These
+classes can be accessed from:
+
+.. code-block:: python
+
+    from pyresample.future.geometry import AreaDefinition, SwathDefinition
+
+Eventually these classes will be the default in Pyresample 2.0 and this flag
+will have no effect.

--- a/docs/source/howtos/configuration.rst
+++ b/docs/source/howtos/configuration.rst
@@ -71,7 +71,7 @@ Or for specific blocks of code:
     import pyresample
     with pyresample.config.set(some_key="some_value):
         # ... some pyresample code ...
-    # ... code using the original cache_dir
+    # ... code using the original 'some_key' setting
 
 Similarly, if you need to access one of the values you can
 use the ``pyresample.config.get`` method.

--- a/docs/source/howtos/configuration.rst
+++ b/docs/source/howtos/configuration.rst
@@ -15,7 +15,7 @@ This functionality is provided by the :doc:`donfig <donfig:configuration>`
 library. The currently available settings are described below.
 Each option is available from all three methods. If specified as an
 environment variable or specified in the YAML file on disk, it must be set
-**before** Satpy is imported.
+**before** Pyresample is imported.
 
 **YAML Configuration**
 
@@ -70,11 +70,11 @@ Or for specific blocks of code:
 
     import pyresample
     with pyresample.config.set(some_key="some_value):
-        # ... some satpy code ...
+        # ... some pyresample code ...
     # ... code using the original cache_dir
 
 Similarly, if you need to access one of the values you can
-use the ``satpy.config.get`` method.
+use the ``pyresample.config.get`` method.
 
 Feature Flags
 -------------

--- a/docs/source/howtos/index.rst
+++ b/docs/source/howtos/index.rst
@@ -16,6 +16,7 @@ They assume some minimal level of understanding of the
 .. toctree::
    :maxdepth: 1
 
+   configuration
    geo_def
    geometry_utils
    geo_filter

--- a/pyresample/__init__.py
+++ b/pyresample/__init__.py
@@ -19,6 +19,10 @@
 
 import os
 
+from pyresample._config import config  # noqa, isort: skip <- import first so everything below has access
+
+CHUNK_SIZE = int(os.getenv('PYTROLL_CHUNK_SIZE', 4096))  # isort: skip <- imported by below modules
+
 # Backwards compatibility
 from pyresample import geometry  # noqa
 from pyresample import grid  # noqa
@@ -41,16 +45,12 @@ from pyresample.geometry import SwathDefinition  # noqa
 from pyresample.kd_tree import XArrayResamplerNN  # noqa
 from pyresample.plot import area_def2basemap, save_quicklook  # noqa
 
-from pyresample._config import config  # isort: skip <- import first so everything below has access
-
+# Pre-2.0 geometry aliases for convenience
+# To be removed in 2.0
 LegacyAreaDefinition = AreaDefinition
 LegacySwathDefinition = SwathDefinition
-if config.get("features.future_geometries"):
-    from pyresample.future.geometry import AreaDefinition, SwathDefinition
 
 from .version import get_versions  # noqa
-
-CHUNK_SIZE = int(os.getenv('PYTROLL_CHUNK_SIZE', 4096))
 
 __all__ = ['grid', 'image', 'kd_tree', 'utils', 'plot', 'geo_filter', 'geometry', 'CHUNK_SIZE',
            'load_area', 'create_area_def', 'get_area_def', 'parse_area_file', 'convert_def_to_yaml']

--- a/pyresample/__init__.py
+++ b/pyresample/__init__.py
@@ -19,8 +19,6 @@
 
 import os
 
-CHUNK_SIZE = int(os.getenv('PYTROLL_CHUNK_SIZE', 4096))
-
 # Backwards compatibility
 from pyresample import geometry  # noqa
 from pyresample import grid  # noqa
@@ -43,7 +41,16 @@ from pyresample.geometry import SwathDefinition  # noqa
 from pyresample.kd_tree import XArrayResamplerNN  # noqa
 from pyresample.plot import area_def2basemap, save_quicklook  # noqa
 
+from pyresample._config import config  # isort: skip <- import first so everything below has access
+
+LegacyAreaDefinition = AreaDefinition
+LegacySwathDefinition = SwathDefinition
+if config.get("features.future_geometries"):
+    from pyresample.future.geometry import AreaDefinition, SwathDefinition
+
 from .version import get_versions  # noqa
+
+CHUNK_SIZE = int(os.getenv('PYTROLL_CHUNK_SIZE', 4096))
 
 __all__ = ['grid', 'image', 'kd_tree', 'utils', 'plot', 'geo_filter', 'geometry', 'CHUNK_SIZE',
            'load_area', 'create_area_def', 'get_area_def', 'parse_area_file', 'convert_def_to_yaml']

--- a/pyresample/_config.py
+++ b/pyresample/_config.py
@@ -1,4 +1,37 @@
+# Copyright (C) 2023 Pyresample developers
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Central configuration management for pyresample."""
+
+import os
+import sys
+
+import platformdirs
 from donfig import Config
+
+BASE_PATH = os.path.dirname(os.path.realpath(__file__))
+# FIXME: Use package_resources?
+PACKAGE_CONFIG_PATH = os.path.join(BASE_PATH, 'etc')
+
+_user_config_dir = platformdirs.user_config_dir("pyresample", "pytroll")
+_CONFIG_PATHS = [
+    os.path.join(PACKAGE_CONFIG_PATH, 'pyresample.yaml'),
+    os.getenv('PYRESAMPLE_ROOT_CONFIG', os.path.join('/etc', 'pyresample', 'pyresample.yaml')),
+    os.path.join(sys.prefix, 'etc', 'pyresample', 'pyresample.yaml'),
+    os.path.join(_user_config_dir, 'pyresample.yaml'),
+    os.path.join(os.path.expanduser('~'), '.pyresample', 'pyresample.yaml'),
+]
 
 config = Config(
     "pyresample",
@@ -7,4 +40,5 @@ config = Config(
             "future_geometries": False,
         },
     }],
+    paths=_CONFIG_PATHS,
 )

--- a/pyresample/_config.py
+++ b/pyresample/_config.py
@@ -1,0 +1,10 @@
+from donfig import Config
+
+config = Config(
+    "pyresample",
+    defaults=[{
+        "features": {
+            "future_geometries": False,
+        },
+    }],
+)

--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -543,7 +543,7 @@ def _make_area(
         }
         attrs.update(kwargs)
         area_def = AreaDefinition(projection, width, height, area_extent, attrs=attrs)
-        return area_def if pyresample.config.get("features.future_geometries") else area_def.to_legacy()
+        return area_def if pyresample.config.get("features.future_geometries", False) else area_def.to_legacy()
 
     return DynamicAreaDefinition(area_id=area_id, description=description, projection=projection, width=width,
                                  height=height, area_extent=area_extent,

--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -30,6 +30,7 @@ import yaml
 from pyproj import Proj, Transformer
 from pyproj.crs import CRS, CRSError
 
+import pyresample
 from pyresample.utils import proj4_str_to_dict
 
 try:
@@ -523,7 +524,8 @@ def _make_area(
         area_extent: tuple,
         **kwargs):
     """Handle the creation of an area definition for create_area_def."""
-    from pyresample.geometry import AreaDefinition, DynamicAreaDefinition
+    from pyresample.future.geometry import AreaDefinition
+    from pyresample.geometry import DynamicAreaDefinition
 
     # Remove arguments that are only for DynamicAreaDefinition.
     optimize_projection = kwargs.pop('optimize_projection', False)
@@ -534,7 +536,14 @@ def _make_area(
     if shape is not None:
         height, width = shape
     if None not in (area_extent, shape):
-        return AreaDefinition(area_id, description, proj_id, projection, width, height, area_extent, **kwargs)
+        attrs = {
+            "name": area_id,
+            "description": description,
+            "proj_id": proj_id,
+        }
+        attrs.update(kwargs)
+        area_def = AreaDefinition(projection, width, height, area_extent, attrs=attrs)
+        return area_def if pyresample.config.get("features.future_geometries") else area_def.to_legacy()
 
     return DynamicAreaDefinition(area_id=area_id, description=description, projection=projection, width=width,
                                  height=height, area_extent=area_extent,

--- a/pyresample/future/geometry/area.py
+++ b/pyresample/future/geometry/area.py
@@ -123,3 +123,15 @@ class AreaDefinition(LegacyAreaDefinition):
             area_extent,
         )
         self.attrs = attrs
+
+    def to_legacy(self) -> LegacyAreaDefinition:
+        """Create a pyresample 1.x AreaDefinition object from this instance."""
+        return LegacyAreaDefinition(
+            self.attrs.get("name", ""),
+            self.attrs.get("description", ""),
+            self.attrs.get("proj_id", ""),
+            self.crs,
+            self.width,
+            self.height,
+            self.area_extent,
+        )

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -619,7 +619,7 @@ class CoordinateDefinition(BaseDefinition):
         if not isinstance(lons, (np.ndarray, DataArray)):
             lons = np.asanyarray(lons)
             lats = np.asanyarray(lats)
-        super(CoordinateDefinition, self).__init__(lons, lats, nprocs)
+        super().__init__(lons, lats, nprocs)
         if lons.shape == lats.shape and lons.dtype == lats.dtype:
             self.shape = lons.shape
             self.size = lons.size
@@ -747,7 +747,7 @@ class GridDefinition(CoordinateDefinition):
 
     def __init__(self, lons, lats, nprocs=1):
         """Initialize GridDefinition."""
-        super(GridDefinition, self).__init__(lons, lats, nprocs)
+        super().__init__(lons, lats, nprocs)
         if lons.shape != lats.shape:
             raise ValueError('lon and lat grid must have same shape')
         elif lons.ndim != 2:
@@ -802,7 +802,7 @@ class SwathDefinition(CoordinateDefinition):
         if not isinstance(lons, (np.ndarray, DataArray)):
             lons = np.asanyarray(lons)
             lats = np.asanyarray(lats)
-        super(SwathDefinition, self).__init__(lons, lats, nprocs)
+        super().__init__(lons, lats, nprocs)
         if lons.shape != lats.shape:
             raise ValueError('lon and lat arrays must have same shape')
         elif lons.ndim > 2:
@@ -1507,7 +1507,7 @@ class AreaDefinition(_ProjectionDefinition):
                  area_extent, nprocs=1, lons=None, lats=None,
                  dtype=np.float64):
         """Initialize AreaDefinition."""
-        super(AreaDefinition, self).__init__(lons, lats, nprocs)
+        super().__init__(lons, lats, nprocs)
         self.area_id = area_id
         self.description = description
         self.proj_id = proj_id
@@ -2028,7 +2028,7 @@ class AreaDefinition(_ProjectionDefinition):
                     (self.crs == other.crs) and
                     (self.shape == other.shape))
         except AttributeError:
-            return super(AreaDefinition, self).__eq__(other)
+            return super().__eq__(other)
 
     def __ne__(self, other):
         """Test for equality."""
@@ -2878,7 +2878,7 @@ class StackedAreaDefinition(_ProjectionDefinition):
         *kwargs* used here are `nprocs` and `dtype` (see AreaDefinition).
         """
         nprocs = kwargs.get('nprocs', 1)
-        super(StackedAreaDefinition, self).__init__(nprocs=nprocs)
+        super().__init__(nprocs=nprocs)
         self.dtype = kwargs.get('dtype', np.float64)
         self.defs = []
         self.crs_wkt = None

--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -39,7 +39,7 @@ DST_AREA_SHAPE = (80, 85)
 
 
 @pytest.fixture(autouse=True)
-def reset_satpy_config(tmpdir):
+def reset_pyresample_config(tmpdir):
     """Set pyresample config to logical defaults for tests."""
     test_config = {
         "features": {

--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -23,13 +23,12 @@ import pytest
 import xarray as xr
 from pyproj import CRS
 
+from pyresample import LegacyAreaDefinition, LegacySwathDefinition
 from pyresample.future.geometry import (
     AreaDefinition,
     CoordinateDefinition,
     SwathDefinition,
 )
-from pyresample.geometry import AreaDefinition as LegacyAreaDefinition
-from pyresample.geometry import SwathDefinition as LegacySwathDefinition
 from pyresample.test.utils import create_test_latitude, create_test_longitude
 
 SRC_SWATH_2D_SHAPE = (50, 10)

--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -23,6 +23,7 @@ import pytest
 import xarray as xr
 from pyproj import CRS
 
+import pyresample
 from pyresample import LegacyAreaDefinition, LegacySwathDefinition
 from pyresample.future.geometry import (
     AreaDefinition,
@@ -35,6 +36,18 @@ SRC_SWATH_2D_SHAPE = (50, 10)
 SRC_SWATH_1D_SHAPE = (3,)
 SRC_AREA_SHAPE = (50, 10)
 DST_AREA_SHAPE = (80, 85)
+
+
+@pytest.fixture(autouse=True)
+def reset_satpy_config(tmpdir):
+    """Set pyresample config to logical defaults for tests."""
+    test_config = {
+        "features": {
+            "future_geometries": False,
+        },
+    }
+    with pyresample.config.set(test_config):
+        yield
 
 
 @pytest.fixture(params=[LegacySwathDefinition, SwathDefinition],

--- a/pyresample/test/test_config/__init__.py
+++ b/pyresample/test/test_config/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Pyresample developers
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the configuration functionality."""

--- a/pyresample/test/test_config/test_feature_flags.py
+++ b/pyresample/test/test_config/test_feature_flags.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2023 Pyresample developers
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for feature flags changed using configuration."""
+# import importlib
+# import sys
+#
+# import pyresample
+# from pyresample.geometry import AreaDefinition as LegacyAreaDefinition
+# from pyresample.future.geometry import AreaDefinition as FutureAreaDefinition
+#
+#
+# def test_future_geometries():
+#     # with pyresample.config.set({"features.future_geometries": True}):
+#     #     _reload_all_pyresample()
+#     #     from pyresample import AreaDefinition
+#     #     _equal_full_name(AreaDefinition, FutureAreaDefinition)
+#     with pyresample.config.set({"features.future_geometries": False}):
+#         _reload_all_pyresample()
+#         from pyresample import AreaDefinition
+#         _equal_full_name(AreaDefinition, LegacyAreaDefinition)
+#     # reset environment back to default configuration
+#     _reload_all_pyresample()
+#
+#
+# def _equal_full_name(cls1, cls2):
+#     """Compare full module class name.
+#
+#     This is needed when reloading modules makes past instances not the same as new instances.
+#
+#     """
+#     assert cls1.__qualname__ == cls2.__qualname__
+#     assert cls1.__module__ == cls2.__module__
+#
+#
+# def _reload_all_pyresample():
+#     pyresample_mods = [(mod_name, mod) for mod_name, mod in sys.modules.items() if "pyresample" in mod_name and
+#                        ("config" not in mod_name)]
+#     # pyresample_mods = [(mod_name, mod) for mod_name, mod in sys.modules.items() if "pyresample" in mod_name and
+#     #                    ("config" not in mod_name and "pyresample.test" not in mod_name)]
+#     for mod_name, module in pyresample_mods:
+#         # print(f"Reloading {mod_name}")
+#         del sys.modules[mod_name]
+#         # importlib.reload(module)
+#     for mod_name, module in pyresample_mods:
+#         print(f"Reloading {mod_name}")
+#         # del sys.modules[mod_name]
+#         importlib.reload(module)
+#     importlib.reload(sys.modules[__name__])
+#     # for module in pyresample_mods:
+#     #     importlib.reload(module)

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -35,6 +35,7 @@ from pyresample.future.geometry.area import (
 )
 from pyresample.future.geometry.base import get_array_hashable
 from pyresample.geometry import AreaDefinition as LegacyAreaDefinition
+from pyresample.test.utils import assert_future_geometry
 
 
 @pytest.fixture
@@ -1370,9 +1371,7 @@ class TestCreateAreaDef:
         future_geometries = isinstance(base_def, AreaDefinition)
         with pyresample.config.set({"features.future_geometries": future_geometries}):
             area_def = cad(*args, **kwargs)
-        # roundabout isinstance check since future area is currently subclass of legacy area
-        is_new_area = isinstance(area_def, AreaDefinition)
-        assert is_new_area if future_geometries else not is_new_area
+        assert_future_geometry(area_def, future_geometries)
         self._compare_area_defs(area_def, base_def, use_proj4="EPSG" in projection)
 
     def test_create_area_def_extra_combinations(self, create_test_area):

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -33,6 +33,7 @@ from pyresample.future.geometry.area import (
     ignore_pyproj_proj_warnings,
 )
 from pyresample.future.geometry.base import get_array_hashable
+from pyresample.geometry import AreaDefinition as LegacyAreaDefinition
 
 
 @pytest.fixture
@@ -1972,3 +1973,26 @@ class TestBoundary:
                                       [9.37106733, 45.85619242],
                                       [8.08352612, 45.87097006]])
         assert np.allclose(expected_vertices, boundary.vertices)
+
+
+def test_future_to_legacy_conversion():
+    """Test that future AreaDefinitions can be converted to legacy areas."""
+    area_def = AreaDefinition(
+        {
+            'a': '6378144.0',
+            'b': '6356759.0',
+            'lat_0': '50.00',
+            'lat_ts': '50.00',
+            'lon_0': '8.00',
+            'proj': 'stere'
+        },
+        800,
+        800,
+        (-1370912.72, -909968.64000000001, 1029087.28, 1490031.3600000001),
+        attrs={"name": 'areaD'},
+    )
+    legacy_area = area_def.to_legacy()
+    assert isinstance(legacy_area, LegacyAreaDefinition)
+    assert legacy_area.area_extent == area_def.area_extent
+    assert legacy_area.crs == area_def.crs
+    assert legacy_area.area_id == area_def.attrs["name"]

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -481,7 +481,6 @@ class TestRBGradientSearchResamplerArea2Area:
         res = self.resampler.compute(
             data, method='nn',
             fill_value=2.0).compute(scheduler='single-threaded').values
-        print(res)
         np.testing.assert_allclose(res, expected_resampled_data)
         assert res.shape == dst_area.shape
 

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -26,7 +26,12 @@ import numpy as np
 import pytest
 from pyproj import CRS
 
-from pyresample.test.utils import create_test_latitude, create_test_longitude
+import pyresample
+from pyresample.test.utils import (
+    assert_future_geometry,
+    create_test_latitude,
+    create_test_longitude,
+)
 from pyresample.utils import load_cf_area
 from pyresample.utils.row_appendable_array import RowAppendableArray
 
@@ -510,10 +515,13 @@ class TestLoadCFAreaPublic:
             (_prepare_cf_llnocrs, {}, "lat", "lon"),
         ]
     )
-    def test_load_cf_latlon(self, file_func, kwargs, exp_lat, exp_lon):
+    @pytest.mark.parametrize("future_geometries", [False, True])
+    def test_load_cf_latlon(self, file_func, kwargs, exp_lat, exp_lon, future_geometries):
         cf_file = file_func()
-        adef, cf_info = load_cf_area(cf_file, **kwargs)
+        with pyresample.config.set({"features.future_geometries": future_geometries}):
+            adef, cf_info = load_cf_area(cf_file, **kwargs)
         _validate_lonlat_cf_area(adef, cf_info, exp_lon, exp_lat)
+        assert_future_geometry(adef, future_geometries)
 
 
 def _validate_lonlat_cf_area(adef, cf_info, exp_lon, exp_lat):

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -293,14 +293,17 @@ class TestFromRasterio:
         with pytest.raises(ValueError):
             utils.rasterio.get_area_def_from_raster(source)
 
-    def test_get_area_def_from_raster_non_georef_respects_proj_dict(self):
+    @pytest.mark.parametrize("future_geometries", [False, True])
+    def test_get_area_def_from_raster_non_georef_respects_proj_dict(self, future_geometries):
         from affine import Affine
 
         from pyresample import utils
         transform = Affine(300.0379266750948, 0.0, 101985.0,
                            0.0, -300.041782729805, 2826915.0)
         source = tmptiff(transform=transform)
-        area_def = utils.rasterio.get_area_def_from_raster(source, projection="EPSG:3857")
+        with pyresample.config.set({"features.future_geometries": future_geometries}):
+            area_def = utils.rasterio.get_area_def_from_raster(source, projection="EPSG:3857")
+        assert_future_geometry(area_def, future_geometries)
         assert area_def.crs == CRS(3857)
 
 

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -501,27 +501,17 @@ class TestLoadCFAreaPublic:
         assert cf_info['y']['last'] == 1583173.6575
 
     @pytest.mark.parametrize(
-        ("kwargs", "exp_lat", "exp_lon"),
+        ("file_func", "kwargs", "exp_lat", "exp_lon"),
         [
-            ({"variable": "crs", "y": "lat", "x": "lon"}, None, None),
-            ({"variable": "temp"}, "lat", "lon"),
-            ({}, "lat", "lon"),
+            (_prepare_cf_llwgs84, {"variable": "crs", "y": "lat", "x": "lon"}, None, None),
+            (_prepare_cf_llwgs84, {"variable": "temp"}, "lat", "lon"),
+            (_prepare_cf_llwgs84, {}, "lat", "lon"),
+            (_prepare_cf_llnocrs, {"variable": "temp"}, "lat", "lon"),
+            (_prepare_cf_llnocrs, {}, "lat", "lon"),
         ]
     )
-    def test_load_cf_llwgs84(self, kwargs, exp_lat, exp_lon):
-        cf_file = _prepare_cf_llwgs84()
-        adef, cf_info = load_cf_area(cf_file, **kwargs)
-        _validate_lonlat_cf_area(adef, cf_info, exp_lon, exp_lat)
-
-    @pytest.mark.parametrize(
-        ("kwargs", "exp_lat", "exp_lon"),
-        [
-            ({"variable": "temp"}, "lat", "lon"),
-            ({}, "lat", "lon"),
-        ]
-    )
-    def test_load_cf_llnocrs(self, kwargs, exp_lat, exp_lon):
-        cf_file = _prepare_cf_llnocrs()
+    def test_load_cf_latlon(self, file_func, kwargs, exp_lat, exp_lon):
+        cf_file = file_func()
         adef, cf_info = load_cf_area(cf_file, **kwargs)
         _validate_lonlat_cf_area(adef, cf_info, exp_lon, exp_lat)
 

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -23,9 +23,11 @@ import uuid
 from timeit import timeit
 
 import numpy as np
+import pytest
 from pyproj import CRS
 
 from pyresample.test.utils import create_test_latitude, create_test_longitude
+from pyresample.utils import load_cf_area
 from pyresample.utils.row_appendable_array import RowAppendableArray
 
 
@@ -414,182 +416,131 @@ def _prepare_cf_llnocrs():
     return ds
 
 
-class TestLoadCFArea_Public(unittest.TestCase):
+class TestLoadCFAreaPublic:
     """Test public API load_cf_area() for loading an AreaDefinition from netCDF/CF files."""
 
-    def test_load_cf_from_wrong_filepath(self):
-        from pyresample.utils import load_cf_area
-
-        # wrong case #1: the path does not exist
+    def test_load_cf_no_exist(self):
         cf_file = os.path.join(os.path.dirname(__file__), 'test_files', 'does_not_exist.nc')
-        self.assertRaises(FileNotFoundError, load_cf_area, cf_file)
+        with pytest.raises(FileNotFoundError):
+            load_cf_area(cf_file)
 
-        # wrong case #2: the path exists, but is not a netCDF file
+    def test_load_cf_from_not_nc(self):
         cf_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
-        self.assertRaises((ValueError, OSError), load_cf_area, cf_file)
+        with pytest.raises((ValueError, OSError)):
+            load_cf_area(cf_file)
 
-    def test_load_cf_parameters_errors(self):
-        from pyresample.utils import load_cf_area
-
-        # prepare xarray Dataset
+    @pytest.mark.parametrize(
+        ("exc_type", "kwargs"),
+        [
+            (KeyError, {"variable": "doesNotExist"}),
+            (ValueError, {"variable": "Polar_Stereographic_Grid"}),
+            (KeyError, {"variable": "Polar_Stereographic_Grid", "y": "doesNotExist", "x": "xc"}),
+            (ValueError, {"variable": "Polar_Stereographic_Grid", "y": "time", "x": "xc"}),
+            (ValueError, {"variable": "lat"}),
+        ]
+    )
+    def test_load_cf_parameters_errors(self, exc_type, kwargs):
         cf_file = _prepare_cf_nh10km()
+        with pytest.raises(exc_type):
+            load_cf_area(cf_file, **kwargs)
 
-        # try to load from a variable= that does not exist
-        self.assertRaises(KeyError, load_cf_area, cf_file, 'doesNotExist')
-
-        # try to load from a variable= that is itself is a grid_mapping, but without y= or x=
-        self.assertRaises(ValueError, load_cf_area, cf_file, 'Polar_Stereographic_Grid',)
-
-        # try to load using a variable= that is a valid grid_mapping container, but use wrong x= and y=
-        self.assertRaises(KeyError, load_cf_area, cf_file, 'Polar_Stereographic_Grid', y='doesNotExist', x='xc',)
-        self.assertRaises(ValueError, load_cf_area, cf_file, 'Polar_Stereographic_Grid', y='time', x='xc',)
-
-        # try to load using a variable= that does not define a grid mapping
-        self.assertRaises(ValueError, load_cf_area, cf_file, 'lat',)
-
-    def test_load_cf_nh10km(self):
-        from pyresample.utils import load_cf_area
-
-        def validate_nh10km_adef(adef):
-            self.assertEqual(adef.shape, (1120, 760))
-            xc = adef.projection_x_coords
-            yc = adef.projection_y_coords
-            self.assertEqual(xc[0], -3845000.0, msg="Wrong x axis (index 0)")
-            self.assertEqual(xc[1], xc[0] + 10000.0, msg="Wrong x axis (index 1)")
-            self.assertEqual(yc[0], 5845000.0, msg="Wrong y axis (index 0)")
-            self.assertEqual(yc[1], yc[0] - 10000.0, msg="Wrong y axis (index 1)")
-
-        # prepare xarray Dataset
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"variable": "Polar_Stereographic_Grid", "y": "yc", "x": "xc"},
+            {"variable": "ice_conc"},
+            {},
+        ]
+    )
+    def test_load_cf_nh10km(self, kwargs):
         cf_file = _prepare_cf_nh10km()
+        adef, _ = load_cf_area(cf_file, **kwargs)
+        assert adef.shape == (1120, 760)
+        xc = adef.projection_x_coords
+        yc = adef.projection_y_coords
+        assert xc[0] == -3845000.0, "Wrong x axis (index 0)"
+        assert xc[1] == xc[0] + 10000.0, "Wrong x axis (index 1)"
+        assert yc[0] == 5845000.0, "Wrong y axis (index 0)"
+        assert yc[1] == yc[0] - 10000.0, "Wrong y axis (index 1)"
 
-        # load using a variable= that is a valid grid_mapping container
-        adef, _ = load_cf_area(cf_file, 'Polar_Stereographic_Grid', y='yc', x='xc',)
-        validate_nh10km_adef(adef)
-
-        # load using a variable= that has a :grid_mapping attribute
-        adef, _ = load_cf_area(cf_file, 'ice_conc')
-        validate_nh10km_adef(adef)
-
-        # load without using a variable=
-        adef, _ = load_cf_area(cf_file)
-        validate_nh10km_adef(adef)
-
-    def test_load_cf_nh10km_cfinfo(self):
-        from pyresample.utils import load_cf_area
-
-        def validate_nh10km_cfinfo(cfinfo, variable='ice_conc', lat='lat', lon='lon'):
-            # test some of the fields
-            self.assertEqual(cf_info['variable'], variable)
-            self.assertEqual(cf_info['grid_mapping_variable'], 'Polar_Stereographic_Grid')
-            self.assertEqual(cf_info['type_of_grid_mapping'], 'polar_stereographic')
-            self.assertEqual(cf_info['lon'], lon)
-            self.assertEqual(cf_info['lat'], lat)
-            self.assertEqual(cf_info['x']['varname'], 'xc')
-            self.assertEqual(cf_info['x']['first'], -3845.0)
-            self.assertEqual(cf_info['y']['varname'], 'yc')
-            self.assertEqual(cf_info['y']['last'], -5345.0)
-
-        # prepare xarray Dataset
+    @pytest.mark.parametrize(
+        ("kwargs", "exp_var", "exp_lat", "exp_lon"),
+        [
+            ({"variable": "Polar_Stereographic_Grid", "y": "yc", "x": "xc"}, "Polar_Stereographic_Grid", None, None),
+            ({"variable": "ice_conc"}, "ice_conc", "lat", "lon"),
+            ({}, "ice_conc", "lat", "lon"),
+        ]
+    )
+    def test_load_cf_nh10km_cfinfo(self, kwargs, exp_var, exp_lat, exp_lon):
         cf_file = _prepare_cf_nh10km()
+        _, cf_info = load_cf_area(cf_file, **kwargs)
+        assert cf_info['variable'] == exp_var
+        assert cf_info['grid_mapping_variable'] == 'Polar_Stereographic_Grid'
+        assert cf_info['type_of_grid_mapping'] == 'polar_stereographic'
+        assert cf_info['lon'] == exp_lon
+        assert cf_info['lat'] == exp_lat
+        assert cf_info['x']['varname'] == 'xc'
+        assert cf_info['x']['first'] == -3845.0
+        assert cf_info['y']['varname'] == 'yc'
+        assert cf_info['y']['last'] == -5345.0
 
-        # load using a variable= that is a valid grid_mapping container
-        _, cf_info = load_cf_area(cf_file, 'Polar_Stereographic_Grid', y='yc', x='xc')
-        validate_nh10km_cfinfo(cf_info, variable='Polar_Stereographic_Grid', lat=None, lon=None)
-
-        # load using a variable= that has a :grid_mapping attribute
-        _, cf_info = load_cf_area(cf_file, 'ice_conc')
-        validate_nh10km_cfinfo(cf_info)
-
-        # load without using a variable=
-        _, cf_info = load_cf_area(cf_file)
-        validate_nh10km_cfinfo(cf_info)
-
-    def test_load_cf_goes(self):
-        from pyresample.utils import load_cf_area
-
-        def validate_goes(adef, cfinfo):
-            # test some of the fields
-            self.assertEqual(cf_info['grid_mapping_variable'], 'GOES-East')
-            self.assertEqual(cf_info['type_of_grid_mapping'], 'geostationary')
-            self.assertEqual(cf_info['x']['varname'], 'x')
-            self.assertEqual(cf_info['x']['first'], -3627271.2913)
-            self.assertEqual(cf_info['y']['varname'], 'y')
-            self.assertEqual(cf_info['y']['last'], 1583173.6575)
-
-        # prepare xarray Dataset
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"variable": "C13"},
+            {},
+        ])
+    def test_load_cf_goes(self, kwargs):
         cf_file = _prepare_cf_goes()
+        adef, cf_info = load_cf_area(cf_file, **kwargs)
+        assert cf_info['grid_mapping_variable'] == 'GOES-East'
+        assert cf_info['type_of_grid_mapping'] == 'geostationary'
+        assert cf_info['x']['varname'] == 'x'
+        assert cf_info['x']['first'] == -3627271.2913
+        assert cf_info['y']['varname'] == 'y'
+        assert cf_info['y']['last'] == 1583173.6575
 
-        # load using a variable=temp
-        adef, cf_info = load_cf_area(cf_file, 'C13')
-        validate_goes(adef, cf_info)
-
-        # load using a variable=None
-        adef, cf_info = load_cf_area(cf_file)
-        validate_goes(adef, cf_info)
-
-    def test_load_cf_llwgs84(self):
-        from pyresample.utils import load_cf_area
-
-        def validate_llwgs84(adef, cfinfo, lat='lat', lon='lon'):
-            self.assertEqual(adef.shape, (19, 37))
-            xc = adef.projection_x_coords
-            yc = adef.projection_y_coords
-            self.assertEqual(xc[0], -180., msg="Wrong x axis (index 0)")
-            self.assertEqual(xc[1], -180. + 10.0, msg="Wrong x axis (index 1)")
-            self.assertEqual(yc[0], -90., msg="Wrong y axis (index 0)")
-            self.assertEqual(yc[1], -90. + 10.0, msg="Wrong y axis (index 1)")
-            self.assertEqual(cfinfo['lon'], lon)
-            self.assertEqual(cf_info['lat'], lat)
-            self.assertEqual(cf_info['type_of_grid_mapping'], 'latitude_longitude')
-            self.assertEqual(cf_info['x']['varname'], 'lon')
-            self.assertEqual(cf_info['x']['first'], -180.)
-            self.assertEqual(cf_info['y']['varname'], 'lat')
-            self.assertEqual(cf_info['y']['first'], -90.)
-
-        # prepare xarray Dataset
+    @pytest.mark.parametrize(
+        ("kwargs", "exp_lat", "exp_lon"),
+        [
+            ({"variable": "crs", "y": "lat", "x": "lon"}, None, None),
+            ({"variable": "temp"}, "lat", "lon"),
+            ({}, "lat", "lon"),
+        ]
+    )
+    def test_load_cf_llwgs84(self, kwargs, exp_lat, exp_lon):
         cf_file = _prepare_cf_llwgs84()
+        adef, cf_info = load_cf_area(cf_file, **kwargs)
+        _validate_lonlat_cf_area(adef, cf_info, exp_lon, exp_lat)
 
-        # load using a variable= that is a valid grid_mapping container
-        adef, cf_info = load_cf_area(cf_file, 'crs', y='lat', x='lon')
-        validate_llwgs84(adef, cf_info, lat=None, lon=None)
-
-        # load using a variable=temp
-        adef, cf_info = load_cf_area(cf_file, 'temp')
-        validate_llwgs84(adef, cf_info)
-
-        # load using a variable=None
-        adef, cf_info = load_cf_area(cf_file)
-        validate_llwgs84(adef, cf_info)
-
-    def test_load_cf_llnocrs(self):
-        from pyresample.utils import load_cf_area
-
-        def validate_llnocrs(adef, cfinfo, lat='lat', lon='lon'):
-            self.assertEqual(adef.shape, (19, 37))
-            xc = adef.projection_x_coords
-            yc = adef.projection_y_coords
-            self.assertEqual(xc[0], -180., msg="Wrong x axis (index 0)")
-            self.assertEqual(xc[1], -180. + 10.0, msg="Wrong x axis (index 1)")
-            self.assertEqual(yc[0], -90., msg="Wrong y axis (index 0)")
-            self.assertEqual(yc[1], -90. + 10.0, msg="Wrong y axis (index 1)")
-            self.assertEqual(cfinfo['lon'], lon)
-            self.assertEqual(cf_info['lat'], lat)
-            self.assertEqual(cf_info['type_of_grid_mapping'], 'latitude_longitude')
-            self.assertEqual(cf_info['x']['varname'], 'lon')
-            self.assertEqual(cf_info['x']['first'], -180.)
-            self.assertEqual(cf_info['y']['varname'], 'lat')
-            self.assertEqual(cf_info['y']['first'], -90.)
-
-        # prepare xarray Dataset
+    @pytest.mark.parametrize(
+        ("kwargs", "exp_lat", "exp_lon"),
+        [
+            ({"variable": "temp"}, "lat", "lon"),
+            ({}, "lat", "lon"),
+        ]
+    )
+    def test_load_cf_llnocrs(self, kwargs, exp_lat, exp_lon):
         cf_file = _prepare_cf_llnocrs()
+        adef, cf_info = load_cf_area(cf_file, **kwargs)
+        _validate_lonlat_cf_area(adef, cf_info, exp_lon, exp_lat)
 
-        # load using a variable=temp
-        adef, cf_info = load_cf_area(cf_file, 'temp')
-        validate_llnocrs(adef, cf_info)
 
-        # load using a variable=None
-        adef, cf_info = load_cf_area(cf_file)
-        validate_llnocrs(adef, cf_info)
+def _validate_lonlat_cf_area(adef, cf_info, exp_lon, exp_lat):
+    assert adef.shape == (19, 37)
+    xc = adef.projection_x_coords
+    yc = adef.projection_y_coords
+    assert xc[0] == -180., "Wrong x axis (index 0)"
+    assert xc[1] == -180. + 10.0, "Wrong x axis (index 1)"
+    assert yc[0] == -90., "Wrong y axis (index 0)"
+    assert yc[1] == -90. + 10.0, "Wrong y axis (index 1)"
+    assert cf_info['lon'] == exp_lon
+    assert cf_info['lat'] == exp_lat
+    assert cf_info['type_of_grid_mapping'] == 'latitude_longitude'
+    assert cf_info['x']['varname'] == 'lon'
+    assert cf_info['x']['first'] == -180.
+    assert cf_info['y']['varname'] == 'lat'
+    assert cf_info['y']['first'] == -90.
 
 
 class TestLoadCFArea_Private(unittest.TestCase):

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -278,3 +278,11 @@ def assert_warnings_contain(collected_warnings: list, message: str, count: int =
     msgs = [msg.message.args[0].lower() for msg in collected_warnings]
     msgs_with = [msg for msg in msgs if message in msg]
     assert len(msgs_with) == count
+
+
+def assert_future_geometry(area_def, expect_future_geometry):
+    """Check that the provided geometry is an instance of a pyresample 2.0 geometry class."""
+    # roundabout isinstance check since future area is currently a subclass of legacy area
+    from pyresample.future.geometry import AreaDefinition
+    is_new_area = isinstance(area_def, AreaDefinition)
+    assert is_new_area if expect_future_geometry else not is_new_area

--- a/pyresample/utils/cf.py
+++ b/pyresample/utils/cf.py
@@ -307,17 +307,14 @@ def _load_cf_area_one_variable_axis(nc_handle, variable, type_of_grid_mapping, y
 
 def _load_cf_area_one_variable_areadef(axis_info, crs, unit, grid_mapping_variable):
     """Prepare the AreaDefinition object."""
-    from pyresample import geometry
-
-    # create shape
+    from pyresample import create_area_def
     shape = (axis_info['y']['nb'], axis_info['x']['nb'])
-
-    # get area extent from the x and y info
     extent = _get_area_extent_from_cf_axis(axis_info['x'], axis_info['y'])
-
-    # finally prepare the AreaDefinition object
-    return geometry.AreaDefinition.from_extent(grid_mapping_variable, crs,
-                                               shape, extent, units=unit)
+    return create_area_def(grid_mapping_variable, crs,
+                           width=shape[1],
+                           height=shape[0],
+                           area_extent=extent,
+                           units=unit)
 
 
 def _load_cf_area_one_variable(nc_handle, variable, y=None, x=None):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ import versioneer
 
 requirements = ['setuptools>=3.2', 'pyproj>=3.0', 'configobj',
                 'pykdtree>=1.3.1', 'pyyaml', 'numpy>=1.10.0',
-                "shapely",
+                "shapely", "donfig",
                 ]
 
 if sys.version_info < (3, 10):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ import versioneer
 
 requirements = ['setuptools>=3.2', 'pyproj>=3.0', 'configobj',
                 'pykdtree>=1.3.1', 'pyyaml', 'numpy>=1.10.0',
-                "shapely", "donfig",
+                "shapely", "donfig", "platformdirs",
                 ]
 
 if sys.version_info < (3, 10):


### PR DESCRIPTION
This is the first step of many to allow users a way of transitioning easily between pyresample 1.x and pyresample 2.x interfaces and objects. As a first step this PR adds a new `pyresample.config` object using `donfig` and includes a `features.future_geometries` boolean flag. This flag modifies utility functions like `create_area_def` to return a future `AreaDefinition` instead of the old/existing `AreaDefinition`. Along with some changes to imports users should be able to easily switch usage to the new geometry objects semi-easily (I think).

This also adds a `to_legacy()` method to the future area so it is easier to create the future area but return the legacy version.

As part of these changes I originally added an import in `pyresample/__init__.py` so that importing `AreaDefinition` and `SwathDefinition` from `pyresample` would get you the new versions of the classes if this toggle config flag was set. This seemed near impossible to test so I ended up removing it.

TODO:
 - [x] Add documentation on configuration
 - [x] Modify other utility methods that create AreaDefinitions to use the toggle

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
