### PR TITLE
Use pyproj TransformDirection enum for better performance

### DIFF
--- a/pyresample/_spatial_mp.py
+++ b/pyresample/_spatial_mp.py
@@ -25,6 +25,7 @@ import multiprocessing as mp
 import numpy as np
 import pyproj
 from pyproj import CRS
+from pyproj.enums import TransformDirection
 
 try:
     import numexpr as ne
@@ -244,7 +245,8 @@ def _parallel_proj(scheduler, data1, data2, res1, res2, proj_args, proj_kwargs,
         crs = CRS.from_user_input(proj_def)
         gcrs = get_geodetic_crs_with_no_datum_shift(crs)
         transformer = pyproj.Transformer.from_crs(gcrs, crs, always_xy=True)
-        trans_kwargs = {"radians": radians, "errcheck": errcheck, "direction": "INVERSE" if inverse else "FORWARD"}
+        trans_kwargs = {"radians": radians, "errcheck": errcheck,
+                        "direction": TransformDirection.INVERSE if inverse else TransformDirection.FORWARD}
 
         # Reproject data segment
         for s in scheduler:

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -57,6 +57,7 @@ except ImportError:
     da = None
 
 from pyproj import CRS
+from pyproj.enums import TransformDirection
 
 logger = getLogger(__name__)
 HashType = hashlib._hashlib.HASH
@@ -1276,7 +1277,7 @@ def _invproj(data_x, data_y, proj_wkt):
     crs = CRS.from_wkt(proj_wkt)
     gcrs = get_geodetic_crs_with_no_datum_shift(crs)
     transformer = pyproj.Transformer.from_crs(gcrs, crs, always_xy=True)
-    lon, lat = transformer.transform(data_x, data_y, direction="INVERSE")
+    lon, lat = transformer.transform(data_x, data_y, direction=TransformDirection.INVERSE)
     return np.stack([lon.astype(data_x.dtype), lat.astype(data_y.dtype)])
 
 
@@ -2528,7 +2529,7 @@ class AreaDefinition(_ProjectionDefinition):
             gcrs = get_geodetic_crs_with_no_datum_shift(self.crs)
             target_trans = pyproj.Transformer.from_crs(gcrs, self.crs, always_xy=True)
             target_proj = target_trans.transform
-            proj_kwargs["direction"] = "INVERSE"
+            proj_kwargs["direction"] = TransformDirection.INVERSE
 
         # Get corresponding longitude and latitude values
         lons, lats = target_proj(target_x, target_y, **proj_kwargs)

--- a/pyresample/slicer.py
+++ b/pyresample/slicer.py
@@ -24,6 +24,7 @@ from functools import lru_cache
 
 import numpy as np
 from pyproj import Transformer
+from pyproj.enums import TransformDirection
 
 from pyresample import AreaDefinition, SwathDefinition
 from pyresample.geometry import (
@@ -154,7 +155,7 @@ class AreaSlicer(Slicer):
         x, y = self.area_to_contain.get_edge_bbox_in_projection_coordinates(frequency=10)
         if self.area_to_crop.is_geostationary:
             x_geos, y_geos = get_geostationary_bounding_box_in_proj_coords(self.area_to_crop, 360)
-            x_geos, y_geos = self._transformer.transform(x_geos, y_geos, direction='INVERSE')
+            x_geos, y_geos = self._transformer.transform(x_geos, y_geos, direction=TransformDirection.INVERSE)
             geos_poly = Polygon(zip(x_geos, y_geos))
             poly = Polygon(zip(x, y))
             poly = poly.intersection(geos_poly)


### PR DESCRIPTION
As mentioned by @snowman2, using the pyproj enum for these operations is slightly faster than not using it. This is a simple import and usage.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
