### PR TITLE
Add missing meta keyword arguments on all dask map_blocks calls

### DIFF
--- a/pyresample/_spatial_mp.py
+++ b/pyresample/_spatial_mp.py
@@ -188,7 +188,7 @@ def _run_jobs(target, args, nprocs):
         p.join()
     if ierr.value != 0:
         raise RuntimeError('%d errors in worker processes. Last one reported:\n%s' %
-                           (ierr.value, warn_msg.value.decode()))
+                           (ierr.value, warn_msg.value._object_hook()))
 
 # This is executed in an external process:
 

--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -273,7 +273,12 @@ def _check_data_shape(data, input_xy_shape):
 
     # Ensure two dimensions
     if data.ndim == 1:
-        data = DataArray(da.map_blocks(np.expand_dims, data.data, 0, new_axis=[0]))
+        data = DataArray(da.map_blocks(np.expand_dims,
+                                       data.data,
+                                       0,
+                                       meta=np.array((), dtype=data.dtype),
+                                       dtype=data.dtype,
+                                       new_axis=[0]))
 
     return data
 

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -181,6 +181,8 @@ class BucketResampler(object):
         lons = self.source_lons.ravel()
         lats = self.source_lats.ravel()
         result = da.map_blocks(self._get_proj_coordinates, lons, lats,
+                               meta=np.array((), dtype=lons.dtype),
+                               dtype=lons.dtype,
                                new_axis=0, chunks=(2,) + lons.chunks)
         proj_x = result[0, :]
         proj_y = result[1, :]

--- a/pyresample/future/resamplers/nearest.py
+++ b/pyresample/future/resamplers/nearest.py
@@ -340,7 +340,7 @@ class KDTreeNearestXarrayResampler(Resampler):
             new_data, src_adims,
             vii_slices=vii_slices, ia_slices=ia_slices,
             fill_value=fill_value,
-            met=np.array((), dtype=new_data.dtype),
+            meta=np.array((), dtype=new_data.dtype),
             dtype=new_data.dtype, concatenate=True)
         res = DataArray(res, dims=dst_dims,
                         attrs=deepcopy(data.attrs))

--- a/pyresample/future/resamplers/nearest.py
+++ b/pyresample/future/resamplers/nearest.py
@@ -189,6 +189,7 @@ class KDTreeNearestXarrayResampler(Resampler):
             valid_output_index, 'ji', *args, kdtree=resample_kdtree,
             neighbours=neighbors, epsilon=epsilon,
             radius=radius_of_influence, dtype=np.int64,
+            meta=np.array((), dtype=np.int64),
             new_axes={'k': neighbors}, concatenate=True)
         return res
 
@@ -339,6 +340,7 @@ class KDTreeNearestXarrayResampler(Resampler):
             new_data, src_adims,
             vii_slices=vii_slices, ia_slices=ia_slices,
             fill_value=fill_value,
+            met=np.array((), dtype=new_data.dtype),
             dtype=new_data.dtype, concatenate=True)
         res = DataArray(res, dims=dst_dims,
                         attrs=deepcopy(data.attrs))

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -873,12 +873,16 @@ class SwathDefinition(CoordinateDefinition):
         res = da.map_blocks(self._do_transform, latlong, geocent,
                             self.lons.data, self.lats.data,
                             da.zeros_like(self.lons.data), new_axis=[2],
+                            meta=np.array((), dtype=self.lons.dtype),
+                            dtype=self.lons.dtype,
                             chunks=(self.lons.chunks[0], self.lons.chunks[1], 3))
         res = DataArray(res, dims=['y', 'x', 'coord'], coords=self.lons.coords)
         res = res.coarsen(**dims).mean()
         lonlatalt = da.map_blocks(self._do_transform, geocent, latlong,
                                   res[:, :, 0].data, res[:, :, 1].data,
                                   res[:, :, 2].data, new_axis=[2],
+                                  meta=np.array((), dtype=res.dtype),
+                                  dtype=res.dtype,
                                   chunks=res.data.chunks)
         lons = DataArray(lonlatalt[:, :, 0], dims=self.lons.dims,
                          coords=res.coords, attrs=self.lons.attrs.copy())

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -999,6 +999,7 @@ class XArrayResamplerNN(object):
                         valid_oi, 'ji', *args, kdtree=resample_kdtree,
                         neighbours=self.neighbours, epsilon=self.epsilon,
                         radius=self.radius_of_influence, dtype=np.int64,
+                        meta=np.array((), dtype=np.int64),
                         new_axes={'k': self.neighbours}, concatenate=True)
         return res, None
 
@@ -1155,6 +1156,7 @@ class XArrayResamplerNN(object):
                         new_data, src_adims,
                         vii_slices=vii_slices, ia_slices=ia_slices,
                         fill_value=fill_value,
+                        meta=np.array((), dtype=new_data.dtype),
                         dtype=new_data.dtype, concatenate=True)
         res = DataArray(res, dims=dst_dims, coords=coords,
                         attrs=deepcopy(data.attrs))

--- a/pyresample/utils/proj4.py
+++ b/pyresample/utils/proj4.py
@@ -145,6 +145,7 @@ class DaskFriendlyTransformer:
         result = da.map_blocks(_transform_dask_chunk, x, y,
                                crs_from.to_wkt(), crs_to.to_wkt(),
                                dtype=x.dtype, chunks=x.chunks + ((2,),),
+                               meta=np.array((), dtype=x.dtype),
                                kwargs=self.kwargs,
                                transform_kwargs=kwargs,
                                new_axis=x.ndim)


### PR DESCRIPTION
Without the `meta=` keyword argument to `da.map_blocks` dask will call the mapped function with fake/representative arguments to try to determine what the returned array and dtype are. This PR adds this kwarg to avoid this unnecessary execution of the function.

This very likely won't have any effect on performance, but it helps with debugging and is an unnecessary call if you forget it.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
