### PR TITLE
Fix optimize_projection handling in YAML parsing

### DIFF
--- a/pyresample/test/test_area_config.py
+++ b/pyresample/test/test_area_config.py
@@ -184,6 +184,18 @@ Area extent: (-0.0812, 0.4039, 0.0812, 0.5428)""".format(projection)
         test_area_file = os.path.join(TEST_FILES_PATH, 'areas.yaml')
         test_area = parse_area_file(test_area_file, 'omerc_bb_1000')[0]
         assert test_area.resolution == (1000, 1000)
+        assert test_area.optimize_projection
+
+    def test_dynamic_area_parser_opt_projection_nores(self):
+        """Test that a dynamic area definition can be frozen when no resolution is passed via YAML."""
+        from pyresample import SwathDefinition, parse_area_file
+        test_area_file = os.path.join(TEST_FILES_PATH, 'areas.yaml')
+        test_area = parse_area_file(test_area_file, 'omerc_bb_nores')[0]
+        assert test_area.resolution is None
+        assert test_area.optimize_projection
+        lons, lats = np.meshgrid(np.arange(10, 20), np.arange(10, 20))
+        swath_def = SwathDefinition(lons, lats)
+        test_area.freeze(swath_def)
 
     def test_multiple_file_content(self):
         from pyresample import parse_area_file

--- a/pyresample/test/test_files/areas.yaml
+++ b/pyresample/test/test_files/areas.yaml
@@ -223,6 +223,13 @@ omerc_bb_1000:
   optimize_projection: True
   resolution: 1000
 
+omerc_bb_nores:
+  description: Oblique Mercator Bounding Box for Polar Overpasses
+  projection:
+    ellps: sphere
+    proj: omerc
+  optimize_projection: True
+
 test_dynamic_resolution:
   description: Dynamic with resolution specified in meters
   projection:


### PR DESCRIPTION
Broken in #577. I accidentally stopped passing/parsing `optimize_projection` to `DynamicAreaDefiniton` objects parsed from YAML. This was first noticed in Satpy's tests. This PR fixes it. As stated in #577, I'd still like to follow this up with a PR to move metadata from YAML being any random kwarg to being an explicit `attrs` key.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
