### PR TITLE
Add no build isolation to unstable CI installs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,11 +67,12 @@ jobs:
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray \
           git+https://github.com/shapely/shapely;
+          python -m pip install -e . --no-deps --no-build-isolation;
 
       - name: Install pyresample
         shell: bash -l {0}
         run: |
-          pip install --no-deps -e .
+          python -m pip install --no-deps -e .
 
       - name: Run unit tests
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
+          python -m pip install versioneer extension-helpers setuptools-scm configobj pkgconfig;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --no-deps --pre --upgrade \
@@ -53,9 +54,10 @@ jobs:
           numpy \
           pandas \
           scipy; \
-          python -m pip install versioneer extension-helpers setuptools-scm configobj pkgconfig;
+          mamba remove --force-remove -y pykdtree
           python -m pip install \
           --no-deps --upgrade --pre --no-build-isolation \
+          git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,7 @@ jobs:
           python -m pip install -e . --no-deps --no-build-isolation;
 
       - name: Install pyresample
+        if: matrix.experimental != true
         shell: bash -l {0}
         run: |
           python -m pip install --no-deps -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
           python -m pip install \
           --no-deps --upgrade --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
-          git+https://github.com/dask/dask \
+          git+https://github.com/djhoese/dask@bugfix-np2-ogrid-tuples \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \
           git+https://github.com/Unidata/cftime \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
           python -m pip install \
           --no-deps --upgrade --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
-          git+https://github.com/djhoese/dask@bugfix-np2-ogrid-tuples \
+          git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \
           git+https://github.com/Unidata/cftime \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,8 +53,9 @@ jobs:
           numpy \
           pandas \
           scipy; \
+          python -m pip install versioneer extension-helpers setuptools-scm configobj pkgconfig;
           python -m pip install \
-          --no-deps --upgrade \
+          --no-deps --upgrade --pre --no-build-isolation \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/pyresample/grid.py
+++ b/pyresample/grid.py
@@ -228,9 +228,9 @@ def get_resampled_image(target_area_def, source_area_def, source_image_data,
                 result = next_result
             else:
                 if isinstance(next_result, np.ma.core.MaskedArray):
-                    stack = np.ma.row_stack
+                    stack = np.ma.vstack
                 else:
-                    stack = np.row_stack
+                    stack = np.vstack
                 result = stack((result, next_result))
 
         return result

--- a/pyresample/kd_tree.py
+++ b/pyresample/kd_tree.py
@@ -848,14 +848,14 @@ def _calculate_uncertainty(neighbours, new_data, index_mask_list, weight_list,
             v2 = norm_sqr[new_valid_index, i]
             stddev[new_valid_index, i] = np.sqrt(
                 (v1 / (v1 ** 2 - v2)) * stddev[new_valid_index, i])
-            stddev[~new_valid_index, i] = np.NaN
+            stddev[~new_valid_index, i] = np.nan
     else:
         # If given single input data array
         v1 = norm[new_valid_index]
         v2 = norm_sqr[new_valid_index]
         stddev[new_valid_index] = np.sqrt(
             (v1 / (v1 ** 2 - v2)) * stddev[new_valid_index])
-        stddev[~new_valid_index] = np.NaN
+        stddev[~new_valid_index] = np.nan
     return stddev, count
 
 

--- a/pyresample/spherical.py
+++ b/pyresample/spherical.py
@@ -221,11 +221,11 @@ class SCoordinate(object):
 
     def __str__(self):
         """Get simplified representation of lon/lat arrays in degrees."""
-        return str((np.rad2deg(self.lon), np.rad2deg(self.lat)))
+        return str((float(np.rad2deg(self.lon)), float(np.rad2deg(self.lat))))
 
     def __repr__(self):
         """Get simplified representation of lon/lat arrays in degrees."""
-        return str((np.rad2deg(self.lon), np.rad2deg(self.lat)))
+        return str((float(np.rad2deg(self.lon)), float(np.rad2deg(self.lat))))
 
     def __iter__(self):
         """Get iterator over lon/lat pairs."""

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -100,7 +100,7 @@ class TestOGradientResampler:
     def test_get_chunk_mappings(self):
         """Test that chunk overlap, and source and target slices are correct."""
         chunks = (10, 10)
-        num_chunks = np.product(chunks)
+        num_chunks = np.prod(chunks)
         self.resampler._get_projection_coordinates(chunks)
         self.resampler._get_gradients()
         assert self.resampler.coverage_status is None

--- a/pyresample/test/test_kd_tree.py
+++ b/pyresample/test/test_kd_tree.py
@@ -125,13 +125,13 @@ class Test(unittest.TestCase):
         self.assertEqual(cross_sum, expected)
 
     def test_nearest_complex(self):
-        data = np.fromfunction(lambda y, x: y + complex("j") * x, (50, 10), dtype=np.complex_)
+        data = np.fromfunction(lambda y, x: y + complex("j") * x, (50, 10), dtype=np.complex128)
         lons = np.fromfunction(lambda y, x: 3 + x, (50, 10))
         lats = np.fromfunction(lambda y, x: 75 - y, (50, 10))
         swath_def = geometry.SwathDefinition(lons=lons, lats=lats)
         res = kd_tree.resample_nearest(swath_def, data.ravel(),
                                        self.area_def, 50000, segments=1)
-        assert np.issubdtype(res.dtype, np.complex_)
+        assert np.issubdtype(res.dtype, np.complex128)
         cross_sum = res.sum()
         assert cross_sum.real == 3530219.0
         assert cross_sum.imag == 688723.0

--- a/pyresample/test/test_resample_blocks.py
+++ b/pyresample/test/test_resample_blocks.py
@@ -267,7 +267,7 @@ class TestResampleBlocksArea2Area:
             assert dst_area.shape == dst_array.shape
             return dst_array
 
-        dst_array = da.arange(np.product(self.dst_area.shape)).reshape(self.dst_area.shape).rechunk(40)
+        dst_array = da.arange(np.prod(self.dst_area.shape)).reshape(self.dst_area.shape).rechunk(40)
         res = resample_blocks(fun, self.src_area, [], self.dst_area, dst_arrays=[dst_array], chunk_size=40, dtype=float)
         res = res.compute()
         np.testing.assert_allclose(res[:, 40:], dst_array[:, 40:])
@@ -290,7 +290,7 @@ class TestResampleBlocksArea2Area:
             prev_block_info.append(block_info[0])
             return dst_array
 
-        dst_array = da.arange(np.product(self.dst_area.shape)).reshape(self.dst_area.shape).rechunk(40)
+        dst_array = da.arange(np.prod(self.dst_area.shape)).reshape(self.dst_area.shape).rechunk(40)
         res = resample_blocks(fun, self.src_area, [], self.dst_area, dst_arrays=[dst_array], chunk_size=40, dtype=float)
         _ = res.compute()
 
@@ -311,7 +311,7 @@ class TestResampleBlocksArea2Area:
             prev_block_info.append(block_info[None])
             return dst_array
 
-        dst_array = da.arange(np.product(self.dst_area.shape)).reshape(self.dst_area.shape).rechunk(40)
+        dst_array = da.arange(np.prod(self.dst_area.shape)).reshape(self.dst_area.shape).rechunk(40)
         res = resample_blocks(fun, self.src_area, [], self.dst_area, dst_arrays=[dst_array], chunk_size=40, dtype=float)
         _ = res.compute()
 
@@ -325,7 +325,7 @@ class TestResampleBlocksArea2Area:
             assert dst_area.shape == dst_array.shape[1:]
             return dst_array[0, :, :]
 
-        dst_array = da.arange(np.product(self.dst_area.shape)).reshape((1, *self.dst_area.shape)).rechunk(40)
+        dst_array = da.arange(np.prod(self.dst_area.shape)).reshape((1, *self.dst_area.shape)).rechunk(40)
         res = resample_blocks(fun, self.src_area, [], self.dst_area, dst_arrays=[dst_array],
                               chunk_size=(40, 40), dtype=float)
         res = res.compute()
@@ -359,7 +359,7 @@ class TestResampleBlocksArea2Area:
             assert src_area.shape == src_array.shape[-2:]
             return np.full(src_array.shape[:-2] + dst_area.shape, 18)
 
-        src_array = da.arange(np.product(self.src_area.shape) * 3).reshape((3, *self.src_area.shape)).rechunk(40)
+        src_array = da.arange(np.prod(self.src_area.shape) * 3).reshape((3, *self.src_area.shape)).rechunk(40)
         res = resample_blocks(fun, self.src_area, [src_array], self.dst_area, chunk_size=(3, 40, 40), dtype=float)
         res = res.compute()
         assert res.ndim == 3
@@ -377,7 +377,7 @@ class TestResampleBlocksArea2Area:
             assert src_array.shape[0] == 3
             return np.full(src_array.shape[:-2] + dst_area.shape, 18)
 
-        src_array = da.arange(np.product(self.src_area.shape) * 3).reshape((3, *self.src_area.shape))
+        src_array = da.arange(np.prod(self.src_area.shape) * 3).reshape((3, *self.src_area.shape))
         src_array = src_array.rechunk((1, 40, 40))
 
         res = resample_blocks(fun, self.src_area, [src_array], self.dst_area, chunk_size=(3, 40, 40), dtype=float)
@@ -408,7 +408,7 @@ class TestResampleBlocksArea2Area:
             dst_area = block_info[None]["area"]
             return np.full(src_array.shape[:-2] + dst_area.shape, 18)
 
-        src_array = da.arange(np.product(self.src_area.shape) * 3).reshape((3, *self.src_area.shape))
+        src_array = da.arange(np.prod(self.src_area.shape) * 3).reshape((3, *self.src_area.shape))
         src_array = src_array.rechunk((1, 40, 40))
 
         res = resample_blocks(fun, self.src_area, [src_array], self.dst_area, chunk_size=(3, "auto", "auto"),
@@ -453,10 +453,10 @@ class TestResampleBlocksArea2Area:
             dst_area = block_info[None]["area"]
             return np.full(src_array.shape[:-2] + dst_area.shape, 18)
 
-        src_array = da.arange(np.product(self.src_area.shape) * 3).reshape((3, *self.src_area.shape))
+        src_array = da.arange(np.prod(self.src_area.shape) * 3).reshape((3, *self.src_area.shape))
         src_array = src_array.rechunk((1, 40, 40))
 
-        dst_array = da.arange(np.product(self.dst_area.shape) * 2).reshape((2, *self.dst_area.shape))
+        dst_array = da.arange(np.prod(self.dst_area.shape) * 2).reshape((2, *self.dst_area.shape))
         dst_array = src_array.rechunk((1, 40, 40))
 
         res = resample_blocks(fun, self.src_area, [src_array], self.dst_area, [dst_array],

--- a/pyresample/utils/row_appendable_array.py
+++ b/pyresample/utils/row_appendable_array.py
@@ -46,7 +46,7 @@ class RowAppendableArray:
             if len(next_array.shape) == 1:
                 self._data = np.append(self._data, next_array[remaining:])
             else:
-                self._data = np.row_stack((self._data, next_array[remaining:]))
+                self._data = np.vstack((self._data, next_array[remaining:]))
         else:
             self._data[self._cursor:cursor_end] = next_array
         self._cursor = cursor_end


### PR DESCRIPTION
I need to build deps from github source with the unstable numpy and not in a sandboxed virtualenv. Passing `--no-build-isolation` should fix this.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
