### PR TITLE
Preserve get_area_slices behavior when area to cover has an invalid boundary

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2592,14 +2592,8 @@ class AreaDefinition(_ProjectionDefinition):
                                       "equal.")
 
         data_boundary = Boundary(*get_geostationary_bounding_box_in_lonlats(self))
-        if area_to_cover.is_geostationary:
-            area_boundary = Boundary(
-                *get_geostationary_bounding_box_in_lonlats(area_to_cover))
-        else:
-            area_boundary = AreaDefBoundary(area_to_cover, 100)
-
-        intersection = data_boundary.contour_poly.intersection(
-            area_boundary.contour_poly)
+        area_boundary = self._get_area_to_cover_boundary(area_to_cover)
+        intersection = data_boundary.contour_poly.intersection(area_boundary.contour_poly)
         if intersection is None:
             logger.debug('Cannot determine appropriate slicing. '
                          "Data and projection area do not overlap.")
@@ -2618,6 +2612,15 @@ class AreaDefinition(_ProjectionDefinition):
 
         return (check_slice_orientation(x_slice),
                 check_slice_orientation(y_slice))
+
+    @staticmethod
+    def _get_area_to_cover_boundary(area_to_cover: AreaDefinition) -> Boundary:
+        try:
+            if area_to_cover.is_geostationary:
+                return Boundary(*get_geostationary_bounding_box_in_lonlats(area_to_cover))
+            return AreaDefBoundary(area_to_cover, 100)
+        except ValueError:
+            raise NotImplementedError("Can't determine boundary of area to cover")
 
     def crop_around(self, other_area):
         """Crop this area around `other_area`."""

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1814,6 +1814,17 @@ class TestAreaDefGetAreaSlices:
         assert slice_lines == expected_slice_lines
         assert slice_cols == expected_slice_cols
 
+    def test_area_to_cover_all_nan_bounds(self, geos_src_area, create_test_area):
+        """Check area slicing when the target doesn't have a valid boundary."""
+        area_def = geos_src_area
+        # An area that is a subset of the original one
+        area_to_cover = create_test_area(
+            {"proj": "moll"},
+            1000, 1000,
+            area_extent=(-18000000.0, -9000000.0, 18000000.0, 9000000.0))
+        with pytest.raises(NotImplementedError):
+            area_def.get_area_slices(area_to_cover)
+
 
 class TestBoundary:
     """Test 'boundary' method for AreaDefinition classes."""


### PR DESCRIPTION
As described by @lobsiger on the mailing list, Satpy now fails resampling (specifically reducing data before resampling) because of changes in #465. The main problem is that areas that used to "work" would result in a `NotImplementedError` inside `AreaDefinition.get_area_slices` because no intersection could be determined with the source area and nothing "smarter" is currently implemented. This no intersection determination was actually because the target area ("area to cover") had `inf` in its boundary coordinates and the math just worked out that no intersection was possible. The `notImplementedError` is a signal to Satpy to not attempt data reduction as no area subset slices could be generated...but that its OK that this happened.

After #465, the infinity values in the coordinates is now raising a `ValueError`. This PR catches this and produces a `NotImplementedError` to mimic the previous behavior.

An alternative solution would be to update Satpy to catch not only the `NotImplementedError`, but `ValueError` and maybe `RuntimeError` as possible reasons to ignore/not attempt data reduction.

@mraspaud @pnuu @ghiggi thoughts?

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

