### PR TITLE
Fix derivation of correct radius of influence when data layout is not standard

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2010-2020 Pyresample developers
+# Copyright (C) 2010-2023 Pyresample developers
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -693,7 +693,8 @@ class CoordinateDefinition(BaseDefinition):
         if self.ndim == 1:
             raise RuntimeError("Can't confidently determine geocentric "
                                "resolution for 1D swath.")
-        rows = self.shape[0]
+
+        rows = self.lons['y'].shape[0]
         start_row = rows // 2  # middle row
         src = CRS('+proj=latlong +datum=WGS84')
         if radius:
@@ -701,8 +702,8 @@ class CoordinateDefinition(BaseDefinition):
         else:
             dst = CRS("+proj=cart +ellps={}".format(ellps))
         # simply take the first two columns of the middle of the swath
-        lons = self.lons[start_row: start_row + 1, :2]
-        lats = self.lats[start_row: start_row + 1, :2]
+        lons = self.lons.sel(y=start_row)[:2]
+        lats = self.lats.sel(y=start_row)[:2]
         if hasattr(lons.data, 'compute'):
             # dask arrays, compute them together
             import dask.array as da


### PR DESCRIPTION
This is supposed to solve #554 

Make use of the fact that longitudes are an xarray data array and use 'y' dimension for rows/scanlines

This makes the code resilient towards any other (awkward) data layout than the standard (where first dimension is usually the rows).


<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
