### PR TITLE
Replace width/height in future AreaDefinition with "shape" argument

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -542,7 +542,7 @@ def _make_area(
             "proj_id": proj_id,
         }
         attrs.update(kwargs)
-        area_def = AreaDefinition(projection, width, height, area_extent, attrs=attrs)
+        area_def = AreaDefinition(projection, (height, width), area_extent, attrs=attrs)
         return area_def if pyresample.config.get("features.future_geometries", False) else area_def.to_legacy()
 
     return DynamicAreaDefinition(area_id=area_id, description=description, projection=projection, width=width,

--- a/pyresample/future/geometry/area.py
+++ b/pyresample/future/geometry/area.py
@@ -41,10 +41,11 @@ class AreaDefinition(LegacyAreaDefinition):
         crs:
             Dictionary of PROJ parameters or string of PROJ or WKT parameters.
             Can also be a :class:`pyproj.crs.CRS` object.
-        width:
-            x dimension in number of pixels, aka number of grid columns
-        height:
-            y dimension in number of pixels, aka number of grid rows
+        shape:
+            Shape of the geographic region. Currently only a 2-element tuple
+            is supported. The first element should be the number of elements
+            in the Y direction (rows) and the second in the X direction
+            (columns). So the final tuple is (rows, columns).
         area_extent:
             Area extent as a list (lower_left_x, lower_left_y, upper_right_x, upper_right_y)
         attrs:
@@ -66,6 +67,8 @@ class AreaDefinition(LegacyAreaDefinition):
             Identifier for the area. This is a convenience for backwards
             compatibility and accesses the ``.attrs['name']`` metadata.
             This will be set to an empty string if not provided.
+        shape:
+            Shape of the grid as (rows, columns).
         width (int):
             x dimension in number of pixels, aka number of grid columns
         height (int):
@@ -101,8 +104,7 @@ class AreaDefinition(LegacyAreaDefinition):
     def __init__(
             self,
             crs: Union[str, int, dict, CRS],
-            width: int,
-            height: int,
+            shape: tuple[int, ...],
             area_extent: tuple[float, float, float, float],
             attrs: Optional[dict] = None
     ):
@@ -118,8 +120,8 @@ class AreaDefinition(LegacyAreaDefinition):
             "",
             area_id,
             crs,
-            width,
-            height,
+            shape[1],
+            shape[0],
             area_extent,
         )
         self.attrs = attrs

--- a/pyresample/future/geometry/area.py
+++ b/pyresample/future/geometry/area.py
@@ -108,8 +108,6 @@ class AreaDefinition(LegacyAreaDefinition):
             area_extent: tuple[float, float, float, float],
             attrs: Optional[dict] = None
     ):
-        # FUTURE: Maybe do `shape` instead of the separate height and width
-        # FUTURE: Add 'to_legacy()' method
         # FUTURE: Add __slots__
         # FUTURE: Convert this to new class that uses a legacy area internally
         #         Use this to more easily deprecate usage of old properties

--- a/pyresample/future/geometry/area.py
+++ b/pyresample/future/geometry/area.py
@@ -111,6 +111,9 @@ class AreaDefinition(LegacyAreaDefinition):
         # FUTURE: Add __slots__
         # FUTURE: Convert this to new class that uses a legacy area internally
         #         Use this to more easily deprecate usage of old properties
+        if len(shape) != 2:
+            raise NotImplementedError("Only 2-dimensional areas are supported at this time.")
+
         attrs = attrs or {}
         area_id = attrs.get("name", "")
         super().__init__(

--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -101,8 +101,9 @@ def create_test_area(area_class):
     """
     def _create_test_area(crs, width, height, area_extent, **kwargs):
         """Create an AreaDefinition object for testing."""
-        args = (crs, width, height, area_extent)
+        args = (crs, (height, width), area_extent)
         if area_class is LegacyAreaDefinition:
+            args = (crs, width, height, area_extent)
             attrs = kwargs.pop("attrs", {})
             area_id = attrs.pop("name", "test_area")
             args = (area_id, "", "") + args

--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -193,7 +193,7 @@ def area_def_lcc_conus_1km():
     """Create an AreaDefinition with an LCC projection over CONUS (1500, 2000)."""
     proj_str = "+proj=lcc +lon_0=-95 +lat_1=35.0 +lat_2=35.0 +datum=WGS84 +no_defs"
     crs = CRS.from_string(proj_str)
-    area_def = AreaDefinition(crs, SRC_AREA_SHAPE[1], SRC_AREA_SHAPE[0],
+    area_def = AreaDefinition(crs, (SRC_AREA_SHAPE[0], SRC_AREA_SHAPE[1]),
                               (-750000, -750000, 750000, 750000))
     return area_def
 
@@ -214,7 +214,7 @@ def area_def_stere_source():
             'lon_0': '5.00',
             'proj': 'stere'
         },
-        SRC_AREA_SHAPE[1], SRC_AREA_SHAPE[0],
+        (SRC_AREA_SHAPE[0], SRC_AREA_SHAPE[1]),
         (-1370912.72, -909968.64000000001, 1029087.28, 1490031.3600000001),
     )
 
@@ -231,7 +231,7 @@ def area_def_stere_target():
             'lon_0': '8.00',
             'proj': 'stere'
         },
-        DST_AREA_SHAPE[1], DST_AREA_SHAPE[0],
+        (DST_AREA_SHAPE[0], DST_AREA_SHAPE[1]),
         (-1370912.72, -909968.64000000001, 1029087.28, 1490031.3600000001)
     )
 
@@ -246,7 +246,7 @@ def area_def_lonlat_pm180_target():
             'datum': 'WGS84',
             'no_defs': None,
         },
-        DST_AREA_SHAPE[1], DST_AREA_SHAPE[0],
+        (DST_AREA_SHAPE[0], DST_AREA_SHAPE[1]),
         (-20.0, 20.0, 20.0, 35.0)
     )
 

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1212,8 +1212,7 @@ class TestAreaDefinitionMetadata:
         }
         area_def = AreaDefinition(
             4326,
-            200,
-            100,
+            (100, 200),
             (-1000, -500, 1500, 2000),
             attrs=my_meta,
         )
@@ -1223,8 +1222,7 @@ class TestAreaDefinitionMetadata:
         """Test not passing metadata to AreaDefinition still results in a usable mapping."""
         area_def = AreaDefinition(
             4326,
-            200,
-            100,
+            (100, 200),
             (-1000, -500, 1500, 2000),
         )
         assert area_def.attrs == {}
@@ -1233,15 +1231,13 @@ class TestAreaDefinitionMetadata:
         """Test that metadata differences don't contribute to inequality."""
         area_def1 = AreaDefinition(
             4326,
-            200,
-            100,
+            (100, 200),
             (-1000, -500, 1500, 2000),
             attrs={"a": 1},
         )
         area_def2 = AreaDefinition(
             4326,
-            200,
-            100,
+            (100, 200),
             (-1000, -500, 1500, 2000),
             attrs={"a": 2},
         )
@@ -2015,8 +2011,7 @@ def test_future_to_legacy_conversion():
             'lon_0': '8.00',
             'proj': 'stere'
         },
-        800,
-        800,
+        (800, 800),
         (-1370912.72, -909968.64000000001, 1029087.28, 1490031.3600000001),
         attrs={"name": 'areaD'},
     )

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -2020,3 +2020,10 @@ def test_future_to_legacy_conversion():
     assert legacy_area.area_extent == area_def.area_extent
     assert legacy_area.crs == area_def.crs
     assert legacy_area.area_id == area_def.attrs["name"]
+
+
+@pytest.mark.parametrize("shape", [(100,), (100, 100, 100)])
+def test_non2d_shape_error(shape):
+    """Test that non-2D shapes fail."""
+    with pytest.raises(NotImplementedError):
+        AreaDefinition("EPSG:4326", shape, (-1000.0, -1000.0, 1000.0, 1000.0))

--- a/pyresample/test/test_resamplers/test_nearest.py
+++ b/pyresample/test/test_resamplers/test_nearest.py
@@ -289,8 +289,7 @@ class TestInvalidUsageNearestNeighborResampler:
         if isinstance(src_geom, AreaDefinition):
             src_geom = AreaDefinition(
                 src_geom.crs,
-                src_geom.height,
-                src_geom.width,
+                (src_geom.width, src_geom.height),
                 src_geom.area_extent,
                 attrs=src_geom.attrs.copy(),
             )

--- a/pyresample/utils/rasterio.py
+++ b/pyresample/utils/rasterio.py
@@ -50,7 +50,7 @@ def _get_area_def_from_gdal(dataset, area_id=None, description=None, proj_id=Non
             proj_id = proj.split('"')[1]
 
     attrs = {"name": area_id, "description": description, "proj_id": proj_id}
-    area_def = AreaDefinition(projection, dataset.RasterXSize, dataset.RasterYSize, area_extent, attrs=attrs)
+    area_def = AreaDefinition(projection, (dataset.RasterYSize, dataset.RasterXSize), area_extent, attrs=attrs)
     return area_def
 
 
@@ -70,7 +70,7 @@ def _get_area_def_from_rasterio(dataset, area_id, description, proj_id=None, pro
             proj_id = projection.wkt.split('"')[1]
 
     attrs = {"name": area_id, "description": description, "proj_id": proj_id}
-    area_def = AreaDefinition(projection, dataset.width, dataset.height, dataset.bounds, attrs=attrs)
+    area_def = AreaDefinition(projection, (dataset.height, dataset.width), dataset.bounds, attrs=attrs)
     return area_def
 
 


### PR DESCRIPTION
This was discussed in a previous PR regarding cleaning up AreaDefinitions. The basic idea is to reduce the number of arguments passed to an AreaDefinition to keep the interface a little cleaner and simpler. This PR does this by grouping the width and height arguments into a single "shape" tuple.

This also makes it easier to create AreaDefinitions with more than 2 dimensions in the long long term.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
