### PR TITLE
Fix performance regression in base resampler class when comparing geometries

### DIFF
--- a/pyresample/test/test_resamplers/test_resampler.py
+++ b/pyresample/test/test_resamplers/test_resampler.py
@@ -20,12 +20,14 @@ from __future__ import annotations
 
 from unittest import mock
 
+import dask.array as da
 import numpy as np
 import pytest
+import xarray as xr
 from pytest_lazyfixture import lazy_fixture
 
 from pyresample.future.resamplers.resampler import Resampler
-from pyresample.geometry import AreaDefinition
+from pyresample.geometry import AreaDefinition, SwathDefinition
 from pyresample.resampler import BaseResampler
 
 
@@ -76,13 +78,68 @@ def test_resampler(src, dst):
     assert resample_results.shape == dst.shape
 
 
-def test_base_resampler_does_nothing_when_src_and_dst_areas_are_equal():
+@pytest.mark.parametrize(
+    ("use_swaths", "copy_dst_swath"),
+    [
+        (False, None),
+        (True, None),  # same objects are equal
+        (True, "dask"),  # same dask tasks are equal
+        (True, "swath_def"),  # same underlying arrays are equal
+    ])
+def test_base_resampler_does_nothing_when_src_and_dst_areas_are_equal(_geos_area, use_swaths, copy_dst_swath):
     """Test that the BaseResampler does nothing when the source and target areas are the same."""
+    src_geom = _geos_area if not use_swaths else _xarray_swath_def_from_area(_geos_area)
+    dst_geom = src_geom
+    if copy_dst_swath == "dask":
+        dst_geom = _xarray_swath_def_from_area(_geos_area)
+    elif copy_dst_swath == "swath_def":
+        dst_geom = SwathDefinition(dst_geom.lons, dst_geom.lats)
+
+    resampler = BaseResampler(src_geom, dst_geom)
+    some_data = xr.DataArray(da.zeros(src_geom.shape, dtype=np.float64), dims=('y', 'x'))
+    assert resampler.resample(some_data) is some_data
+
+
+@pytest.mark.parametrize(
+    ("src_area", "numpy_swath"),
+    [
+        (False, False),
+        (False, True),
+        (True, False),
+    ])
+@pytest.mark.parametrize("dst_area", [False, True])
+def test_base_resampler_unequal_geometries(_geos_area, _geos_area2, src_area, numpy_swath, dst_area):
+    """Test cases where BaseResampler geometries are not considered equal."""
+    src_geom = _geos_area if src_area else _xarray_swath_def_from_area(_geos_area, numpy_swath)
+    dst_geom = _geos_area2 if dst_area else _xarray_swath_def_from_area(_geos_area2)
+    resampler = BaseResampler(src_geom, dst_geom)
+    some_data = xr.DataArray(da.zeros(src_geom.shape, dtype=np.float64), dims=('y', 'x'))
+    with pytest.raises(NotImplementedError):
+        resampler.resample(some_data)
+
+
+def _xarray_swath_def_from_area(area_def, use_numpy=False):
+    chunks = None if use_numpy else -1
+    lons_da, lats_da = area_def.get_lonlats(chunks=chunks)
+    lons = xr.DataArray(lons_da, dims=('y', 'x'))
+    lats = xr.DataArray(lats_da, dims=('y', 'x'))
+    swath_def = SwathDefinition(lons, lats)
+    return swath_def
+
+
+@pytest.fixture
+def _geos_area():
     src_area = AreaDefinition('src', 'src area', None,
                               {'ellps': 'WGS84', 'h': '35785831', 'proj': 'geos'},
                               100, 100,
                               (5550000.0, 5550000.0, -5550000.0, -5550000.0))
+    return src_area
 
-    resampler = BaseResampler(src_area, src_area)
-    some_data = np.zeros(src_area.shape, dtype=np.float64)
-    assert resampler.resample(some_data) is some_data
+
+@pytest.fixture
+def _geos_area2():
+    src_area = AreaDefinition('src', 'src area', None,
+                              {'ellps': 'WGS84', 'h': '35785831', 'proj': 'geos'},
+                              200, 200,
+                              (5550000.0, 5550000.0, -5550000.0, -5550000.0))
+    return src_area


### PR DESCRIPTION
As mentioned in #517, the new comparison added to the base resampler class in #508 was significantly slowing down any cases where non-areas were involved. This was most noticeable with EWA resampling as it is based on this resampler class and only deals with swath definitions.

The primary issue is/was that if the swaths are *not* equal the `==` used in the `if` statement was comparing the every coordinate (every pixel) of the source swath arrays to every pixel of the area definitions generated coordinates. This is usually not necessary since when we get to that point the objects are probably not equal and two swaths that aren't the same exact objects (or the underlying arrays are not the same) are probably not equal even if they have the same shape.

This PR is the first step in a proper fix. This should be released in a 1.27.1 release to fix the performance issue. The second step will be a separate PR (as discussed on the pytroll slack) where a `coordinates_equal` method will be added to the geometries to compare coordinates values no matter the cost in performance. The `__eq__` method will be updated to be strict about objects needing to be the same type and then take the shortcuts implemented in this PR.

 - [x] Closes #517  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
