### PR TITLE
Remove `__file__` usage in test units for `test_files` path

### DIFF
--- a/pyresample/test/test_area_config.py
+++ b/pyresample/test/test_area_config.py
@@ -24,6 +24,8 @@ import unittest
 
 import numpy as np
 
+from pyresample.test.utils import TEST_FILES_PATH
+
 
 class TestLegacyAreaParser(unittest.TestCase):
     """Test legacy .cfg parsing."""
@@ -31,7 +33,7 @@ class TestLegacyAreaParser(unittest.TestCase):
     def test_area_parser_legacy(self):
         """Test legacy area parser."""
         from pyresample import parse_area_file
-        ease_nh, ease_sh = parse_area_file(os.path.join(os.path.dirname(__file__), 'test_files', 'areas.cfg'),
+        ease_nh, ease_sh = parse_area_file(os.path.join(TEST_FILES_PATH, 'areas.cfg'),
                                            'ease_nh', 'ease_sh')
 
         # pyproj 2.0+ adds some extra parameters
@@ -63,7 +65,7 @@ Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)""".forma
 
     def test_load_area(self):
         from pyresample import load_area
-        ease_nh = load_area(os.path.join(os.path.dirname(__file__), 'test_files', 'areas.cfg'), 'ease_nh')
+        ease_nh = load_area(os.path.join(TEST_FILES_PATH, 'areas.cfg'), 'ease_nh')
         # pyproj 2.0+ adds some extra parameters
         projection = ("{'R': '6371228', 'lat_0': '90', 'lon_0': '0', "
                       "'no_defs': 'None', 'proj': 'laea', 'type': 'crs', "
@@ -87,11 +89,11 @@ Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)""".forma
     def test_not_found_exception(self):
         from pyresample.area_config import AreaNotFound, parse_area_file
         self.assertRaises(AreaNotFound, parse_area_file,
-                          os.path.join(os.path.dirname(__file__), 'test_files', 'areas.cfg'), 'no_area')
+                          os.path.join(TEST_FILES_PATH, 'areas.cfg'), 'no_area')
 
     def test_commented(self):
         from pyresample import parse_area_file
-        areas = parse_area_file(os.path.join(os.path.dirname(__file__), 'test_files', 'areas.cfg'))
+        areas = parse_area_file(os.path.join(TEST_FILES_PATH, 'areas.cfg'))
         self.assertNotIn('commented', [area.name for area in areas])
 
 
@@ -101,7 +103,7 @@ class TestYAMLAreaParser(unittest.TestCase):
     def test_area_parser_yaml(self):
         """Test YAML area parser."""
         from pyresample import parse_area_file
-        test_area_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
+        test_area_file = os.path.join(TEST_FILES_PATH, 'areas.yaml')
         test_areas = parse_area_file(test_area_file, 'ease_nh', 'ease_sh', 'test_meters', 'test_degrees',
                                      'test_latlong')
         ease_nh, ease_sh, test_m, test_deg, test_latlong = test_areas
@@ -158,7 +160,7 @@ Area extent: (-0.0812, 0.4039, 0.0812, 0.5428)""".format(projection)
         """Test YAML area parser on dynamic areas."""
         from pyresample import parse_area_file
         from pyresample.geometry import DynamicAreaDefinition
-        test_area_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
+        test_area_file = os.path.join(TEST_FILES_PATH, 'areas.yaml')
         test_area = parse_area_file(test_area_file, 'test_dynamic_resolution')[0]
 
         self.assertIsInstance(test_area, DynamicAreaDefinition)
@@ -168,7 +170,7 @@ Area extent: (-0.0812, 0.4039, 0.0812, 0.5428)""".format(projection)
         # lat/lon
         from pyresample import parse_area_file
         from pyresample.geometry import DynamicAreaDefinition
-        test_area_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
+        test_area_file = os.path.join(TEST_FILES_PATH, 'areas.yaml')
         test_area = parse_area_file(test_area_file, 'test_dynamic_resolution_ll')[0]
 
         self.assertIsInstance(test_area, DynamicAreaDefinition)
@@ -178,7 +180,7 @@ Area extent: (-0.0812, 0.4039, 0.0812, 0.5428)""".format(projection)
     def test_dynamic_area_parser_passes_resolution(self):
         """Test that the resolution from the file is passed to a dynamic area."""
         from pyresample import parse_area_file
-        test_area_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
+        test_area_file = os.path.join(TEST_FILES_PATH, 'areas.yaml')
         test_area = parse_area_file(test_area_file, 'omerc_bb_1000')[0]
         assert test_area.resolution == (1000, 1000)
 

--- a/pyresample/test/test_image.py
+++ b/pyresample/test/test_image.py
@@ -23,6 +23,7 @@ import unittest
 import numpy
 
 from pyresample import geometry, image, utils
+from pyresample.test.utils import TEST_FILES_PATH
 
 
 class Test(unittest.TestCase):
@@ -108,8 +109,7 @@ class Test(unittest.TestCase):
         area_con = msg_con.resample(self.area_def)
         res = area_con.image_data
         resampled_mask = res.mask.astype('int')
-        expected = numpy.fromfile(os.path.join(os.path.dirname(__file__),
-                                               'test_files', 'mask_grid.dat'),
+        expected = numpy.fromfile(os.path.join(TEST_FILES_PATH, 'mask_grid.dat'),
                                   sep=' ').reshape((800, 800))
         self.assertTrue(numpy.array_equal(resampled_mask, expected))
 
@@ -123,9 +123,7 @@ class Test(unittest.TestCase):
         area_con = msg_con.resample(self.area_def)
         res = area_con.image_data
         resampled_mask = res.mask.astype('int')
-        expected = numpy.fromfile(os.path.join(os.path.dirname(__file__),
-                                               'test_files',
-                                               'mask_grid.dat'),
+        expected = numpy.fromfile(os.path.join(TEST_FILES_PATH, 'mask_grid.dat'),
                                   sep=' ').reshape((800, 800))
         self.assertTrue(numpy.array_equal(resampled_mask, expected))
 

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -23,7 +23,7 @@ from unittest import mock
 import numpy as np
 
 from pyresample import geometry, kd_tree, utils
-from pyresample.test.utils import catch_warnings
+from pyresample.test.utils import TEST_FILES_PATH, catch_warnings
 
 
 class Test(unittest.TestCase):
@@ -495,13 +495,9 @@ class Test(unittest.TestCase):
         masked_data = np.ma.array(data, mask=mask)
         res = kd_tree.resample_nearest(swath_def, masked_data.ravel(),
                                        self.area_def, 50000, segments=1)
-        expected_mask = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                 'test_files',
-                                                 'mask_test_nearest_mask.dat'),
+        expected_mask = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_nearest_mask.dat'),
                                     sep=' ').reshape((800, 800))
-        expected_data = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                 'test_files',
-                                                 'mask_test_nearest_data.dat'),
+        expected_data = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_nearest_data.dat'),
                                     sep=' ').reshape((800, 800))
         self.assertTrue(np.array_equal(expected_mask, res.mask))
         self.assertTrue(np.array_equal(expected_data, res.data))
@@ -530,13 +526,9 @@ class Test(unittest.TestCase):
         masked_data = np.ma.array(data, mask=mask)
         res = kd_tree.resample_gauss(swath_def, masked_data.ravel(),
                                      self.area_def, 50000, 25000, segments=1)
-        expected_mask = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                 'test_files',
-                                                 'mask_test_mask.dat'),
+        expected_mask = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_mask.dat'),
                                     sep=' ').reshape((800, 800))
-        expected_data = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                 'test_files',
-                                                 'mask_test_data.dat'),
+        expected_data = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_data.dat'),
                                     sep=' ').reshape((800, 800))
         expected = expected_data.sum()
         cross_sum = res.data.sum()
@@ -551,9 +543,7 @@ class Test(unittest.TestCase):
         swath_def = geometry.SwathDefinition(lons=lons, lats=lats)
         res = kd_tree.resample_nearest(swath_def, data.ravel(),
                                        self.area_def, 50000, fill_value=None, segments=1)
-        expected_fill_mask = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                      'test_files',
-                                                      'mask_test_fill_value.dat'),
+        expected_fill_mask = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_fill_value.dat'),
                                          sep=' ').reshape((800, 800))
         fill_mask = res.mask
         self.assertTrue(np.array_equal(fill_mask, expected_fill_mask))
@@ -565,9 +555,7 @@ class Test(unittest.TestCase):
         swath_def = geometry.SwathDefinition(lons=lons, lats=lats)
         res = kd_tree.resample_nearest(swath_def, data.ravel(),
                                        self.area_def, 50000, fill_value=None, segments=1)
-        expected_fill_mask = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                      'test_files',
-                                                      'mask_test_fill_value.dat'),
+        expected_fill_mask = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_fill_value.dat'),
                                          sep=' ').reshape((800, 800))
         fill_mask = res.mask
         self.assertTrue(np.array_equal(fill_mask, expected_fill_mask))
@@ -585,9 +573,7 @@ class Test(unittest.TestCase):
                                        masked_data.ravel(
                                        ), self.area_def, 50000,
                                        fill_value=None, segments=1)
-        expected_fill_mask = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                      'test_files',
-                                                      'mask_test_full_fill.dat'),
+        expected_fill_mask = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_full_fill.dat'),
                                          sep=' ').reshape((800, 800))
         fill_mask = res.mask
 
@@ -613,9 +599,7 @@ class Test(unittest.TestCase):
         res = kd_tree.resample_nearest(swath_def,
                                        masked_data, self.area_def, 50000,
                                        fill_value=None, segments=1)
-        expected_fill_mask = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                      'test_files',
-                                                      'mask_test_full_fill_multi.dat'),
+        expected_fill_mask = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_full_fill_multi.dat'),
                                          sep=' ').reshape((800, 800, 3))
         fill_mask = res.mask
         cross_sum = res.sum()
@@ -749,9 +733,7 @@ class Test(unittest.TestCase):
                                                      valid_input_index,
                                                      valid_output_index, index_array,
                                                      fill_value=None)
-        expected_fill_mask = np.fromfile(os.path.join(os.path.dirname(__file__),
-                                                      'test_files',
-                                                      'mask_test_full_fill_multi.dat'),
+        expected_fill_mask = np.fromfile(os.path.join(TEST_FILES_PATH, 'mask_test_full_fill_multi.dat'),
                                          sep=' ').reshape((800, 800, 3))
         fill_mask = res.mask
         self.assertTrue(np.array_equal(fill_mask, expected_fill_mask))

--- a/pyresample/test/test_plot.py
+++ b/pyresample/test/test_plot.py
@@ -24,6 +24,8 @@ from unittest import mock
 
 import numpy as np
 
+from pyresample.test.utils import TEST_FILES_PATH
+
 try:
     import matplotlib
     matplotlib.use('Agg')
@@ -48,8 +50,7 @@ PARALLELS1 = np.array([-90, -80, -70, -60, -50, -40, -30, -20, -10, 0, 10, 20, 3
 class Test(unittest.TestCase):
     """Test the plot utilities."""
 
-    filename = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                            'test_files', 'ssmis_swath.npz'))
+    filename = os.path.abspath(os.path.join(TEST_FILES_PATH, 'ssmis_swath.npz'))
     data = np.load(filename)['data']
     lons = data[:, 0].astype(np.float64)
     lats = data[:, 1].astype(np.float64)
@@ -79,7 +80,7 @@ class Test(unittest.TestCase):
     def test_area_def2basemap(self):
         """Test the area to Basemap object conversion function."""
         from pyresample import parse_area_file, plot
-        area_def = parse_area_file(os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml'), 'ease_sh')[0]
+        area_def = parse_area_file(os.path.join(TEST_FILES_PATH, 'areas.yaml'), 'ease_sh')[0]
         bmap = plot.area_def2basemap(area_def)
         self.assertTrue(bmap.rmajor == bmap.rminor and bmap.rmajor == 6371228.0,
                         'Failed to create Basemap object')
@@ -158,7 +159,7 @@ class Test(unittest.TestCase):
     def test_plate_carreeplot(self):
         """Test the Plate Caree plotting functionality."""
         from pyresample import geometry, kd_tree, parse_area_file, plot
-        area_def = parse_area_file(os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml'), 'pc_world')[0]
+        area_def = parse_area_file(os.path.join(TEST_FILES_PATH, 'areas.yaml'), 'pc_world')[0]
         swath_def = geometry.SwathDefinition(self.lons, self.lats)
         result = kd_tree.resample_nearest(swath_def, self.tb37v, area_def,
                                           radius_of_influence=20000,
@@ -171,7 +172,7 @@ class Test(unittest.TestCase):
     def test_easeplot(self):
         """Test the plotting on the ease grid area."""
         from pyresample import geometry, kd_tree, parse_area_file, plot
-        area_def = parse_area_file(os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml'), 'ease_sh')[0]
+        area_def = parse_area_file(os.path.join(TEST_FILES_PATH, 'areas.yaml'), 'ease_sh')[0]
         swath_def = geometry.SwathDefinition(self.lons, self.lats)
         result = kd_tree.resample_nearest(swath_def, self.tb37v, area_def,
                                           radius_of_influence=20000,
@@ -181,7 +182,7 @@ class Test(unittest.TestCase):
     def test_orthoplot(self):
         """Test the ortho plotting."""
         from pyresample import geometry, kd_tree, parse_area_file, plot
-        area_def = parse_area_file(os.path.join(os.path.dirname(__file__), 'test_files', 'areas.cfg'), 'ortho')[0]
+        area_def = parse_area_file(os.path.join(TEST_FILES_PATH, 'areas.cfg'), 'ortho')[0]
         swath_def = geometry.SwathDefinition(self.lons, self.lats)
         result = kd_tree.resample_nearest(swath_def, self.tb37v, area_def,
                                           radius_of_influence=20000,

--- a/pyresample/test/test_swath.py
+++ b/pyresample/test/test_swath.py
@@ -24,7 +24,7 @@ import warnings
 import numpy as np
 
 from pyresample import geometry, kd_tree
-from pyresample.test.utils import catch_warnings
+from pyresample.test.utils import TEST_FILES_PATH, catch_warnings
 
 warnings.simplefilter("always")
 
@@ -32,8 +32,7 @@ warnings.simplefilter("always")
 class Test(unittest.TestCase):
     """Tests for swath definitions."""
 
-    filename = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                            'test_files', 'ssmis_swath.npz'))
+    filename = os.path.abspath(os.path.join(TEST_FILES_PATH, 'ssmis_swath.npz'))
     data = np.load(filename)['data']
     lons = data[:, 0].astype(np.float64)
     lats = data[:, 1].astype(np.float64)

--- a/pyresample/test/test_utils.py
+++ b/pyresample/test/test_utils.py
@@ -29,6 +29,7 @@ from pyproj import CRS
 
 import pyresample
 from pyresample.test.utils import (
+    TEST_FILES_PATH,
     assert_future_geometry,
     create_test_latitude,
     create_test_longitude,
@@ -236,7 +237,7 @@ class TestMisc(unittest.TestCase):
         import tempfile
 
         from pyresample import convert_def_to_yaml, parse_area_file
-        def_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.cfg')
+        def_file = os.path.join(TEST_FILES_PATH, 'areas.cfg')
         filehandle, yaml_file = tempfile.mkstemp()
         os.close(filehandle)
         try:
@@ -458,12 +459,12 @@ class TestLoadCFAreaPublic:
     """Test public API load_cf_area() for loading an AreaDefinition from netCDF/CF files."""
 
     def test_load_cf_no_exist(self):
-        cf_file = os.path.join(os.path.dirname(__file__), 'test_files', 'does_not_exist.nc')
+        cf_file = os.path.join(TEST_FILES_PATH, 'does_not_exist.nc')
         with pytest.raises(FileNotFoundError):
             load_cf_area(cf_file)
 
     def test_load_cf_from_not_nc(self):
-        cf_file = os.path.join(os.path.dirname(__file__), 'test_files', 'areas.yaml')
+        cf_file = os.path.join(TEST_FILES_PATH, 'areas.yaml')
         with pytest.raises((ValueError, OSError)):
             load_cf_area(cf_file)
 

--- a/pyresample/test/utils.py
+++ b/pyresample/test/utils.py
@@ -21,6 +21,7 @@
 This mostly takes from astropy's method for checking collected_warnings during
 tests.
 """
+import os
 import sys
 import types
 import warnings
@@ -37,6 +38,9 @@ _deprecations_as_exceptions = False
 _include_astropy_deprecations = False
 AstropyDeprecationWarning = None
 AstropyPendingDeprecationWarning = None
+
+
+TEST_FILES_PATH = os.path.join(os.path.dirname(__file__), 'test_files')
 
 
 def treat_deprecations_as_exceptions():


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Remove `__file__` usage in test units for `test_files` path.