### PR TITLE
Fix DynamicAreaDefinition not preserving user's requested resolution

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1127,18 +1127,24 @@ class DynamicAreaDefinition(object):
             height, width = shape
             x_resolution = (corners[2] - corners[0]) * 1.0 / (width - 1)
             y_resolution = (corners[3] - corners[1]) * 1.0 / (height - 1)
+            area_extent = (corners[0] - x_resolution / 2,
+                           corners[1] - y_resolution / 2,
+                           corners[2] + x_resolution / 2,
+                           corners[3] + y_resolution / 2)
         else:
             x_resolution, y_resolution = resolution
-            width = int(np.rint((corners[2] - corners[0]) * 1.0 / x_resolution + 1))
-            height = int(np.rint((corners[3] - corners[1]) * 1.0 / y_resolution + 1))
-            # align corners with pixel resolution
-            corners[2] = corners[0] + (width - 1) * x_resolution
-            corners[3] = corners[1] + (height - 1) * y_resolution
+            half_x = x_resolution / 2
+            half_y = y_resolution / 2
+            # align extents with pixel resolution
+            area_extent = (
+                math.floor((corners[0] - half_x) / x_resolution) * x_resolution,
+                math.floor((corners[1] - half_y) / y_resolution) * y_resolution,
+                math.ceil((corners[2] + half_x) / x_resolution) * x_resolution,
+                math.ceil((corners[3] + half_y) / y_resolution) * y_resolution,
+            )
+            width = int(round((area_extent[2] - area_extent[0]) / x_resolution))
+            height = int(round((area_extent[3] - area_extent[1]) / y_resolution))
 
-        area_extent = (corners[0] - x_resolution / 2,
-                       corners[1] - y_resolution / 2,
-                       corners[2] + x_resolution / 2,
-                       corners[3] + y_resolution / 2)
         return area_extent, width, height
 
     def _update_corners_for_full_extent(self, corners, shape, resolution, projection):

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1131,6 +1131,9 @@ class DynamicAreaDefinition(object):
             x_resolution, y_resolution = resolution
             width = int(np.rint((corners[2] - corners[0]) * 1.0 / x_resolution + 1))
             height = int(np.rint((corners[3] - corners[1]) * 1.0 / y_resolution + 1))
+            # align corners with pixel resolution
+            corners[2] = corners[0] + (width - 1) * x_resolution
+            corners[3] = corners[1] + (height - 1) * y_resolution
 
         area_extent = (corners[0] - x_resolution / 2,
                        corners[1] - y_resolution / 2,

--- a/pyresample/test/test_geometry_legacy.py
+++ b/pyresample/test/test_geometry_legacy.py
@@ -291,14 +291,14 @@ class TestDynamicAreaDefinition:
                              resolution=3000,
                              proj_info={'lon_0': 16, 'lat_0': 58})
 
-        np.testing.assert_allclose(result.area_extent, (-432079.38952,
-                                                        -872594.690447,
-                                                        431920.61048,
-                                                        903405.309553))
+        np.testing.assert_allclose(result.area_extent, (-435000.0,
+                                                        -873000.0,
+                                                        435000.0,
+                                                        906000.0))
         assert result.proj_dict['lon_0'] == 16
         assert result.proj_dict['lat_0'] == 58
-        assert result.width == 288
-        assert result.height == 592
+        assert result.width == 290
+        assert result.height == 593
         assert result.pixel_size_x == 3000
         assert result.pixel_size_y == 3000
 
@@ -306,15 +306,15 @@ class TestDynamicAreaDefinition:
         result = area.freeze((lons, lats),
                              resolution=3000,
                              proj_info={'lon_0': 0})
-        np.testing.assert_allclose(result.area_extent, (538546.7274949469,
-                                                        5380808.879250369,
-                                                        1723546.727495,
-                                                        6997808.87925))
+        np.testing.assert_allclose(result.area_extent, (537000.0,
+                                                        5379000.0,
+                                                        1725000.0,
+                                                        6999000.0))
         assert result.proj_dict['lon_0'] == 0
         # lat_0 could be provided or not depending on version of pyproj
         assert result.proj_dict.get('lat_0', 0) == 0
-        assert result.width == 395
-        assert result.height == 539
+        assert result.width == 396
+        assert result.height == 540
         assert result.pixel_size_x == 3000
         assert result.pixel_size_y == 3000
 
@@ -394,11 +394,11 @@ class TestDynamicAreaDefinition:
         if is_pole:
             assert extent[0] < -178
             assert extent[2] > 178
-            assert result.width == 64088
+            assert result.width == 64090
         else:
             assert extent[0] > 0
             assert extent[2] > 0
-            assert result.width == 1787
+            assert result.width == 1788
         assert result.height == 2680
 
     def test_freeze_with_bb(self):
@@ -457,10 +457,10 @@ class TestDynamicAreaDefinition:
             "exclude_proj_components"
         ),
         [
-            (None, (21, 59), (164.75, 24.75, 194.25, 35.25), tuple(), ("+pm=180",)),
-            ("modify_extents", (21, 59), (164.75, 24.75, 194.25, 35.25), tuple(), ("+pm=180",)),
-            ("modify_crs", (21, 59), (164.75 - 180.0, 24.75, 194.25 - 180.0, 35.25), ("+pm=180",), tuple()),
-            ("global_extents", (21, 720), (-180.0, 24.75, 180.0, 35.25), tuple(), ("+pm=180",)),
+            (None, (22, 60), (164.5, 24.5, 194.5, 35.5), tuple(), ("+pm=180",)),
+            ("modify_extents", (22, 60), (164.5, 24.5, 194.5, 35.5), tuple(), ("+pm=180",)),
+            ("modify_crs", (22, 60), (164.5 - 180.0, 24.5, 194.5 - 180.0, 35.5), ("+pm=180",), tuple()),
+            ("global_extents", (22, 720), (-180.0, 24.5, 180.0, 35.5), tuple(), ("+pm=180",)),
         ],
     )
     @pytest.mark.parametrize("use_dask", [False, True])

--- a/pyresample/test/test_geometry_legacy.py
+++ b/pyresample/test/test_geometry_legacy.py
@@ -293,27 +293,30 @@ class TestDynamicAreaDefinition:
 
         np.testing.assert_allclose(result.area_extent, (-432079.38952,
                                                         -872594.690447,
-                                                        432079.38952,
-                                                        904633.303964))
+                                                        431920.61048,
+                                                        903405.309553))
         assert result.proj_dict['lon_0'] == 16
         assert result.proj_dict['lat_0'] == 58
         assert result.width == 288
         assert result.height == 592
+        assert result.pixel_size_x == 3000
+        assert result.pixel_size_y == 3000
 
-        # make sure that setting `proj_info` once doesn't
-        # set it in the dynamic area
+        # make sure that setting `proj_info` once doesn't set it in the dynamic area
         result = area.freeze((lons, lats),
                              resolution=3000,
                              proj_info={'lon_0': 0})
         np.testing.assert_allclose(result.area_extent, (538546.7274949469,
                                                         5380808.879250369,
-                                                        1724415.6519203288,
-                                                        6998895.701001488))
+                                                        1723546.727495,
+                                                        6997808.87925))
         assert result.proj_dict['lon_0'] == 0
         # lat_0 could be provided or not depending on version of pyproj
         assert result.proj_dict.get('lat_0', 0) == 0
         assert result.width == 395
         assert result.height == 539
+        assert result.pixel_size_x == 3000
+        assert result.pixel_size_y == 3000
 
     def test_freeze_when_area_is_optimized_and_has_a_resolution(self):
         """Test freezing an optimized area with a resolution."""

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -485,7 +485,6 @@ class TestRBGradientSearchResamplerArea2Area:
         res = self.resampler.compute(
             data, method='nn',
             fill_value=2.0).compute(scheduler='single-threaded').values
-        print(res)
         np.testing.assert_allclose(res, expected_resampled_data)
         assert res.shape == dst_area.shape
 


### PR DESCRIPTION
Closes the new issue described in #517 where the user points out that they requested a resolution of 250.0 but the resulting `AreaDefinition` does not match that and actually changes between cases. This PR fixes this so in the cases where resolution is provided (and not shape) the resulting area should have `pixel_size_x/pixel_size_y` very very close to this value except for some floating point precision.

 - [x] Closes #517 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
