### PR TITLE
Add optional caching to AreaDefinition.get_area_slices

### DIFF
--- a/docs/source/howtos/configuration.rst
+++ b/docs/source/howtos/configuration.rst
@@ -117,6 +117,17 @@ are cached, this option saves a pair of ``slice`` objects that consist of
 only 3 integers each. This makes the amount of space used in the cache very
 small for many cached results.
 
+The slicing operations in Pyresample typically involve finding the intersection
+between two geometries. This requires generating bounding polygons for the
+geometries and doing polygon intersection calculations that can handle
+projection anti-meridians. At the time of writing these calculations can take
+as long as 15 seconds depending on number of vertices used in the bounding
+polygons. One use case for these slices is reducing input data to only the
+overlap of the target area. This can be done before or during resampling as
+part of the algorithm or as part of a third-party resampling interface
+(ex. Satpy). In the future as optimizations are made to the polygon
+intersection logic this caching option should hopefully not be needed.
+
 When setting this as an environment variable, this should be set with the
 string equivalent of the Python boolean values ``="True"`` or ``="False"``.
 

--- a/docs/source/howtos/configuration.rst
+++ b/docs/source/howtos/configuration.rst
@@ -76,6 +76,56 @@ Or for specific blocks of code:
 Similarly, if you need to access one of the values you can
 use the ``pyresample.config.get`` method.
 
+Cache Directory
+^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``PYRESAMPLE_CACHE_DIR``
+* **YAML/Config Key**: ``cache_dir``
+* **Default**: See below
+
+Directory where any files cached by Pyresample will be stored. This
+directory is not necessarily cleared out by Pyresample, but is rarely used
+without explicitly being enabled by the user. This
+defaults to a different path depending on your operating system following
+the `platformdirs <https://github.com/platformdirs/platformdirs#example-output>`_
+"user cache dir".
+
+.. note::
+
+   Some resampling algorithms provide caching functionality when the user
+   provides a directory to cache to. These resamplers do not currently use this
+   configuration option.
+
+.. _config_cache_sensor_angles_setting:
+
+Cache Geometry Slices
+^^^^^^^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``PYRESAMPLE_CACHE_GEOM_SLICES``
+* **YAML/Config Key**: ``cache_geom_slices``
+* **Default**: ``False``
+
+Whether or not generated slices for geometry objects are cached to disk.
+These slices are used in various parts of Pyresample like
+cropping or overlap calculations including those performed in some resampling
+algorithms. At the time of writing this is only performed on
+``AreaDefinition`` objects through their
+:meth:`~pyresample.geometry.AreaDefinition.get_area_slices` method.
+Slices are stored in ``cache_dir`` (see above).
+Unlike other caching performed in Pyresample where potentially large arrays
+are cached, this option saves a pair of ``slice`` objects that consist of
+only 3 integers each. This makes the amount of space used in the cache very
+small for many cached results.
+
+When setting this as an environment variable, this should be set with the
+string equivalent of the Python boolean values ``="True"`` or ``="False"``.
+
+.. warning::
+
+    This caching does not limit the number of entries nor does it expire old
+    entries. It is up to the user to manage the contents of the cache
+    directory.
+
 Feature Flags
 -------------
 

--- a/docs/source/howtos/configuration.rst
+++ b/docs/source/howtos/configuration.rst
@@ -101,8 +101,8 @@ the `platformdirs <https://github.com/platformdirs/platformdirs#example-output>`
 Cache Geometry Slices
 ^^^^^^^^^^^^^^^^^^^^^
 
-* **Environment variable**: ``PYRESAMPLE_CACHE_GEOM_SLICES``
-* **YAML/Config Key**: ``cache_geom_slices``
+* **Environment variable**: ``PYRESAMPLE_CACHE_GEOMETRY_SLICES``
+* **YAML/Config Key**: ``cache_geometry_slices``
 * **Default**: ``False``
 
 Whether or not generated slices for geometry objects are cached to disk.

--- a/pyresample/_caching.py
+++ b/pyresample/_caching.py
@@ -64,7 +64,7 @@ class JSONCacheHelper:
             res = self._callable(*args)
             json_path.parent.mkdir(exist_ok=True)
             with open(json_path, "w") as json_cache:
-                json.dump(res, json_cache, cls=_ExtraJSONEncoder)
+                json.dump(res, json_cache, cls=_JSONEncoderWithSlice)
 
         # for consistency, always load the cached result
         with open(json_path, "r") as json_cache:
@@ -97,7 +97,7 @@ def _hash_args(args: tuple[Any]) -> str:
     return arg_hash.hexdigest()
 
 
-class _ExtraJSONEncoder(json.JSONEncoder):
+class _JSONEncoderWithSlice(json.JSONEncoder):
     def default(self, obj: Any) -> Any:
         if isinstance(obj, slice):
             return {"__slice__": True, "start": obj.start, "stop": obj.stop, "step": obj.step}

--- a/pyresample/_caching.py
+++ b/pyresample/_caching.py
@@ -4,6 +4,8 @@ These tools are rarely needed by users and are used where they make sense
 throughout pyresample.
 
 """
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/pyresample/_caching.py
+++ b/pyresample/_caching.py
@@ -4,57 +4,69 @@ These tools are rarely needed by users and are used where they make sense
 throughout pyresample.
 
 """
-
-import functools
 import hashlib
 import json
+import shutil
+from functools import update_wrapper
+from glob import glob
 from pathlib import Path
 from typing import Any, Callable
 
 import pyresample
 
 
-class JSONCache:
+class JSONCacheHelper:
     """Decorator class to cache results to a JSON file on-disk."""
 
-    def __init__(self, *args, **kwargs):
-        self._callable = None
-        if len(args) == 1 and not kwargs:
-            self._callable = args[0]
+    def __init__(
+            self,
+            func: Callable,
+            cache_config_key: str,
+            cache_version: int = 1,
+    ):
+        self._callable = func
+        self._cache_config_key = cache_config_key
+        self._cache_version = cache_version
+
+    def cache_clear(self, cache_dir: str | None = None):
+        """Remove all on-disk files associated with this function.
+
+        Intended to mimic the :func:`functools.cache` behavior.
+        """
+        cache_dir = self._get_cache_dir_from_config(cache_dir=cache_dir, cache_version="*")
+        for zarr_dir in glob(str(cache_dir / "*.json")):
+            shutil.rmtree(zarr_dir, ignore_errors=True)
 
     def __call__(self, *args, **kwargs):
         """Call decorated function and cache the result to JSON."""
-        is_decorated = len(args) == 1 and isinstance(args[0], Callable)
-        if is_decorated:
-            self._callable = args[0]
+        if not pyresample.config.get(self._cache_config_key, False):
+            return self._callable(*args, **kwargs)
 
-        @functools.wraps(self._callable)
-        def _func(*args, **kwargs):
-            if not pyresample.config.get("cache_geom_slices", False):
-                return self._callable(*args, **kwargs)
+        existing_hash = hashlib.sha1()
+        # TODO: exclude SwathDefinition for hashing reasons
+        hashable_args = [hash(arg) if arg.__class__.__name__ in ("AreaDefinition",) else arg for arg in args]
+        hashable_args += sorted(kwargs.items())
+        existing_hash.update(json.dumps(tuple(hashable_args)).encode("utf8"))
+        arg_hash = existing_hash.hexdigest()
+        base_cache_dir = self._get_cache_dir_from_config(cache_version=self._cache_version)
+        json_path = base_cache_dir / f"{arg_hash}.json"
+        if not json_path.is_file():
+            res = self._callable(*args, **kwargs)
+            json_path.parent.mkdir(exist_ok=True)
+            with open(json_path, "w") as json_cache:
+                json.dump(res, json_cache, cls=_ExtraJSONEncoder)
+        else:
+            with open(json_path, "r") as json_cache:
+                res = json.load(json_cache, object_hook=_object_hook)
+        return res
 
-            # TODO: kwargs
-            existing_hash = hashlib.sha1()
-            # hashable_args = [hash(arg) if isinstance(arg, AreaDefinition) else arg for arg in args]
-            hashable_args = [hash(arg) if arg.__class__.__name__ == "AreaDefinition" else arg for arg in args]
-            existing_hash.update(json.dumps(tuple(hashable_args)).encode("utf8"))
-            arg_hash = existing_hash.hexdigest()
-            print(arg_hash)
-            base_cache_dir = Path(pyresample.config.get("cache_dir")) / "geometry_slices"
-            json_path = base_cache_dir / f"{arg_hash}.json"
-            if not json_path.is_file():
-                res = self._callable(*args, **kwargs)
-                json_path.parent.mkdir(exist_ok=True)
-                with open(json_path, "w") as json_cache:
-                    json.dump(res, json_cache, cls=_ExtraJSONEncoder)
-            else:
-                with open(json_path, "r") as json_cache:
-                    res = json.load(json_cache, object_hook=_object_hook)
-            return res
-
-        if is_decorated:
-            return _func
-        return _func(*args, **kwargs)
+    @staticmethod
+    def _get_cache_dir_from_config(cache_dir: str | None = None, cache_version: int | str = 1) -> Path:
+        cache_dir = cache_dir or pyresample.config.get("cache_dir")
+        if cache_dir is None:
+            raise RuntimeError("Can't use JSON caching. No 'cache_dir' configured.")
+        subdir = f"geometry_slices_v{cache_version}"
+        return Path(cache_dir) / subdir
 
 
 class _ExtraJSONEncoder(json.JSONEncoder):
@@ -68,3 +80,21 @@ def _object_hook(obj: object) -> Any:
     if isinstance(obj, dict) and obj.get("__slice__", False):
         return slice(obj["start"], obj["stop"], obj["step"])
     return obj
+
+
+def cache_to_json_if(cache_config_key: str) -> Callable:
+    """Decorate a function and cache the results to a JSON file on disk.
+
+    This caching only happens if the ``pyresample.config`` boolean value for
+    the provided key is ``True`` as well as some other conditions. See
+    :class:`JSONCacheHelper` for more information. Most importantly this
+    decorator does not limit how many items can be cached and does not clear
+    out old entries. It is up to the user to manage the size of the cache.
+
+    """
+    def _decorator(func: Callable) -> Callable:
+        zarr_cacher = JSONCacheHelper(func, cache_config_key)
+        wrapper = update_wrapper(zarr_cacher, func)
+        return wrapper
+
+    return _decorator

--- a/pyresample/_caching.py
+++ b/pyresample/_caching.py
@@ -1,0 +1,70 @@
+"""Various tools for caching.
+
+These tools are rarely needed by users and are used where they make sense
+throughout pyresample.
+
+"""
+
+import functools
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import pyresample
+
+
+class JSONCache:
+    """Decorator class to cache results to a JSON file on-disk."""
+
+    def __init__(self, *args, **kwargs):
+        self._callable = None
+        if len(args) == 1 and not kwargs:
+            self._callable = args[0]
+
+    def __call__(self, *args, **kwargs):
+        """Call decorated function and cache the result to JSON."""
+        is_decorated = len(args) == 1 and isinstance(args[0], Callable)
+        if is_decorated:
+            self._callable = args[0]
+
+        @functools.wraps(self._callable)
+        def _func(*args, **kwargs):
+            if not pyresample.config.get("cache_geom_slices", False):
+                return self._callable(*args, **kwargs)
+
+            # TODO: kwargs
+            existing_hash = hashlib.sha1()
+            # hashable_args = [hash(arg) if isinstance(arg, AreaDefinition) else arg for arg in args]
+            hashable_args = [hash(arg) if arg.__class__.__name__ == "AreaDefinition" else arg for arg in args]
+            existing_hash.update(json.dumps(tuple(hashable_args)).encode("utf8"))
+            arg_hash = existing_hash.hexdigest()
+            print(arg_hash)
+            base_cache_dir = Path(pyresample.config.get("cache_dir")) / "geometry_slices"
+            json_path = base_cache_dir / f"{arg_hash}.json"
+            if not json_path.is_file():
+                res = self._callable(*args, **kwargs)
+                json_path.parent.mkdir(exist_ok=True)
+                with open(json_path, "w") as json_cache:
+                    json.dump(res, json_cache, cls=_ExtraJSONEncoder)
+            else:
+                with open(json_path, "r") as json_cache:
+                    res = json.load(json_cache, object_hook=_object_hook)
+            return res
+
+        if is_decorated:
+            return _func
+        return _func(*args, **kwargs)
+
+
+class _ExtraJSONEncoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, slice):
+            return {"__slice__": True, "start": obj.start, "stop": obj.stop, "step": obj.step}
+        return super().default(obj)
+
+
+def _object_hook(obj: object) -> Any:
+    if isinstance(obj, dict) and obj.get("__slice__", False):
+        return slice(obj["start"], obj["stop"], obj["step"])
+    return obj

--- a/pyresample/_config.py
+++ b/pyresample/_config.py
@@ -36,6 +36,8 @@ _CONFIG_PATHS = [
 config = Config(
     "pyresample",
     defaults=[{
+        "cache_dir": platformdirs.user_cache_dir("pyresample", "pytroll"),
+        "cache_geom_slices": False,
         "features": {
             "future_geometries": False,
         },

--- a/pyresample/_config.py
+++ b/pyresample/_config.py
@@ -21,7 +21,6 @@ import platformdirs
 from donfig import Config
 
 BASE_PATH = os.path.dirname(os.path.realpath(__file__))
-# FIXME: Use package_resources?
 PACKAGE_CONFIG_PATH = os.path.join(BASE_PATH, 'etc')
 
 _user_config_dir = platformdirs.user_config_dir("pyresample", "pytroll")
@@ -37,7 +36,7 @@ config = Config(
     "pyresample",
     defaults=[{
         "cache_dir": platformdirs.user_cache_dir("pyresample", "pytroll"),
-        "cache_geom_slices": False,
+        "cache_geometry_slices": False,
         "features": {
             "future_geometries": False,
         },

--- a/pyresample/future/geometry/_subset.py
+++ b/pyresample/future/geometry/_subset.py
@@ -1,0 +1,123 @@
+"""Functions and tools for subsetting a geometry object."""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from pyresample import AreaDefinition
+
+# this caching module imports the geometries so this subset module
+# must be imported inside functions in the geometry modules if needed
+# to avoid circular dependencies
+from pyresample._caching import cache_to_json_if
+from pyresample.boundary import Boundary
+from pyresample.geometry import get_geostationary_bounding_box_in_lonlats, logger
+from pyresample.utils import check_slice_orientation
+
+
+@cache_to_json_if("cache_geom_slices")
+def get_area_slices(
+        src_area: AreaDefinition,
+        area_to_cover: AreaDefinition,
+        shape_divisible_by: int | None,
+) -> tuple[slice, slice]:
+    """Compute the slice to read based on an `area_to_cover`."""
+    if not isinstance(area_to_cover, AreaDefinition):
+        raise NotImplementedError('Only AreaDefinitions can be used')
+
+    # Intersection only required for two different projections
+    proj_def_to_cover = area_to_cover.crs
+    proj_def = src_area.crs
+    if proj_def_to_cover == proj_def:
+        logger.debug('Projections for data and slice areas are identical: %s',
+                     proj_def_to_cover)
+        # Get slice parameters
+        xstart, xstop, ystart, ystop = _get_slice_starts_stops(src_area, area_to_cover)
+
+        x_slice = check_slice_orientation(slice(xstart, xstop))
+        y_slice = check_slice_orientation(slice(ystart, ystop))
+        x_slice = _ensure_integer_slice(x_slice)
+        y_slice = _ensure_integer_slice(y_slice)
+        return x_slice, y_slice
+
+    data_boundary = _get_area_boundary(src_area)
+    area_boundary = _get_area_boundary(area_to_cover)
+    intersection = data_boundary.contour_poly.intersection(
+        area_boundary.contour_poly)
+    if intersection is None:
+        logger.debug('Cannot determine appropriate slicing. '
+                     "Data and projection area do not overlap.")
+        raise NotImplementedError
+    x, y = src_area.get_array_indices_from_lonlat(
+        np.rad2deg(intersection.lon), np.rad2deg(intersection.lat))
+    x_slice = slice(np.ma.min(x), np.ma.max(x) + 1)
+    y_slice = slice(np.ma.min(y), np.ma.max(y) + 1)
+    x_slice = _ensure_integer_slice(x_slice)
+    y_slice = _ensure_integer_slice(y_slice)
+    if shape_divisible_by is not None:
+        x_slice = _make_slice_divisible(x_slice, src_area.width,
+                                        factor=shape_divisible_by)
+        y_slice = _make_slice_divisible(y_slice, src_area.height,
+                                        factor=shape_divisible_by)
+
+    return (check_slice_orientation(x_slice),
+            check_slice_orientation(y_slice))
+
+
+def _get_slice_starts_stops(src_area, area_to_cover):
+    """Get x and y start and stop points for slicing."""
+    llx, lly, urx, ury = area_to_cover.area_extent
+    x, y = src_area.get_array_coordinates_from_projection_coordinates([llx, urx], [lly, ury])
+
+    # we use `round` because we want the *exterior* of the pixels to contain the area_to_cover's area extent.
+    if (src_area.area_extent[0] > src_area.area_extent[2]) ^ (llx > urx):
+        xstart = max(0, round(x[1]))
+        xstop = min(src_area.width, round(x[0]) + 1)
+    else:
+        xstart = max(0, round(x[0]))
+        xstop = min(src_area.width, round(x[1]) + 1)
+    if (src_area.area_extent[1] > src_area.area_extent[3]) ^ (lly > ury):
+        ystart = max(0, round(y[0]))
+        ystop = min(src_area.height, round(y[1]) + 1)
+    else:
+        ystart = max(0, round(y[1]))
+        ystop = min(src_area.height, round(y[0]) + 1)
+
+    return xstart, xstop, ystart, ystop
+
+
+def _get_area_boundary(area_to_cover: AreaDefinition) -> Boundary:
+    try:
+        if area_to_cover.is_geostationary:
+            return Boundary(*get_geostationary_bounding_box_in_lonlats(area_to_cover))
+        boundary_shape = max(max(*area_to_cover.shape) // 100 + 1, 3)
+        return area_to_cover.boundary(frequency=boundary_shape, force_clockwise=True)
+    except ValueError:
+        raise NotImplementedError("Can't determine boundary of area to cover")
+
+
+def _make_slice_divisible(sli, max_size, factor=2):
+    """Make the given slice even in size."""
+    rem = (sli.stop - sli.start) % factor
+    if rem != 0:
+        adj = factor - rem
+        if sli.stop + 1 + rem < max_size:
+            sli = slice(sli.start, sli.stop + adj)
+        elif sli.start > 0:
+            sli = slice(sli.start - adj, sli.stop)
+        else:
+            sli = slice(sli.start, sli.stop - rem)
+
+    return sli
+
+
+def _ensure_integer_slice(sli):
+    start = sli.start
+    stop = sli.stop
+    step = sli.step
+    return slice(
+        math.floor(start) if start is not None else None,
+        math.ceil(stop) if stop is not None else None,
+        math.floor(step) if step is not None else None
+    )

--- a/pyresample/future/geometry/_subset.py
+++ b/pyresample/future/geometry/_subset.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from pyresample import AreaDefinition
 
 
-@cache_to_json_if("cache_geom_slices")
+@cache_to_json_if("cache_geometry_slices")
 def get_area_slices(
         src_area: AreaDefinition,
         area_to_cover: AreaDefinition,

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -34,7 +34,7 @@ from pyproj import Geod, Proj
 from pyproj.aoi import AreaOfUse
 
 from pyresample import CHUNK_SIZE
-from pyresample._caching import JSONCache
+from pyresample._caching import cache_to_json_if
 from pyresample._spatial_mp import Cartesian, Cartesian_MP, Proj_MP
 from pyresample.area_config import create_area_def
 from pyresample.boundary import Boundary, SimpleBoundary
@@ -2680,7 +2680,7 @@ class AreaDefinition(_ProjectionDefinition):
         return res
 
 
-@JSONCache()
+@cache_to_json_if("cache_geom_slices")
 def get_area_slices(
         src_area: AreaDefinition,
         area_to_cover: AreaDefinition,

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -34,11 +34,10 @@ from pyproj import Geod, Proj
 from pyproj.aoi import AreaOfUse
 
 from pyresample import CHUNK_SIZE
-from pyresample._caching import cache_to_json_if
 from pyresample._spatial_mp import Cartesian, Cartesian_MP, Proj_MP
 from pyresample.area_config import create_area_def
-from pyresample.boundary import Boundary, SimpleBoundary
-from pyresample.utils import check_slice_orientation, load_cf_area
+from pyresample.boundary import SimpleBoundary
+from pyresample.utils import load_cf_area
 from pyresample.utils.proj4 import (
     get_geodetic_crs_with_no_datum_shift,
     get_geostationary_height,
@@ -2579,6 +2578,7 @@ class AreaDefinition(_ProjectionDefinition):
 
     def get_area_slices(self, area_to_cover, shape_divisible_by=None):
         """Compute the slice to read based on an `area_to_cover`."""
+        from .future.geometry._subset import get_area_slices
         return get_area_slices(self, area_to_cover, shape_divisible_by)
 
     def crop_around(self, other_area):
@@ -2678,113 +2678,6 @@ class AreaDefinition(_ProjectionDefinition):
             raise RuntimeError("Could not calculate geocentric resolution")
         # return np.max(np.concatenate(vert_dist, hor_dist))  # alternative to histogram
         return res
-
-
-@cache_to_json_if("cache_geom_slices")
-def get_area_slices(
-        src_area: AreaDefinition,
-        area_to_cover: AreaDefinition,
-        shape_divisible_by: int | None = None
-) -> tuple[slice, slice]:
-    """Compute the slice to read based on an `area_to_cover`."""
-    if not isinstance(area_to_cover, AreaDefinition):
-        raise NotImplementedError('Only AreaDefinitions can be used')
-
-    # Intersection only required for two different projections
-    proj_def_to_cover = area_to_cover.crs
-    proj_def = src_area.crs
-    if proj_def_to_cover == proj_def:
-        logger.debug('Projections for data and slice areas are identical: %s',
-                     proj_def_to_cover)
-        # Get slice parameters
-        xstart, xstop, ystart, ystop = _get_slice_starts_stops(src_area, area_to_cover)
-
-        x_slice = check_slice_orientation(slice(xstart, xstop))
-        y_slice = check_slice_orientation(slice(ystart, ystop))
-        x_slice = _ensure_integer_slice(x_slice)
-        y_slice = _ensure_integer_slice(y_slice)
-        return x_slice, y_slice
-
-    data_boundary = _get_area_boundary(src_area)
-    area_boundary = _get_area_boundary(area_to_cover)
-    intersection = data_boundary.contour_poly.intersection(
-        area_boundary.contour_poly)
-    if intersection is None:
-        logger.debug('Cannot determine appropriate slicing. '
-                     "Data and projection area do not overlap.")
-        raise NotImplementedError
-    x, y = src_area.get_array_indices_from_lonlat(
-        np.rad2deg(intersection.lon), np.rad2deg(intersection.lat))
-    x_slice = slice(np.ma.min(x), np.ma.max(x) + 1)
-    y_slice = slice(np.ma.min(y), np.ma.max(y) + 1)
-    x_slice = _ensure_integer_slice(x_slice)
-    y_slice = _ensure_integer_slice(y_slice)
-    if shape_divisible_by is not None:
-        x_slice = _make_slice_divisible(x_slice, src_area.width,
-                                        factor=shape_divisible_by)
-        y_slice = _make_slice_divisible(y_slice, src_area.height,
-                                        factor=shape_divisible_by)
-
-    return (check_slice_orientation(x_slice),
-            check_slice_orientation(y_slice))
-
-
-def _get_slice_starts_stops(src_area, area_to_cover):
-    """Get x and y start and stop points for slicing."""
-    llx, lly, urx, ury = area_to_cover.area_extent
-    x, y = src_area.get_array_coordinates_from_projection_coordinates([llx, urx], [lly, ury])
-
-    # we use `round` because we want the *exterior* of the pixels to contain the area_to_cover's area extent.
-    if (src_area.area_extent[0] > src_area.area_extent[2]) ^ (llx > urx):
-        xstart = max(0, round(x[1]))
-        xstop = min(src_area.width, round(x[0]) + 1)
-    else:
-        xstart = max(0, round(x[0]))
-        xstop = min(src_area.width, round(x[1]) + 1)
-    if (src_area.area_extent[1] > src_area.area_extent[3]) ^ (lly > ury):
-        ystart = max(0, round(y[0]))
-        ystop = min(src_area.height, round(y[1]) + 1)
-    else:
-        ystart = max(0, round(y[1]))
-        ystop = min(src_area.height, round(y[0]) + 1)
-
-    return xstart, xstop, ystart, ystop
-
-
-def _get_area_boundary(area_to_cover: AreaDefinition) -> Boundary:
-    try:
-        if area_to_cover.is_geostationary:
-            return Boundary(*get_geostationary_bounding_box_in_lonlats(area_to_cover))
-        boundary_shape = max(max(*area_to_cover.shape) // 100 + 1, 3)
-        return area_to_cover.boundary(frequency=boundary_shape, force_clockwise=True)
-    except ValueError:
-        raise NotImplementedError("Can't determine boundary of area to cover")
-
-
-def _make_slice_divisible(sli, max_size, factor=2):
-    """Make the given slice even in size."""
-    rem = (sli.stop - sli.start) % factor
-    if rem != 0:
-        adj = factor - rem
-        if sli.stop + 1 + rem < max_size:
-            sli = slice(sli.start, sli.stop + adj)
-        elif sli.start > 0:
-            sli = slice(sli.start - adj, sli.stop)
-        else:
-            sli = slice(sli.start, sli.stop - rem)
-
-    return sli
-
-
-def _ensure_integer_slice(sli):
-    start = sli.start
-    stop = sli.stop
-    step = sli.step
-    return slice(
-        math.floor(start) if start is not None else None,
-        math.ceil(stop) if stop is not None else None,
-        math.floor(step) if step is not None else None
-    )
 
 
 def get_geostationary_angle_extent(geos_area):

--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -42,6 +42,7 @@ DST_AREA_SHAPE = (80, 85)
 def reset_pyresample_config(tmpdir):
     """Set pyresample config to logical defaults for tests."""
     test_config = {
+        "cache_geom_slices": False,
         "features": {
             "future_geometries": False,
         },

--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -42,7 +42,7 @@ DST_AREA_SHAPE = (80, 85)
 def reset_pyresample_config(tmpdir):
     """Set pyresample config to logical defaults for tests."""
     test_config = {
-        "cache_geom_slices": False,
+        "cache_geometry_slices": False,
         "features": {
             "future_geometries": False,
         },

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1850,13 +1850,13 @@ class TestAreaDefGetAreaSlices:
                                      100, 100,
                                      (15.9689, 58.5284, 16.4346, 58.6995))
         with pyresample.config.set(cache_dir=tmp_path, cache_geom_slices=False):
-            assert len(glob(str(tmp_path / "geometry_slices" / "*.json"))) == 0
+            assert len(glob(str(tmp_path / "geometry_slices_v1" / "*.json"))) == 0
             slice_x, slice_y = src_area.get_area_slices(crop_area)
-            assert len(glob(str(tmp_path / "geometry_slices" / "*.json"))) == 0
+            assert len(glob(str(tmp_path / "geometry_slices_v1" / "*.json"))) == 0
         with pyresample.config.set(cache_dir=tmp_path, cache_geom_slices=True):
-            assert len(glob(str(tmp_path / "geometry_slices" / "*.json"))) == 0
+            assert len(glob(str(tmp_path / "geometry_slices_v1" / "*.json"))) == 0
             slice_x, slice_y = src_area.get_area_slices(crop_area)
-            assert len(glob(str(tmp_path / "geometry_slices" / "*.json"))) == 1
+            assert len(glob(str(tmp_path / "geometry_slices_v1" / "*.json"))) == 1
         assert slice_x == slice(5630, 8339)
         assert slice_y == slice(9261, 10980)
 

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -882,6 +882,7 @@ class TestAreaDefinition:
 
     def test_get_slice_starts_stops(self, create_test_area):
         """Check area slice end-points."""
+        from pyresample.future.geometry._subset import _get_slice_starts_stops
         x_size = 3712
         y_size = 3712
         area_extent = (-5570248.477339745, -5561247.267842293, 5567248.074173927, 5570248.477339745)
@@ -895,25 +896,25 @@ class TestAreaDefinition:
         # Source and target have the same orientation
         area_extent = (-5580248.477339745, -5571247.267842293, 5577248.074173927, 5580248.477339745)
         source_area = create_test_area(proj_dict, x_size, y_size, area_extent)
-        res = source_area._get_slice_starts_stops(target_area)
+        res = _get_slice_starts_stops(source_area, target_area)
         assert res == expected
 
         # Source is flipped in X direction
         area_extent = (5577248.074173927, -5571247.267842293, -5580248.477339745, 5580248.477339745)
         source_area = create_test_area(proj_dict, x_size, y_size, area_extent)
-        res = source_area._get_slice_starts_stops(target_area)
+        res = _get_slice_starts_stops(source_area, target_area)
         assert res == expected
 
         # Source is flipped in Y direction
         area_extent = (-5580248.477339745, 5580248.477339745, 5577248.074173927, -5571247.267842293)
         source_area = create_test_area(proj_dict, x_size, y_size, area_extent)
-        res = source_area._get_slice_starts_stops(target_area)
+        res = _get_slice_starts_stops(source_area, target_area)
         assert res == expected
 
         # Source is flipped in both X and Y directions
         area_extent = (5577248.074173927, 5580248.477339745, -5580248.477339745, -5571247.267842293)
         source_area = create_test_area(proj_dict, x_size, y_size, area_extent)
-        res = source_area._get_slice_starts_stops(target_area)
+        res = _get_slice_starts_stops(source_area, target_area)
         assert res == expected
 
     def test_proj_str(self, create_test_area):
@@ -1251,7 +1252,7 @@ class TestMakeSliceDivisible:
 
     def test_make_slice_divisible(self):
         """Test that making area shape divisible by a given factor works."""
-        from pyresample.geometry import _make_slice_divisible
+        from pyresample.future.geometry._subset import _make_slice_divisible
 
         # Divisible by 2
         sli = slice(10, 21)

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1833,7 +1833,7 @@ class TestAreaDefGetAreaSlices:
                                      100, 100,
                                      (15.9689, 58.5284, 16.4346, 58.6995))
         cache_glob = str(tmp_path / "geometry_slices_v1" / "*.json")
-        with pyresample.config.set(cache_dir=tmp_path, cache_geom_slices=cache_slices):
+        with pyresample.config.set(cache_dir=tmp_path, cache_geometry_slices=cache_slices):
             assert len(glob(cache_glob)) == 0
             slice_x, slice_y = src_area.get_area_slices(crop_area)
             assert len(glob(cache_glob)) == int(cache_slices)
@@ -1857,7 +1857,7 @@ class TestAreaDefGetAreaSlices:
         lats = create_test_latitude(25.0, 35.0, shape=(1000, 500))
         swath = create_test_swath(lons, lats)
 
-        with pyresample.config.set(cache_dir=tmp_path, cache_geom_slices=True), pytest.raises(NotImplementedError):
+        with pyresample.config.set(cache_dir=tmp_path, cache_geometry_slices=True), pytest.raises(NotImplementedError):
             with pytest.warns(UserWarning, match="unhashable"):
                 get_area_slices(swath, area, None)
 

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -15,6 +15,7 @@
 """Test AreaDefinition objects."""
 import io
 import sys
+from glob import glob
 from unittest.mock import MagicMock, patch
 
 import dask.array as da
@@ -1839,6 +1840,25 @@ class TestAreaDefGetAreaSlices:
             area_extent=(-18000000.0, -9000000.0, 18000000.0, 9000000.0))
         with pytest.raises(NotImplementedError):
             area_def.get_area_slices(area_to_cover)
+
+    def test_area_slices_caching(self, create_test_area, tmp_path):
+        """Check that area slices can be cached."""
+        src_area = create_test_area(dict(proj="utm", zone=33),
+                                    10980, 10980,
+                                    (499980.0, 6490200.0, 609780.0, 6600000.0))
+        crop_area = create_test_area({'proj': 'latlong'},
+                                     100, 100,
+                                     (15.9689, 58.5284, 16.4346, 58.6995))
+        with pyresample.config.set(cache_dir=tmp_path, cache_geom_slices=False):
+            assert len(glob(str(tmp_path / "geometry_slices" / "*.json"))) == 0
+            slice_x, slice_y = src_area.get_area_slices(crop_area)
+            assert len(glob(str(tmp_path / "geometry_slices" / "*.json"))) == 0
+        with pyresample.config.set(cache_dir=tmp_path, cache_geom_slices=True):
+            assert len(glob(str(tmp_path / "geometry_slices" / "*.json"))) == 0
+            slice_x, slice_y = src_area.get_area_slices(crop_area)
+            assert len(glob(str(tmp_path / "geometry_slices" / "*.json"))) == 1
+        assert slice_x == slice(5630, 8339)
+        assert slice_y == slice(9261, 10980)
 
 
 class TestBoundary:

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1849,16 +1849,22 @@ class TestAreaDefGetAreaSlices:
         crop_area = create_test_area({'proj': 'latlong'},
                                      100, 100,
                                      (15.9689, 58.5284, 16.4346, 58.6995))
+        cache_glob = str(tmp_path / "geometry_slices_v1" / "*.json")
         with pyresample.config.set(cache_dir=tmp_path, cache_geom_slices=False):
-            assert len(glob(str(tmp_path / "geometry_slices_v1" / "*.json"))) == 0
+            assert len(glob(cache_glob)) == 0
             slice_x, slice_y = src_area.get_area_slices(crop_area)
-            assert len(glob(str(tmp_path / "geometry_slices_v1" / "*.json"))) == 0
+            assert len(glob(cache_glob)) == 0
         with pyresample.config.set(cache_dir=tmp_path, cache_geom_slices=True):
-            assert len(glob(str(tmp_path / "geometry_slices_v1" / "*.json"))) == 0
+            assert len(glob(cache_glob)) == 0
             slice_x, slice_y = src_area.get_area_slices(crop_area)
-            assert len(glob(str(tmp_path / "geometry_slices_v1" / "*.json"))) == 1
+            assert len(glob(cache_glob)) == 1
         assert slice_x == slice(5630, 8339)
         assert slice_y == slice(9261, 10980)
+
+        from pyresample.future.geometry._subset import get_area_slices
+        with pyresample.config.set(cache_dir=tmp_path):
+            get_area_slices.cache_clear()
+        assert len(glob(cache_glob)) == 0
 
 
 class TestBoundary:

--- a/versioneer.py
+++ b/versioneer.py
@@ -528,7 +528,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         if verbose:
             print("unable to find command, tried %%s" %% (commands,))
         return None, None
-    stdout = process.communicate()[0].strip().decode()
+    stdout = process.communicate()[0].strip()._object_hook()
     if process.returncode != 0:
         if verbose:
             print("unable to run %%s (error)" %% dispcmd)


### PR DESCRIPTION
While profiling some Satpy computations (ABI full disk -> nearest neighbor resampling) I noticed that a decent amount of time at the beginning of processing was spent outside of dask computations and was using a single core. After some print-statement debugging I discovered it was Satpy's `reduce_data` functionality and the `AreaDefinition.get_area_slices` that was taking the most time. The majority of that time is spent in the polygon intersection operation to see if the two areas being used intersect and where.

This PR adds a decorator and a couple configuration settings for caching the results of `AreaDefinition.get_area_slices` to on-disk JSON files. For my testing case I was seeing about ~10-12 seconds being used for `get_area_slices` per area definition pair. I was using 2 resolutions of ABI data and one target area so that was ~22 seconds. With this caching enabled that time basically disappears.

This PR is only a proof of concept at this point and I will continue to improve it. I just wanted to get the initial commits up on github for others to see.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
