### PR TITLE
Fix shortcut for prime meridian checks

### DIFF
--- a/pyresample/utils/proj4.py
+++ b/pyresample/utils/proj4.py
@@ -179,7 +179,7 @@ def ignore_pyproj_proj_warnings():
 def get_geodetic_crs_with_no_datum_shift(crs: CRS) -> CRS:
     """Get the geodetic CRS for the provided CRS but with no prime meridian shift."""
     gcrs = crs.geodetic_crs
-    if gcrs.prime_meridian == 0:
+    if gcrs.prime_meridian.longitude == 0:
         return gcrs
     with ignore_pyproj_proj_warnings():
         gcrs_dict = gcrs.to_dict()


### PR DESCRIPTION
This shortcut exists in the code to avoid having to convert a CRS to a PROJ.4 dict if it isn't needed. I'm not sure how or why, but `.prime_meridian` is not an integer, it is an object, and comparing it to `== 0` will always give False from what I'm seeing. I should have always been using `.prime_meridian.longitude`.

I'm not exactly sure how to test this as it is just a performance thing (avoid unnecessary conversions). The end result should have always been the same.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
