### PR TITLE
Fix area definition YAML not warning on typos

### DIFF
--- a/pyresample/test/test_area_config.py
+++ b/pyresample/test/test_area_config.py
@@ -23,6 +23,7 @@ import pathlib
 import unittest
 
 import numpy as np
+import pytest
 
 from pyresample.test.utils import TEST_FILES_PATH
 
@@ -278,3 +279,24 @@ australia:
         assert call_args[0][1]['include_static_files']
         # check that static files are not included for the second area
         assert not call_args[1][1]['include_static_files']
+
+
+def test_unused_params_warn():
+    """Test unused parameters produce a warning."""
+    from pyresample.area_config import load_area_from_string
+
+    yaml_str = """ease_sh2:
+  description: Antarctic EASE grid
+  projection:
+    a: 6371228.0
+    units: m
+    lon_0: 0
+    proj: laea
+    lat_0: -90
+  revolution: 1000
+  area_extent:
+    lower_left_xy: [-5326849.0625, -5326849.0625]
+    upper_right_xy: [5326849.0625, 5326849.0625]
+    units: m"""
+    with pytest.warns(UserWarning, match=r"Unused/unexpected area definition parameter.*revolution"):
+        load_area_from_string(yaml_str)


### PR DESCRIPTION
If a user has a typo or some other unused parameter in an area YAML definition then pyresample silently ignores it and the user is left confused as to why things aren't working as expected. This PR fixes this by producing a UserWarning in these cases.

I could make this an error but I feel that limits the future flexibility and maintainability of the YAML reading. I could also make a configuration (`pyresample.config`) parameter that controls whether this is a warnings or error...or maybe just another keyword argument, but I'm not sure we need any more kwargs for these functions.

TODO: I'd like to rework some of the metadata handling in the future area definitions. I might not do that in this PR as it is decently separate. I noticed while working on this that any unused kwarg is put into the future AreaDefinition's `.attrs` dictionary property. This is error prone as it means that any unrecognized property will go in as "metadata". I'd like to add an explicit `attrs:` section to the YAML for defining these metadata values.

 - [x] Closes #570  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
