### PR TITLE
Handle value-less parameters in `proj4_dict_to_str`

### DIFF
--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -214,6 +214,16 @@ class TestMisc(unittest.TestCase):
         # EPSG to PROJ.4 can be lossy
         # self.assertEqual(utils._proj4.proj4_dict_to_str(proj_dict), proj_str)  # round-trip
 
+    def test_proj4_str_dict_conversion_with_valueless_parameter(self):
+        from pyresample import utils
+
+        # Value-less south parameter
+        proj_str = "+ellps=WGS84 +no_defs +proj=utm +south +type=crs +units=m +zone=54"
+        proj_dict = utils.proj4.proj4_str_to_dict(proj_str)
+        proj_str2 = utils.proj4.proj4_dict_to_str(proj_dict)
+        proj_dict2 = utils.proj4.proj4_str_to_dict(proj_str2)
+        self.assertDictEqual(proj_dict, proj_dict2)
+
     def test_def2yaml_converter(self):
         import tempfile
 

--- a/pyresample/utils/proj4.py
+++ b/pyresample/utils/proj4.py
@@ -64,7 +64,7 @@ def proj4_dict_to_str(proj4_dict, sort=False):
     params = []
     for key, val in items:
         key = str(key) if key.startswith('+') else '+' + str(key)
-        if key in ['+no_defs', '+no_off', '+no_rot']:
+        if key in ['+no_defs', '+no_off', '+no_rot'] or val is None:
             param = key
         else:
             param = '{}={}'.format(key, val)


### PR DESCRIPTION
Fix bug in `AreaDefinition.proj_str` where value-less parameters are given a value of `None`:

```
>>> ad = pyresample.AreaDefinition(
...     area_id='area_id',
...     description='description',
...     proj_id='tasmania_utm',
...     projection='+ellps=WGS84 +no_defs +proj=utm +south +towgs84=0,0,0 +type=crs +units=m +zone=50',
...     area_extent=(701609.0, 5127659.0, 901609.0, 5327659.0),
...     height=10,
...     width=10,
... )
>>> 
>>> ad.proj_str
(path to venv)/lib/python3.11/site-packages/pyproj/crs/crs.py:1286: UserWarning: You will likely lose important projection information when converting to a PROJ string from another format. See: https://proj.org/faq.html#what-is-the-best-format-for-describing-coordinate-reference-systems
  proj = self._crs.to_proj4(version=version)
'+ellps=WGS84 +no_defs +proj=utm +south=None +type=crs +units=m +zone=50'
```


 - [ x ] Tests added <!-- for all bug fixes or enhancements -->
 - [ x ] Tests passed <!-- for all non-documentation changes -->
 - [ x ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
