### PR TITLE
Fix AreaDefinition array index methods mishandling outer edge values

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,6 @@ jobs:
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
-          git+https://github.com/zarr-developers/zarr \
           git+https://github.com/Unidata/cftime \
           git+https://github.com/mapbox/rasterio \
           git+https://github.com/pyproj4/pyproj \

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1451,11 +1451,14 @@ def masked_ints(func):
         is_scalar = np.isscalar(xm) and np.isscalar(ym)
 
         x__, y__ = func(self, xm, ym)
+        epsilon = 0.02  # arbitrary buffer for floating point precision
+        x_mask = ((x__ < -0.5 - epsilon) | (x__ > self.width - 0.5 + epsilon))
+        y_mask = ((y__ < -0.5 - epsilon) | (y__ > self.height - 0.5 + epsilon))
+        x__ = np.clip(x__, 0, self.width - 1)
+        y__ = np.clip(y__, 0, self.height - 1)
         x__ = np.round(x__).astype(int)
         y__ = np.round(y__).astype(int)
 
-        x_mask = ((x__ < 0) | (x__ >= self.width))
-        y_mask = ((y__ < 0) | (y__ >= self.height))
         x_masked = np.ma.masked_array(x__, mask=x_mask, copy=False)
         y_masked = np.ma.masked_array(y__, mask=y_mask, copy=False)
         if is_scalar:

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -598,47 +598,6 @@ class TestAreaDefinition:
         assert lons[0, 0] == -179.5
         assert lats[0, 0] == 89.5
 
-    def test_get_array_indices_from_lonlat_mask_actual_values(self, create_test_area):
-        """Test that the masked values of get_array_indices_from_lonlat can be valid."""
-        x_size = 3712
-        y_size = 3712
-        area_extent = (-5570248.477339745, -5561247.267842293, 5567248.074173927, 5570248.477339745)
-        proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'lat_1': 25.,
-                     'lat_2': 25., 'lon_0': 0.0, 'proj': 'lcc', 'units': 'm'}
-        area_def = create_test_area(proj_dict, x_size, y_size, area_extent)
-
-        # Choose a point just outside the area
-        x, y = area_def.get_array_indices_from_lonlat([33.5], [-40.5])
-        assert x.item() == 3723
-        assert y.item() == 3746
-
-    def test_lonlat2colrow(self, create_test_area):
-        """Test lonlat2colrow."""
-        x_size = 3712
-        y_size = 3712
-        area_extent = [-5570248.477339261, -5567248.074173444, 5567248.074173444, 5570248.477339261]
-        proj_dict = {'a': '6378169.00',
-                     'b': '6356583.80',
-                     'h': '35785831.0',
-                     'lon_0': '0.0',
-                     'proj': 'geos'}
-        area = create_test_area(proj_dict, x_size, y_size, area_extent)
-
-        # Imatra, Wiesbaden
-        longitudes = np.array([28.75242, 8.24932])
-        latitudes = np.array([61.17185, 50.08258])
-        cols__, rows__ = area.get_array_indices_from_lonlat(longitudes, latitudes)
-
-        # test arrays
-        cols_expects = np.array([2304, 2040])
-        rows_expects = np.array([186, 341])
-        np.testing.assert_array_equal(cols__, cols_expects)
-        np.testing.assert_array_equal(rows__, rows_expects)
-
-        # test scalars
-        lon, lat = (-8.125547604568746, -14.345524111874646)
-        assert area.get_array_indices_from_lonlat(lon, lat) == (1567, 2375)
-
     def test_colrow2lonlat(self, create_test_area):
         """Test colrow2lonlat."""
         # test square, symmetric areadef
@@ -800,8 +759,52 @@ class TestAreaDefinition:
         actual = [(np.rad2deg(coord.lon), np.rad2deg(coord.lat)) for coord in area_def.corners]
         np.testing.assert_allclose(actual, expected)
 
+    def test_get_array_indices_from_lonlat_mask_actual_values(self, create_test_area):
+        """Test that the masked values of get_array_indices_from_lonlat can be valid."""
+        x_size = 3712
+        y_size = 3712
+        area_extent = (-5570248.477339745, -5561247.267842293, 5567248.074173927, 5570248.477339745)
+        proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'lat_1': 25.,
+                     'lat_2': 25., 'lon_0': 0.0, 'proj': 'lcc', 'units': 'm'}
+        area_def = create_test_area(proj_dict, x_size, y_size, area_extent)
+
+        # Choose a point just outside the area
+        x, y = area_def.get_array_indices_from_lonlat([33.5], [-40.5])
+        assert x.item() == 3723
+        assert y.item() == 3746
+
+    @pytest.mark.parametrize(
+        ("lons", "lats", "exp_cols", "exp_rows"),
+        [
+            # Imatra, Wiesbaden
+            (np.array([28.75242, 8.24932]), np.array([61.17185, 50.08258]),
+             np.array([2304, 2040]), np.array([186, 341])),
+            (-8.125547604568746, -14.345524111874646,
+             1567, 2375),
+        ]
+    )
+    def test_get_array_indices_from_lonlat_geos(self, create_test_area, lons, lats, exp_cols, exp_rows):
+        """Test get_array_indices_from_lonlat."""
+        x_size = 3712
+        y_size = 3712
+        area_extent = [-5570248.477339261, -5567248.074173444, 5567248.074173444, 5570248.477339261]
+        proj_dict = {'a': '6378169.00',
+                     'b': '6356583.80',
+                     'h': '35785831.0',
+                     'lon_0': '0.0',
+                     'proj': 'geos'}
+        area = create_test_area(proj_dict, x_size, y_size, area_extent)
+
+        cols__, rows__ = area.get_array_indices_from_lonlat(lons, lats)
+        if hasattr(exp_cols, "shape"):
+            np.testing.assert_array_equal(cols__, exp_cols)
+            np.testing.assert_array_equal(rows__, exp_rows)
+        else:
+            assert cols__ == exp_cols
+            assert rows__ == exp_rows
+
     def test_get_array_indices_from_lonlat(self, create_test_area):
-        """Test the function get_xy_from_lonlat."""
+        """Test the function get_array_indices_from_lonlat."""
         x_size = 2
         y_size = 2
         area_extent = [1000000, 0, 1050000, 50000]


### PR DESCRIPTION
An attempt to fix https://github.com/ssec/polar2grid/issues/691

Basically, current bounding operations via `get_area_slices` have trouble when the resulting lon/lat extents match *almost* exactly with the source area definition. This PR should fix a couple important bugs in the array index retrieval methods of the AreaDefinition:

1. Floating point precision issues where a X coordinate that is just outside the area (a float precision different) can still be considered part of the area (not masked).
2. Not including -0.5 to 0.0 pixel indexes as "0" (it is the left most part of the left most pixels.
3. Including an extra 0.5 pixels on the right of the area.

Locally I see one failure where my particular approach has changed the underlying value for elements that are masked and this test specifically checks that that doesn't happen (they stay unchanged).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
