### PR TITLE
Switch test area fixtures to session-scoped

### DIFF
--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -51,8 +51,10 @@ def reset_pyresample_config(tmpdir):
         yield
 
 
-@pytest.fixture(params=[LegacySwathDefinition, SwathDefinition],
-                ids=["LegacySwathDefinition", "SwathDefinition"])
+@pytest.fixture(
+    scope="session",
+    params=[LegacySwathDefinition, SwathDefinition],
+    ids=["LegacySwathDefinition", "SwathDefinition"])
 def swath_class(request):
     """Get one of the currently active 'SwathDefinition' classes.
 
@@ -63,7 +65,7 @@ def swath_class(request):
     return request.param
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def create_test_swath(swath_class):
     """Get a function for creating SwathDefinitions for testing.
 
@@ -78,8 +80,10 @@ def create_test_swath(swath_class):
     return _create_test_swath
 
 
-@pytest.fixture(params=[LegacyAreaDefinition, AreaDefinition],
-                ids=["LegacyAreaDefinition", "AreaDefinition"])
+@pytest.fixture(
+    scope="session",
+    params=[LegacyAreaDefinition, AreaDefinition],
+    ids=["LegacyAreaDefinition", "AreaDefinition"])
 def area_class(request):
     """Get one of the currently active 'AreaDefinition' classes.
 
@@ -90,7 +94,7 @@ def area_class(request):
     return request.param
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def create_test_area(area_class):
     """Get a function for creating AreaDefinitions for testing.
 

--- a/pyresample/test/test_formatting.py
+++ b/pyresample/test/test_formatting.py
@@ -26,13 +26,12 @@ from pyresample._formatting_html import (
     swath_area_attrs_section,
 )
 
-from .test_geometry.test_area import stere_area  # noqa F401
 from .test_geometry.test_swath import _gen_swath_def_numpy, _gen_swath_def_xarray_dask
 
 
-def test_plot_area_def_w_area_def(stere_area):  # noqa F811
+def test_plot_area_def_w_area_def(area_def_stere_source):  # noqa F811
     """Test AreaDefinition plotting as svg/png."""
-    area = stere_area
+    area = area_def_stere_source
 
     with mock.patch('matplotlib.pyplot.savefig') as mock_savefig:
         plot_area_def(area, fmt="svg")
@@ -42,9 +41,9 @@ def test_plot_area_def_w_area_def(stere_area):  # noqa F811
         mock_savefig.assert_called_with(ANY, format="png", bbox_inches="tight")
 
 
-def test_plot_area_def_w_area_def_show(stere_area):  # noqa F811
+def test_plot_area_def_w_area_def_show(area_def_stere_source):  # noqa F811
     """Test AreaDefinition plotting as svg/png."""
-    area = stere_area
+    area = area_def_stere_source
 
     with mock.patch('matplotlib.pyplot.show') as mock_show_plot:
         plot_area_def(area)
@@ -60,31 +59,31 @@ def test_plot_area_def_w_swath_def(create_test_swath):
         mock_savefig.assert_called_with(ANY, format="svg", bbox_inches="tight")
 
 
-def test_area_def_cartopy_missing(monkeypatch, stere_area):  # noqa F811
+def test_area_def_cartopy_missing(monkeypatch, area_def_stere_source):  # noqa F811
     """Test missing cartopy installation."""
     with monkeypatch.context() as m:
         m.setattr(pyresample._formatting_html, "cartopy", None)
 
-        area = stere_area
+        area = area_def_stere_source
         assert "Note: If cartopy is installed a display of the area can be seen here" in area._repr_html_()
 
 
-def test_area_def_cartopy_installed(stere_area):  # noqa F811
+def test_area_def_cartopy_installed(area_def_stere_source):  # noqa F811
     """Test cartopy installed."""
-    area = stere_area
+    area = area_def_stere_source
     assert "Note: If cartopy is installed a display of the area can be seen here" not in area._repr_html_()
 
 
-def test_area_repr_w_static_files(stere_area):  # noqa F811
+def test_area_repr_w_static_files(area_def_stere_source):  # noqa F811
     """Test area representation with static files (css/icons) included."""
-    area_def = stere_area
+    area_def = area_def_stere_source
     res = area_repr(area_def)
     assert "<style>" in res
 
 
-def test_area_repr_wo_static_files(stere_area):  # noqa F811
+def test_area_repr_wo_static_files(area_def_stere_source):  # noqa F811
     """Test area representation without static files (css/icons) included."""
-    area_def = stere_area
+    area_def = area_def_stere_source
     res = area_repr(area_def, include_static_files=False)
     assert "<style>" not in res
 

--- a/pyresample/test/test_geometry/conftest.py
+++ b/pyresample/test/test_geometry/conftest.py
@@ -19,7 +19,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def stere_area(create_test_area):
     """Create basic polar-stereographic area definition."""
     proj_dict = {
@@ -41,7 +41,7 @@ def stere_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def geos_src_area(create_test_area):
     """Create basic geostationary area definition."""
     shape = (3712, 3712)
@@ -56,7 +56,7 @@ def geos_src_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def laea_area(create_test_area):
     """Create basic LAEA area definition."""
     shape = (10, 10)
@@ -65,7 +65,7 @@ def laea_area(create_test_area):
     return create_test_area(proj_dict, shape[0], shape[1], area_extent)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def global_lonlat_antimeridian_centered_area(create_test_area):
     """Create global lonlat projection area centered on the -180 antimeridian."""
     shape = (4, 4)
@@ -79,7 +79,7 @@ def global_lonlat_antimeridian_centered_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def global_platee_caree_area(create_test_area):
     """Create global platee projection area."""
     shape = (4, 4)
@@ -93,7 +93,7 @@ def global_platee_caree_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def global_platee_caree_minimum_area(create_test_area):
     """Create minimum size global platee caree projection area."""
     shape = (2, 2)
@@ -107,7 +107,7 @@ def global_platee_caree_minimum_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def local_platee_caree_area(create_test_area):
     """Create local platee caree projection area."""
     shape = (4, 4)
@@ -121,7 +121,7 @@ def local_platee_caree_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def local_lonlat_antimeridian_centered_area(create_test_area):
     """Create local lonlat projection area centered on the -180 antimeridian."""
     shape = (4, 4)
@@ -135,7 +135,7 @@ def local_lonlat_antimeridian_centered_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def local_meter_area(create_test_area):
     """Create local meter projection area."""
     shape = (2, 2)
@@ -149,7 +149,7 @@ def local_meter_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def south_pole_area(create_test_area):
     """Create projection area centered on south pole."""
     shape = (2, 2)
@@ -163,7 +163,7 @@ def south_pole_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def north_pole_area(create_test_area):
     """Create projection area centered on north pole."""
     shape = (2, 2)
@@ -177,7 +177,7 @@ def north_pole_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def geos_fd_area(create_test_area):
     """Create full disc geostationary area definition."""
     shape = (100, 100)
@@ -192,7 +192,7 @@ def geos_fd_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def geos_out_disk_area(create_test_area):
     """Create out of Earth diskc geostationary area definition."""
     shape = (10, 10)
@@ -207,7 +207,7 @@ def geos_out_disk_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def geos_half_out_disk_area(create_test_area):
     """Create geostationary area definition with portion of boundary out of earth_disk."""
     shape = (100, 100)
@@ -222,7 +222,7 @@ def geos_half_out_disk_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def geos_conus_area(create_test_area):
     """Create CONUS geostationary area definition (portion is out-of-Earth disk)."""
     shape = (30, 50)  # (3000, 5000) for GOES-R CONUS/PACUS
@@ -238,7 +238,7 @@ def geos_conus_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def geos_mesoscale_area(create_test_area):
     """Create CONUS geostationary area definition."""
     shape = (10, 10)  # (1000, 1000) for GOES-R mesoscale
@@ -254,7 +254,7 @@ def geos_mesoscale_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def truncated_geos_area(create_test_area):
     """Create a truncated geostationary area (SEVIRI above 30° lat)."""
     proj_dict = {'a': '6378169', 'h': '35785831', 'lon_0': '9.5', 'no_defs': 'None', 'proj': 'geos',
@@ -269,7 +269,7 @@ def truncated_geos_area(create_test_area):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def truncated_geos_area_in_space(create_test_area):
     """Create a geostationary area entirely out of the Earth disk !."""
     proj_dict = {'a': '6378169', 'h': '35785831', 'lon_0': '9.5', 'no_defs': 'None', 'proj': 'geos',


### PR DESCRIPTION
No need to create them for every test. Additionally this fixes a test failure caused by one PR refactoring the imports of another that were both merged at essentially the same time.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
