### PR TITLE
Add attrs to future swath definition

### DIFF
--- a/pyresample/future/geometry/swath.py
+++ b/pyresample/future/geometry/swath.py
@@ -19,4 +19,38 @@
 
 from __future__ import annotations
 
-from pyresample.geometry import CoordinateDefinition, SwathDefinition  # noqa
+from pyresample.geometry import CoordinateDefinition  # noqa
+from pyresample.geometry import SwathDefinition as LegacySwathDefinition
+
+
+class SwathDefinition(LegacySwathDefinition):
+    """Swath defined by lons and lats.
+
+    Parameters
+    ----------
+    lons : numpy array
+    lats : numpy array
+    crs: pyproj.CRS,
+       The CRS to use. longlat on WGS84 by default.
+    attrs: dict,
+       A dictionary made to store metadata.
+
+    Attributes
+    ----------
+    shape : tuple
+        Swath shape
+    size : int
+        Number of elements in swath
+    ndims : int
+        Swath dimensions
+    lons : object
+        Swath lons
+    lats : object
+        Swath lats
+    cartesian_coords : object
+        Swath cartesian coordinates
+    """
+
+    def __init__(self, lons, lats, crs=None, attrs=None):
+        super().__init__(lons, lats, crs=crs)
+        self.attrs = attrs or {}

--- a/pyresample/future/geometry/swath.py
+++ b/pyresample/future/geometry/swath.py
@@ -32,6 +32,8 @@ class SwathDefinition(LegacySwathDefinition):
     lats : numpy array
     crs: pyproj.CRS,
        The CRS to use. longlat on WGS84 by default.
+    nprocs : int, optional
+        Number of processor cores to be used for calculations.
     attrs: dict,
        A dictionary made to store metadata.
 
@@ -51,6 +53,6 @@ class SwathDefinition(LegacySwathDefinition):
         Swath cartesian coordinates
     """
 
-    def __init__(self, lons, lats, crs=None, attrs=None):
-        super().__init__(lons, lats, crs=crs)
+    def __init__(self, lons, lats, crs=None, nprocs=1, attrs=None):
+        super().__init__(lons, lats, crs=crs, nprocs=nprocs)
         self.attrs = attrs or {}

--- a/pyresample/test/conftest.py
+++ b/pyresample/test/conftest.py
@@ -76,6 +76,8 @@ def create_test_swath(swath_class):
 
     """
     def _create_test_swath(lons, lats, **kwargs):
+        if swath_class is SwathDefinition:
+            kwargs.pop("nproc", None)
         return swath_class(lons, lats, **kwargs)
     return _create_test_swath
 

--- a/pyresample/test/test_geometry/test_swath.py
+++ b/pyresample/test/test_geometry/test_swath.py
@@ -468,5 +468,37 @@ def test_future_swath_has_attrs():
     """Test that future SwathDefinition has attrs."""
     from pyresample.future.geometry import SwathDefinition
     lons, lats = _gen_swath_lons_lats()
-    swath = SwathDefinition(lons, lats)
-    assert isinstance(swath.attrs, dict)
+    attrs = dict(meta="data")
+    swath = SwathDefinition(lons, lats, attrs=attrs)
+    assert swath.attrs == attrs
+
+
+def test_future_swath_slice_has_attrs():
+    """Test that future sliced SwathDefinition has attrs."""
+    from pyresample.future.geometry import SwathDefinition
+    lons, lats = _gen_swath_lons_lats()
+    attrs = dict(meta="data")
+    swath = SwathDefinition(lons, lats, attrs=attrs)[0:1, 0:1]
+    assert swath.attrs == attrs
+
+
+def test_future_swath_concat_has_attrs():
+    """Test that future concatenated SwathDefinition has attrs."""
+    from pyresample.future.geometry import SwathDefinition
+    lons, lats = _gen_swath_lons_lats()
+    attrs1 = dict(meta1="data")
+    swath1 = SwathDefinition(lons, lats, attrs=attrs1)
+    attrs2 = dict(meta2="data")
+    swath2 = SwathDefinition(lons, lats, attrs=attrs2)
+    swath = swath1.concatenate(swath2)
+    assert swath.attrs == dict(meta1="data", meta2="data")
+
+
+def test_future_swath_concat_fails_on_different_crs():
+    """Test that future concatenated SwathDefinition must have the same crs."""
+    from pyresample.future.geometry import SwathDefinition
+    lons, lats = _gen_swath_lons_lats()
+    swath1 = SwathDefinition(lons, lats, crs="mycrs")
+    swath2 = SwathDefinition(lons, lats, crs="myothercrs")
+    with pytest.raises(ValueError, match="Incompatible CRSs."):
+        _ = swath1.concatenate(swath2)

--- a/pyresample/test/test_geometry/test_swath.py
+++ b/pyresample/test/test_geometry/test_swath.py
@@ -462,3 +462,11 @@ def assert_np_dict_allclose(dict1, dict2):
             np.testing.assert_allclose(val, dict2[key])
         except TypeError:
             assert val == dict2[key]
+
+
+def test_future_swath_has_attrs():
+    """Test that future SwathDefinition has attrs."""
+    from pyresample.future.geometry import SwathDefinition
+    lons, lats = _gen_swath_lons_lats()
+    swath = SwathDefinition(lons, lats)
+    assert isinstance(swath.attrs, dict)


### PR DESCRIPTION
This PR adds attrs to the future swath definition.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
