### PR TITLE
Remove unnecessary proj4 argument parsing from get_area_def

### DIFF
--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -360,8 +360,8 @@ def get_area_def(area_id, area_name, proj_id, proj4_args, width, height, area_ex
         Description of area
     proj_id : str
         ID of projection
-    proj4_args : list, dict, or str
-        Proj4 arguments as list of arguments or string
+    proj4_args : dict, CRS, or str
+        Projection information passed to pyproj's CRS object
     width : int
         Number of pixel in x dimension
     height : int
@@ -374,7 +374,6 @@ def get_area_def(area_id, area_name, proj_id, proj4_args, width, height, area_ex
     area_def : object
         AreaDefinition object
     """
-    proj_dict = _get_proj4_args(proj4_args)
     return create_area_def(area_id, proj_dict, description=area_name, proj_id=proj_id,
                            shape=(height, width), area_extent=area_extent)
 

--- a/pyresample/area_config.py
+++ b/pyresample/area_config.py
@@ -374,7 +374,7 @@ def get_area_def(area_id, area_name, proj_id, proj4_args, width, height, area_ex
     area_def : object
         AreaDefinition object
     """
-    return create_area_def(area_id, proj_dict, description=area_name, proj_id=proj_id,
+    return create_area_def(area_id, proj4_args, description=area_name, proj_id=proj_id,
                            shape=(height, width), area_extent=area_extent)
 
 


### PR DESCRIPTION
Removes an unnecessary and likely unused PROJ.4 string -> dict conversion in `get_area_def`. See #547 for more info.

 - [x] Closes #547 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
