### PR TITLE
Add support for `fill_value` and `set_empty_bucket_to` in BucketResampler `get_sum`

### DIFF
--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -238,7 +238,7 @@ class BucketResampler(object):
         data = data.ravel()
 
         # Remove fill_values values from the data when used as weights
-        invalid_mask = get_invalid_mask(data, fill_value)
+        invalid_mask = _get_invalid_mask(data, fill_value)
         weights = da.where(invalid_mask, 0, data)
 
         # Rechunk indices to match the data chunking
@@ -260,7 +260,7 @@ class BucketResampler(object):
 
     def _mask_bins_with_nan_if_not_skipna(self, skipna, data, out_size, statistic, fill_value):
         if not skipna:
-            missing_val = get_invalid_mask(data, fill_value)
+            missing_val = _get_invalid_mask(data, fill_value)
             missing_val_bins, _ = da.histogram(self.idxs[missing_val], bins=out_size,
                                                range=(0, out_size))
             statistic = da.where(missing_val_bins > 0, fill_value, statistic)
@@ -469,7 +469,7 @@ class BucketResampler(object):
         return results
 
 
-def get_invalid_mask(data, fill_value):
+def _get_invalid_mask(data, fill_value):
     """Get a boolean array where values equal to fill_value in data are True."""
     if np.isnan(fill_value):
         return np.isnan(data)

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -224,7 +224,7 @@ class BucketResampler(object):
             Note that a bucket could become 0 as the result of a sum
             of positive and negative values. If the user needs to identify these zero-buckets reliably,
             `get_count()` can be used for this purpose.
-            Default: np.nan
+            Default: 0
 
         Returns
         -------

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -210,7 +210,7 @@ class BucketResampler(object):
         data : Numpy or Dask array
             Data to be binned and summed.
         fill_value : float
-            Fill value to mark missing/invalid values in the input data.
+            Fill value of the input data marking missing/invalid values.
             Default: np.nan
         skipna : boolean (optional)
             If True, skips missing values (as marked by NaN or `fill_value`) for the sum calculation

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -238,10 +238,8 @@ class BucketResampler(object):
         data = data.ravel()
 
         # Remove fill_values values from the data when used as weights
-        if np.isnan(fill_value):
-            weights = da.where(np.isnan(data), 0, data)
-        else:
-            weights = da.where(data == fill_value, 0, data)
+        invalid_mask = get_invalid_mask(data, fill_value)
+        weights = da.where(invalid_mask, 0, data)
 
         # Rechunk indices to match the data chunking
         if weights.chunks != self.idxs.chunks:
@@ -262,10 +260,7 @@ class BucketResampler(object):
 
     def _mask_bins_with_nan_if_not_skipna(self, skipna, data, out_size, statistic, fill_value):
         if not skipna:
-            if np.isnan(fill_value):
-                missing_val = np.isnan(data)
-            else:
-                missing_val = data == fill_value
+            missing_val = get_invalid_mask(data, fill_value)
             missing_val_bins, _ = da.histogram(self.idxs[missing_val], bins=out_size,
                                                range=(0, out_size))
             statistic = da.where(missing_val_bins > 0, fill_value, statistic)
@@ -472,6 +467,14 @@ class BucketResampler(object):
         LOG.disabled = False
 
         return results
+
+
+def get_invalid_mask(data, fill_value):
+    """Get a boolean array marking values equal to fill_value in data as True."""
+    if np.isnan(fill_value):
+        return np.isnan(data)
+    else:
+        return data == fill_value
 
 
 def round_to_resolution(arr, resolution):

--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -68,7 +68,7 @@ def _expand_bin_statistics(bins, unique_bin, unique_idx, weights_sorted):
     # assign the valid index to array
     weight_idx[unique_bin[~unique_bin.mask].data] = unique_idx[~unique_bin.mask]
 
-    return weights_sorted[weight_idx]  # last value of weigths_sorted always nan
+    return weights_sorted[weight_idx]  # last value of weights_sorted always nan
 
 
 @dask.delayed(pure=True)
@@ -470,7 +470,7 @@ class BucketResampler(object):
 
 
 def get_invalid_mask(data, fill_value):
-    """Get a boolean array marking values equal to fill_value in data as True."""
+    """Get a boolean array where values equal to fill_value in data are True."""
     if np.isnan(fill_value):
         return np.isnan(data)
     else:

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -26,7 +26,7 @@ import pytest
 import xarray as xr
 
 from pyresample import bucket, create_area_def
-from pyresample.bucket import get_invalid_mask
+from pyresample.bucket import _get_invalid_mask
 from pyresample.geometry import AreaDefinition
 from pyresample.test.utils import CustomScheduler
 
@@ -216,8 +216,8 @@ def test_get_sum_skipna_fillvalue_empty_bucket_value(resampler, skipna, fill_val
 
     assert np.count_nonzero(result == 5.) == n_bkt_with_val_5
     assert np.count_nonzero(result == 2.) == n_bkt_with_val_2
-    assert np.count_nonzero(get_invalid_mask(result, fill_value)) == n_bkt_with_val_fill_value
-    assert np.count_nonzero(get_invalid_mask(result, empty_bucket_value)) == n_bkt_with_empty_value
+    assert np.count_nonzero(_get_invalid_mask(result, fill_value)) == n_bkt_with_val_fill_value
+    assert np.count_nonzero(_get_invalid_mask(result, empty_bucket_value)) == n_bkt_with_empty_value
 
 
 def test_get_count(resampler):

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -205,24 +205,24 @@ class Test(unittest.TestCase):
         self.assertEqual(np.count_nonzero(result == 255), 0)
         self.assertEqual(np.nanmin(result), 0)
 
-    def test_nonzero_set_empty_bucket_to_number(self):
-        """Test drop-in-a-bucket sum for non-zero set_empty_bucket_to np.nan."""
+    def test_nonzero_empty_bucket_value_number(self):
+        """Test drop-in-a-bucket sum for non-zero empty_bucket_value set as number."""
         data = da.from_array(np.array([[2., np.nan], [5., np.nan]]),
                              chunks=self.chunks)
 
-        result = self._get_sum_result(data, skipna=True, set_empty_bucket_to=4095)
+        result = self._get_sum_result(data, skipna=True, empty_bucket_value=4095)
         # 5 is untouched in a single bin
         self.assertEqual(np.count_nonzero(result == 5.), 1)
         # all-nan and rest is 4095
         self.assertEqual(np.count_nonzero(result == 4095), 2048 * 2560 - 2)
         self.assertEqual(np.nanmin(result), 2)
 
-    def test_nonzero_set_empty_bucket_to_npnan(self):
-        """Test drop-in-a-bucket sum for non-zero set_empty_bucket_to np.nan."""
+    def test_nonzero_empty_bucket_valueo_npnan(self):
+        """Test drop-in-a-bucket sum for non-zero empty_bucket_value set as np.nan."""
         data = da.from_array(np.array([[2., np.nan], [5., np.nan]]),
                              chunks=self.chunks)
 
-        result = self._get_sum_result(data, skipna=True, set_empty_bucket_to=np.nan)
+        result = self._get_sum_result(data, skipna=True, empty_bucket_value=np.nan)
         # 5 is untouched in a single bin
         self.assertEqual(np.count_nonzero(result == 5.), 1)
         # all-nan and rest is np.nan

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -17,379 +17,398 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Test the bucket resampler."""
 
-import unittest
 from unittest.mock import MagicMock, patch
 
 import dask
 import dask.array as da
 import numpy as np
 import xarray as xr
-
+import pytest
 from pyresample import bucket, create_area_def
 from pyresample.geometry import AreaDefinition
 from pyresample.test.utils import CustomScheduler
 
+CHUNKS = 2
 
-class Test(unittest.TestCase):
-    """Test bucket resampler."""
-
-    adef = AreaDefinition('eurol', 'description', '',
+@pytest.fixture(scope="module")
+def adef():
+    return AreaDefinition('eurol',
+                          'description',
+                          '',
                           {'ellps': 'WGS84',
                            'lat_0': '90.0',
                            'lat_ts': '60.0',
                            'lon_0': '0.0',
-                           'proj': 'stere'}, 2560, 2048,
+                           'proj': 'stere'},
+                          2560,
+                          2048,
                           (-3780000.0, -7644000.0, 3900000.0, -1500000.0))
-    chunks = 2
-    lons = da.from_array(np.array([[25., 25.], [25., 25.]]),
-                         chunks=chunks)
-    lats = da.from_array(np.array([[60., 60.00001], [60.2, 60.3]]),
-                         chunks=chunks)
 
-    def setUp(self):
-        self.resampler = bucket.BucketResampler(self.adef, self.lons, self.lats)
 
-    @patch('pyresample.bucket.Proj')
-    @patch('pyresample.bucket.BucketResampler._get_indices')
-    def test_init(self, get_indices, prj):
-        resampler = bucket.BucketResampler(self.adef, self.lons, self.lats)
-        get_indices.assert_called_once()
-        prj.assert_called_once_with(self.adef.proj_dict)
-        self.assertTrue(hasattr(resampler, 'target_area'))
-        self.assertTrue(hasattr(resampler, 'source_lons'))
-        self.assertTrue(hasattr(resampler, 'source_lats'))
-        self.assertTrue(hasattr(resampler, 'x_idxs'))
-        self.assertTrue(hasattr(resampler, 'y_idxs'))
-        self.assertTrue(hasattr(resampler, 'idxs'))
-        self.assertTrue(hasattr(resampler, 'get_sum'))
-        self.assertTrue(hasattr(resampler, 'get_count'))
-        self.assertTrue(hasattr(resampler, 'get_min'))
-        self.assertTrue(hasattr(resampler, 'get_max'))
-        self.assertTrue(hasattr(resampler, 'get_abs_max'))
-        self.assertTrue(hasattr(resampler, 'get_average'))
-        self.assertTrue(hasattr(resampler, 'get_fractions'))
-        self.assertIsNone(resampler.counts)
+@pytest.fixture(scope="module")
+def lons():
+    return da.from_array(np.array([[25., 25.], [25., 25.]]), chunks=CHUNKS)
 
-    def test_round_to_resolution(self):
-        """Test rounding to given resolution."""
-        # Scalar, integer resolution
-        self.assertEqual(bucket.round_to_resolution(5.5, 2.), 6)
-        # Scalar, non-integer resolution
-        self.assertEqual(bucket.round_to_resolution(5.5, 1.7), 5.1)
-        # List
-        self.assertTrue(np.all(bucket.round_to_resolution([4.2, 5.6], 2) ==
-                               np.array([4., 6.])))
-        # Numpy array
-        self.assertTrue(np.all(bucket.round_to_resolution(np.array([4.2, 5.6]), 2) ==
-                               np.array([4., 6.])))
-        # Dask array
-        self.assertTrue(
-            np.all(bucket.round_to_resolution(da.array([4.2, 5.6]), 2) ==
-                   np.array([4., 6.])))
 
-    def test_get_proj_coordinates(self):
-        """Test calculation of projection coordinates."""
-        prj = MagicMock()
-        prj.return_value = ([3.1, 3.1, 3.1], [4.8, 4.8, 4.8])
-        lons = [1., 1., 1.]
-        lats = [2., 2., 2.]
-        self.resampler.prj = prj
-        result = self.resampler._get_proj_coordinates(lons, lats)
-        prj.assert_called_once_with(lons, lats)
-        self.assertTrue(isinstance(result, np.ndarray))
-        np.testing.assert_equal(result, np.array([[3.1, 3.1, 3.1],
-                                                  [4.8, 4.8, 4.8]]))
+@pytest.fixture(scope="module")
+def lats():
+    return da.from_array(np.array([[60., 60.00001], [60.2, 60.3]]), chunks=CHUNKS)
 
-    def test_get_bucket_indices(self):
-        """Test calculation of array indices."""
-        # Ensure nothing is calculated
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            self.resampler._get_indices()
-        x_idxs, y_idxs = da.compute(self.resampler.x_idxs,
-                                    self.resampler.y_idxs)
-        np.testing.assert_equal(x_idxs, np.array([1710, 1710, 1707, 1705]))
-        np.testing.assert_equal(y_idxs, np.array([465, 465, 459, 455]))
 
-        # Additional small test case
-        adef = create_area_def(
-            area_id='test',
-            projection={'proj': 'latlong'},
-            width=2, height=2,
-            center=(0, 0),
-            resolution=10)
-        lons = da.from_array(
-            np.array([-10.0, -9.9, -0.1, 0, 0.1, 9.9, 10.0, -10.1, 0]),
-            chunks=2)
-        lats = da.from_array(
-            np.array([-10.0, -9.9, -0.1, 0, 0.1, 9.9, 10.0, 0, 10.1]),
-            chunks=2)
-        resampler = bucket.BucketResampler(source_lats=lats,
-                                           source_lons=lons,
-                                           target_area=adef)
+@pytest.fixture(scope="module")
+def resampler(adef, lons, lats):
+    return bucket.BucketResampler(adef, lons, lats)
+
+
+@patch('pyresample.bucket.Proj')
+@patch('pyresample.bucket.BucketResampler._get_indices')
+def test_init(get_indices, prj, adef, lons, lats):
+    """Test the init method of the BucketResampler"""
+    resampler = bucket.BucketResampler(adef, lons, lats)
+
+    get_indices.assert_called_once()
+    prj.assert_called_once_with(adef.proj_dict)
+
+    assert hasattr(resampler, 'target_area')
+    assert hasattr(resampler, 'source_lons')
+    assert hasattr(resampler, 'source_lats')
+    assert hasattr(resampler, 'x_idxs')
+    assert hasattr(resampler, 'y_idxs')
+    assert hasattr(resampler, 'idxs')
+    assert hasattr(resampler, 'get_sum')
+    assert hasattr(resampler, 'get_count')
+    assert hasattr(resampler, 'get_min')
+    assert hasattr(resampler, 'get_max')
+    assert hasattr(resampler, 'get_abs_max')
+    assert hasattr(resampler, 'get_average')
+    assert hasattr(resampler, 'get_fractions')
+    assert resampler.counts is None
+
+
+def test_round_to_resolution():
+    """Test rounding to given resolution."""
+    # Scalar, integer resolution
+    assert bucket.round_to_resolution(5.5, 2.) == 6
+    # Scalar, non-integer resolution
+    assert bucket.round_to_resolution(5.5, 1.7) == 5.1
+    # List
+    assert np.all(bucket.round_to_resolution([4.2, 5.6], 2) == np.array([4., 6.]))
+    # Numpy array
+    assert np.all(bucket.round_to_resolution(np.array([4.2, 5.6]), 2) == np.array([4., 6.]))
+    # Dask array
+    assert np.all(bucket.round_to_resolution(da.array([4.2, 5.6]), 2) == np.array([4., 6.]))
+
+
+def test_get_proj_coordinates(adef, lons, lats):
+    """Test calculation of projection coordinates."""
+    resampler = bucket.BucketResampler(source_lats=lats, source_lons=lons, target_area=adef)
+    prj = MagicMock()
+    prj.return_value = ([3.1, 3.1, 3.1], [4.8, 4.8, 4.8])
+    lons = [1., 1., 1.]
+    lats = [2., 2., 2.]
+    resampler.prj = prj
+
+    result = resampler._get_proj_coordinates(lons, lats)
+
+    prj.assert_called_once_with(lons, lats)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_equal(result, np.array([[3.1, 3.1, 3.1],
+                                              [4.8, 4.8, 4.8]]))
+
+
+def test_get_bucket_indices(resampler):
+    """Test calculation of array indices."""
+    # Ensure nothing is calculated
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
         resampler._get_indices()
-        np.testing.assert_equal(resampler.x_idxs, np.array([-1, 0, 0, 1, 1, 1, -1, -1, -1]))
-        np.testing.assert_equal(resampler.y_idxs, np.array([-1, 1, 1, 1, 0, 0, -1, -1, -1]))
+    x_idxs, y_idxs = da.compute(resampler.x_idxs, resampler.y_idxs)
+    np.testing.assert_equal(x_idxs, np.array([1710, 1710, 1707, 1705]))
+    np.testing.assert_equal(y_idxs, np.array([465, 465, 459, 455]))
 
-    def _get_sum_result(self, data, **kwargs):
-        """Compute the bucket average with kwargs and check that no dask computation is performed."""
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_sum(data, **kwargs)
-        return result.compute()
 
-    def test_get_sum_valid_data(self):
-        """Test drop-in-a-bucket sum for valid data input."""
-        data = da.from_array(np.array([[2., 3.], [7., 16.]]),
-                             chunks=self.chunks)
+def test_get_bucket_indices_on_latlong():
+    """Test calculation of array indices on latlong grid."""
+    adef = create_area_def(
+        area_id='test',
+        projection={'proj': 'latlong'},
+        width=2, height=2,
+        center=(0, 0),
+        resolution=10)
+    lons = da.from_array(np.array([-10.0, -9.9, -0.1, 0, 0.1, 9.9, 10.0, -10.1, 0]), chunks=CHUNKS)
+    lats = da.from_array(np.array([-10.0, -9.9, -0.1, 0, 0.1, 9.9, 10.0, 0, 10.1]), chunks=CHUNKS)
+    resampler = bucket.BucketResampler(source_lats=lats, source_lons=lons, target_area=adef)
+    resampler._get_indices()
 
-        result = self._get_sum_result(data)
+    np.testing.assert_equal(resampler.x_idxs, np.array([-1, 0, 0, 1, 1, 1, -1, -1, -1]))
+    np.testing.assert_equal(resampler.y_idxs, np.array([-1, 1, 1, 1, 0, 0, -1, -1, -1]))
 
-        # first two values are in same bin
-        self.assertEqual(np.count_nonzero(result == 5), 1)
-        # others are in separate bins
-        self.assertEqual(np.count_nonzero(result == 7), 1)
-        self.assertEqual(np.count_nonzero(result == 16), 1)
 
-        self.assertEqual(result.shape, self.adef.shape)
+def _get_sum_result(resampler, data, **kwargs):
+    """Compute the bucket average with kwargs and check that no dask computation is performed."""
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+        result = resampler.get_sum(data, **kwargs)
+    return result.compute()
 
-        # Test that also xarray.DataArrays work (same output)
-        data = xr.DataArray(data)
-        np.testing.assert_array_equal(result, self._get_sum_result(data))
 
-    def test_get_sum_nan_data_skipna_false(self):
-        """Test drop-in-a-bucket sum for data input with nan and skipna False."""
-        data = da.from_array(np.array([[2., np.nan], [5., np.nan]]),
-                             chunks=self.chunks)
+def test_get_sum_valid_data(resampler, adef):
+    """Test drop-in-a-bucket sum for valid data input."""
+    data = da.from_array(np.array([[2., 3.], [7., 16.]]), chunks=CHUNKS)
+    result = _get_sum_result(resampler, data)
 
-        result = self._get_sum_result(data, skipna=False)
-        # 2 + nan is nan, all-nan bin is nan
-        self.assertEqual(np.count_nonzero(np.isnan(result)), 2)
-        # rest is 0
-        self.assertEqual(np.nanmin(result), 0)
+    # first two values are in same bin
+    assert np.count_nonzero(result == 5) == 1
+    # others are in separate bins
+    assert np.count_nonzero(result == 7) == 1
+    assert np.count_nonzero(result == 16) == 1
+    assert result.shape == adef.shape
 
-    def test_get_sum_nan_data_skipna_true(self):
-        """Test drop-in-a-bucket sum for data input with nan and skipna True."""
-        data = da.from_array(np.array([[2., np.nan], [5., np.nan]]),
-                             chunks=self.chunks)
+    # Test that also xarray.DataArrays work (same output)
+    data = xr.DataArray(data)
+    np.testing.assert_array_equal(result, _get_sum_result(resampler, data))
 
-        result = self._get_sum_result(data, skipna=True)
-        # 2 + nan is 2
-        self.assertEqual(np.count_nonzero(result == 2.), 1)
-        # 5 is untouched in a single bin
-        self.assertEqual(np.count_nonzero(result == 5.), 1)
-        # all-nan and rest is 0
-        self.assertEqual(np.count_nonzero(np.isnan(result)), 0)
-        self.assertEqual(np.nanmin(result), 0)
 
-    def test_get_sum_non_default_fill_value_skipna_false(self):
-        """Test drop-in-a-bucket sum for data input with non-default fill_value and skipna=False."""
-        data = da.from_array(np.array([[2., 255], [5., 255]]),
-                             chunks=self.chunks)
+def test_get_sum_nan_data_skipna_false(resampler):
+    """Test drop-in-a-bucket sum for data input with nan and skipna False."""
+    data = da.from_array(np.array([[2., np.nan], [5., np.nan]]), chunks=CHUNKS)
+    result = _get_sum_result(resampler, data, skipna=False)
 
-        result = self._get_sum_result(data, skipna=False, fill_value=255)
-        # 2 + fill_value  is fill_value, all-fill_value is fill_value
-        self.assertEqual(np.count_nonzero(result == 255), 2)
-        # 5 is untouched in a single bin
-        self.assertEqual(np.count_nonzero(result == 5.), 1)
-        # rest is 0
-        self.assertEqual(np.nanmin(result), 0)
+    # 2 + nan is nan, all-nan bin is nan
+    assert np.count_nonzero(np.isnan(result)) == 2
+    # rest is 0
+    assert np.nanmin(result) == 0
 
-    def test_get_sum_non_default_fill_value_skipna_true(self):
-        """Test drop-in-a-bucket sum for data input with non-default fill_value and skipna=True."""
-        data = da.from_array(np.array([[2., 255], [5., 255]]),
-                             chunks=self.chunks)
 
-        result = self._get_sum_result(data, skipna=True, fill_value=255)
-        # 2 + fill_value  is 2
-        self.assertEqual(np.count_nonzero(result == 2.), 1)
-        # all-missing and rest is 0
-        self.assertEqual(np.count_nonzero(result == 255), 0)
-        self.assertEqual(np.nanmin(result), 0)
+def test_get_sum_nan_data_skipna_true(resampler):
+    """Test drop-in-a-bucket sum for data input with nan and skipna True."""
+    data = da.from_array(np.array([[2., np.nan], [5., np.nan]]), chunks=CHUNKS)
+    result = _get_sum_result(resampler, data, skipna=True)
 
-    def test_nonzero_empty_bucket_value_number(self):
-        """Test drop-in-a-bucket sum for non-zero empty_bucket_value set as number."""
-        data = da.from_array(np.array([[2., np.nan], [5., np.nan]]),
-                             chunks=self.chunks)
+    # 2 + nan is 2
+    assert np.count_nonzero(result == 2.) == 1
+    # 5 is untouched in a single bin
+    assert np.count_nonzero(result == 5.) == 1
+    # all-nan and rest is 0
+    assert np.count_nonzero(np.isnan(result)) == 0
+    assert np.nanmin(result) == 0
 
-        result = self._get_sum_result(data, skipna=True, empty_bucket_value=4095)
-        # 5 is untouched in a single bin
-        self.assertEqual(np.count_nonzero(result == 5.), 1)
-        # all-nan and rest is 4095
-        self.assertEqual(np.count_nonzero(result == 4095), 2048 * 2560 - 2)
-        self.assertEqual(np.nanmin(result), 2)
 
-    def test_nonzero_empty_bucket_valueo_npnan(self):
-        """Test drop-in-a-bucket sum for non-zero empty_bucket_value set as np.nan."""
-        data = da.from_array(np.array([[2., np.nan], [5., np.nan]]),
-                             chunks=self.chunks)
+def test_get_sum_non_default_fill_value_skipna_false(resampler):
+    """Test drop-in-a-bucket sum for data input with non-default fill_value and skipna=False."""
+    data = da.from_array(np.array([[2., 255], [5., 255]]), chunks=CHUNKS)
+    result = _get_sum_result(resampler, data, skipna=False, fill_value=255)
 
-        result = self._get_sum_result(data, skipna=True, empty_bucket_value=np.nan)
-        # 5 is untouched in a single bin
-        self.assertEqual(np.count_nonzero(result == 5.), 1)
-        # all-nan and rest is np.nan
-        self.assertEqual(np.count_nonzero(np.isnan(result)), 2048 * 2560 - 2)
-        self.assertEqual(np.nanmin(result), 2)
+    # 2 + fill_value  is fill_value, all-fill_value is fill_value
+    assert np.count_nonzero(result == 255) == 2
+    # 5 is untouched in a single bin
+    assert np.count_nonzero(result == 5.) == 1
+    # rest is 0
+    assert np.nanmin(result) == 0
 
-    def test_get_count(self):
-        """Test drop-in-a-bucket sum."""
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_count()
-        result = result.compute()
-        self.assertTrue(np.max(result) == 2)
-        self.assertEqual(np.sum(result == 1), 2)
-        self.assertEqual(np.sum(result == 2), 1)
-        self.assertTrue(self.resampler.counts is not None)
 
-    def _get_min_result(self, data, **kwargs):
-        """Compute the bucket average with kwargs and check that no dask computation is performed."""
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_min(data, **kwargs)
-        return result.compute()
+def test_get_sum_non_default_fill_value_skipna_true(resampler):
+    """Test drop-in-a-bucket sum for data input with non-default fill_value and skipna=True."""
+    data = da.from_array(np.array([[2., 255], [5., 255]]), chunks=CHUNKS)
+    result = _get_sum_result(resampler, data, skipna=True, fill_value=255)
 
-    def test_get_min(self):
-        """Test min bucket resampling."""
-        data = da.from_array(np.array([[2, 11], [5, np.nan]]),
-                             chunks=self.chunks)
-        result = self._get_min_result(data)
-        # test multiple entries minimum
-        self.assertEqual(np.count_nonzero(result == 2), 1)
-        # test single entry minimum
-        self.assertEqual(np.count_nonzero(result == 5), 1)
-        # test that minimum of bucket with only nan is nan, and empty buckets are nan
-        self.assertEqual(np.count_nonzero(~np.isnan(result)), 2)
+    # 2 + fill_value  is 2
+    assert np.count_nonzero(result == 2.) == 1
+    # all-missing and rest is 0
+    assert np.count_nonzero(result == 255) == 0
+    assert np.nanmin(result) == 0
 
-    def _get_max_result(self, data, **kwargs):
-        """Compute the bucket max with kwargs and check that no dask computation is performed."""
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_max(data, **kwargs)
-        return result.compute()
 
-    def test_get_max(self):
-        """Test max bucket resampling."""
-        data = da.from_array(np.array([[2, 11], [5, np.nan]]),
-                             chunks=self.chunks)
-        result = self._get_max_result(data)
-        # test multiple entries maximum
-        self.assertEqual(np.count_nonzero(result == 11), 1)
-        # test single entry maximum
-        self.assertEqual(np.count_nonzero(result == 5), 1)
-        # test that minimum of bucket with only nan is nan, and empty buckets are nan
-        self.assertEqual(np.count_nonzero(~np.isnan(result)), 2)
+def test_nonzero_empty_bucket_value_number(resampler):
+    """Test drop-in-a-bucket sum for non-zero empty_bucket_value set as number."""
+    data = da.from_array(np.array([[2., np.nan], [5., np.nan]]), chunks=CHUNKS)
+    result = _get_sum_result(resampler, data, skipna=True, empty_bucket_value=4095)
 
-    def test_get_abs_max(self):
-        """Test abs max bucket resampling."""
-        data = da.from_array(np.array([[2, -11], [5, np.nan]]),
-                             chunks=self.chunks)
-        result = self._get_abs_max_result(data)
-        # test multiple entries absolute maximum
-        self.assertEqual(np.count_nonzero(result == -11), 1)
-        # test single entry maximum
-        self.assertEqual(np.count_nonzero(result == 5), 1)
-        # test that minimum of bucket with only nan is nan, and empty buckets are nan
-        self.assertEqual(np.count_nonzero(~np.isnan(result)), 2)
+    # 5 is untouched in a single bin
+    assert np.count_nonzero(result == 5.) == 1
+    # all-nan and rest is 4095
+    assert np.count_nonzero(result == 4095) == 2048 * 2560 - 2
+    assert np.nanmin(result) == 2
 
-    def _get_abs_max_result(self, data, **kwargs):
-        """Compute the bucket abs max with kwargs and check that no dask computation is performed."""
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_abs_max(data, **kwargs)
-        return result.compute()
 
-    def _get_average_result(self, data, **kwargs):
-        """Compute the bucket average with kwargs and check that no dask computation is performed."""
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_average(data, **kwargs)
-        return result.compute()
+def test_nonzero_empty_bucket_value_npnan(resampler):
+    """Test drop-in-a-bucket sum for non-zero empty_bucket_value set as np.nan."""
+    data = da.from_array(np.array([[2., np.nan], [5., np.nan]]), chunks=CHUNKS)
+    result = _get_sum_result(resampler, data, skipna=True, empty_bucket_value=np.nan)
 
-    def test_get_average_basic(self):
-        """Test averaging bucket resampling."""
-        data = da.from_array(np.array([[2, 11], [5, np.nan]]),
-                             chunks=self.chunks)
-        result = self._get_average_result(data)
-        # test multiple entries average
-        self.assertEqual(np.count_nonzero(result == 6.5), 1)
-        # test single entry average
-        self.assertEqual(np.count_nonzero(result == 5), 1)
-        # test that average of bucket with only nan is nan, and empty buckets are nan
-        self.assertEqual(np.count_nonzero(~np.isnan(result)), 2)
+    # 5 is untouched in a single bin
+    assert np.count_nonzero(result == 5.) == 1
+    # all-nan and rest is np.nan
+    assert np.count_nonzero(np.isnan(result)) == 2048 * 2560 - 2
+    assert np.nanmin(result) == 2
 
-    def test_get_average_with_fillvalue_for_output(self):
-        """Test averaging bucket resampling with defined fill_value for output."""
-        data = da.from_array(np.array([[2, 11], [5, np.nan]]),
-                             chunks=self.chunks)
-        # test fill_value other than np.nan
-        result = self._get_average_result(data, fill_value=-1)
-        # check that all empty buckets are fill_value
-        self.assertEqual(np.count_nonzero(result != -1), 2)
 
-    def test_get_average_skipna_true(self):
-        """Test averaging bucket resampling with skipna True."""
-        # test skipna
-        data = da.from_array(np.array([[2, np.nan], [np.nan, np.nan]]),
-                             chunks=self.chunks)
-        result = self._get_average_result(data, skipna=True)
-        # test that average of 2 and np.nan is 2 for skipna=True
-        self.assertEqual(np.count_nonzero(result == 2), 1)
+def test_get_count(resampler):
+    """Test drop-in-a-bucket sum."""
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+        result = resampler.get_count()
+    result = result.compute()
+    assert np.max(result) == 2
+    assert np.sum(result == 1) == 2
+    assert np.sum(result == 2) == 1
+    assert resampler.counts is not None
 
-    def test_get_average_skipna_false(self):
-        """Test averaging bucket resampling with skipna False."""
-        data = da.from_array(np.array([[2, np.nan], [np.nan, np.nan]]),
-                             chunks=self.chunks)
-        result = self._get_average_result(data, skipna=False)
-        # test that average of 2 and np.nan is nan for skipna=False
-        self.assertTrue(np.all(np.isnan(result)))
 
-    def test_get_average_only_nan_input(self):
-        """Test averaging bucket resampling with only NaN as input."""
-        data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]),
-                             chunks=self.chunks)
-        result = self._get_average_result(data, skipna=True)
-        # test that average of np.nan and np.nan is np.nan for both skipna
-        self.assertTrue(np.all(np.isnan(result)))
-        np.testing.assert_array_equal(result, self._get_average_result(data, skipna=False))
+def _get_min_result(resampler, data, **kwargs):
+    """Compute the bucket average with kwargs and check that no dask computation is performed."""
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+        result = resampler.get_min(data, **kwargs)
+    return result.compute()
 
-    def test_get_average_with_fill_value_in_input(self):
-        """Test averaging bucket resampling with fill_value in input and skipna True."""
-        # test that fill_value in input is recognised as missing value
-        data = da.from_array(np.array([[2, -1], [-1, np.nan]]),
-                             chunks=self.chunks)
-        result = self._get_average_result(data, fill_value=-1, skipna=True)
-        # test that average of 2 and -1 (missing value) is 2
-        self.assertEqual(np.count_nonzero(result == 2), 1)
-        # test than all other buckets are -1
-        self.assertEqual(np.count_nonzero(result != -1), 1)
 
-    def test_resample_bucket_fractions(self):
-        """Test fraction calculations for categorical data."""
-        data = da.from_array(np.array([[2, 4], [2, 2]]),
-                             chunks=self.chunks)
-        categories = [1, 2, 3, 4]
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_fractions(data, categories=categories)
-        self.assertEqual(set(categories), set(result.keys()))
-        res = result[1].compute()
-        self.assertTrue(np.nanmax(res) == 0.)
-        res = result[2].compute()
-        self.assertTrue(np.nanmax(res) == 1.)
-        self.assertTrue(np.nanmin(res) == 0.5)
-        res = result[3].compute()
-        self.assertTrue(np.nanmax(res) == 0.)
-        res = result[4].compute()
-        self.assertTrue(np.nanmax(res) == 0.5)
-        self.assertTrue(np.nanmin(res) == 0.)
-        # There should be NaN values
-        self.assertTrue(np.any(np.isnan(res)))
+def test_get_min(resampler):
+    """Test min bucket resampling."""
+    data = da.from_array(np.array([[2, 11], [5, np.nan]]), chunks=CHUNKS)
+    result = _get_min_result(resampler, data)
+    # test multiple entries minimum
+    assert np.count_nonzero(result == 2) == 1
+    # test single entry minimum
+    assert np.count_nonzero(result == 5) == 1
+    # test that minimum of bucket with only nan is nan, and empty buckets are nan
+    assert np.count_nonzero(~np.isnan(result)) == 2
 
-        # Use a fill value
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            result = self.resampler.get_fractions(data, categories=categories,
-                                                  fill_value=-1)
 
-        # There should not be any NaN values
-        for i in categories:
-            res = result[i].compute()
-            self.assertFalse(np.any(np.isnan(res)))
-            self.assertTrue(np.min(res) == -1)
+def _get_max_result(resampler, data, **kwargs):
+    """Compute the bucket max with kwargs and check that no dask computation is performed."""
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+        result = resampler.get_max(data, **kwargs)
+    return result.compute()
 
-        # No categories given, need to compute the data once to get
-        # the categories
-        with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
-            _ = self.resampler.get_fractions(data, categories=None)
+
+def test_get_max(resampler):
+    """Test max bucket resampling."""
+    data = da.from_array(np.array([[2, 11], [5, np.nan]]), chunks=CHUNKS)
+    result = _get_max_result(resampler, data)
+    # test multiple entries maximum
+    assert np.count_nonzero(result == 11) == 1
+    # test single entry maximum
+    assert np.count_nonzero(result == 5) == 1
+    # test that minimum of bucket with only nan is nan, and empty buckets are nan
+    assert np.count_nonzero(~np.isnan(result)) == 2
+
+
+def _get_abs_max_result(resampler, data, **kwargs):
+    """Compute the bucket abs max with kwargs and check that no dask computation is performed."""
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+        result = resampler.get_abs_max(data, **kwargs)
+    return result.compute()
+
+
+def test_get_abs_max(resampler):
+    """Test abs max bucket resampling."""
+    data = da.from_array(np.array([[2, -11], [5, np.nan]]), chunks=CHUNKS)
+    result = _get_abs_max_result(resampler, data)
+    # test multiple entries absolute maximum
+    assert np.count_nonzero(result == -11) == 1
+    # test single entry maximum
+    assert np.count_nonzero(result == 5) == 1
+    # test that minimum of bucket with only nan is nan, and empty buckets are nan
+    assert np.count_nonzero(~np.isnan(result)) == 2
+
+
+def _get_average_result(resampler, data, **kwargs):
+    """Compute the bucket average with kwargs and check that no dask computation is performed."""
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+        result = resampler.get_average(data, **kwargs)
+    return result.compute()
+
+
+def test_get_average_basic(resampler):
+    """Test averaging bucket resampling."""
+    data = da.from_array(np.array([[2, 11], [5, np.nan]]), chunks=CHUNKS)
+    result = _get_average_result(resampler, data)
+    # test multiple entries average
+    assert np.count_nonzero(result == 6.5) == 1
+    # test single entry average
+    assert np.count_nonzero(result == 5) == 1
+    # test that average of bucket with only nan is nan, and empty buckets are nan
+    assert np.count_nonzero(~np.isnan(result)) == 2
+
+
+def test_get_average_with_fillvalue_for_output(resampler):
+    """Test averaging bucket resampling with defined fill_value for output."""
+    data = da.from_array(np.array([[2, 11], [5, np.nan]]), chunks=CHUNKS)
+    # test fill_value other than np.nan
+    result = _get_average_result(resampler, data, fill_value=-1)
+    # check that all empty buckets are fill_value
+    assert np.count_nonzero(result != -1) == 2
+
+
+def test_get_average_skipna_true(resampler):
+    """Test averaging bucket resampling with skipna True."""
+    # test skipna
+    data = da.from_array(np.array([[2, np.nan], [np.nan, np.nan]]), chunks=CHUNKS)
+    result = _get_average_result(resampler, data, skipna=True)
+    # test that average of 2 and np.nan is 2 for skipna=True
+    assert np.count_nonzero(result == 2) == 1
+
+
+def test_get_average_skipna_false(resampler):
+    """Test averaging bucket resampling with skipna False."""
+    data = da.from_array(np.array([[2, np.nan], [np.nan, np.nan]]), chunks=CHUNKS)
+    result = _get_average_result(resampler, data, skipna=False)
+    # test that average of 2 and np.nan is nan for skipna=False
+    assert np.all(np.isnan(result))
+
+
+def test_get_average_only_nan_input(resampler):
+    """Test averaging bucket resampling with only NaN as input."""
+    data = da.from_array(np.array([[np.nan, np.nan], [np.nan, np.nan]]), chunks=CHUNKS)
+    result = _get_average_result(resampler, data, skipna=True)
+    # test that average of np.nan and np.nan is np.nan for both skipna
+    assert np.all(np.isnan(result))
+    np.testing.assert_array_equal(result, _get_average_result(resampler, data, skipna=False))
+
+
+def test_get_average_with_fill_value_in_input(resampler):
+    """Test averaging bucket resampling with fill_value in input and skipna True."""
+    # test that fill_value in input is recognised as missing value
+    data = da.from_array(np.array([[2, -1], [-1, np.nan]]), chunks=CHUNKS)
+    result = _get_average_result(resampler, data, fill_value=-1, skipna=True)
+    # test that average of 2 and -1 (missing value) is 2
+    assert np.count_nonzero(result == 2) == 1
+    # test that all other buckets are -1
+    assert np.count_nonzero(result != -1) == 1
+
+
+def test_resample_bucket_fractions(resampler):
+    """Test fraction calculations for categorical data."""
+    data = da.from_array(np.array([[2, 4], [2, 2]]), chunks=CHUNKS)
+    categories = [1, 2, 3, 4]
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+        result = resampler.get_fractions(data, categories=categories)
+    assert set(categories) == set(result.keys())
+
+    res = result[1].compute()
+    assert np.nanmax(res) == 0.
+
+    res = result[2].compute()
+    assert np.nanmax(res) == 1.
+    assert np.nanmin(res) == 0.5
+
+    res = result[3].compute()
+    assert np.nanmax(res) == 0.
+
+    res = result[4].compute()
+    assert np.nanmax(res) == 0.5
+    assert np.nanmin(res) == 0.
+    # There should be NaN values
+    assert np.any(np.isnan(res))
+
+    # Use a fill value
+    with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+        result = resampler.get_fractions(data, categories=categories, fill_value=-1)
+
+    # There should not be any NaN values
+    for i in categories:
+        res = result[i].compute()
+        assert not np.any(np.isnan(res))
+        assert np.min(res) == -1
+
+    # No categories given, need to compute the data once to get
+    # the categories
+    with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
+        _ = resampler.get_fractions(data, categories=None)

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -214,7 +214,7 @@ class Test(unittest.TestCase):
         # 5 is untouched in a single bin
         self.assertEqual(np.count_nonzero(result == 5.), 1)
         # all-nan and rest is 4095
-        self.assertEqual(np.count_nonzero(result == 4095), 2048*2560-2)
+        self.assertEqual(np.count_nonzero(result == 4095), 2048 * 2560 - 2)
         self.assertEqual(np.nanmin(result), 2)
 
     def test_nonzero_set_empty_bucket_to_npnan(self):
@@ -226,7 +226,7 @@ class Test(unittest.TestCase):
         # 5 is untouched in a single bin
         self.assertEqual(np.count_nonzero(result == 5.), 1)
         # all-nan and rest is np.nan
-        self.assertEqual(np.count_nonzero(np.isnan(result)), 2048*2560-2)
+        self.assertEqual(np.count_nonzero(np.isnan(result)), 2048 * 2560 - 2)
         self.assertEqual(np.nanmin(result), 2)
 
     def test_get_count(self):

--- a/pyresample/test/test_bucket.py
+++ b/pyresample/test/test_bucket.py
@@ -22,8 +22,9 @@ from unittest.mock import MagicMock, patch
 import dask
 import dask.array as da
 import numpy as np
-import xarray as xr
 import pytest
+import xarray as xr
+
 from pyresample import bucket, create_area_def
 from pyresample.bucket import get_invalid_mask
 from pyresample.geometry import AreaDefinition
@@ -36,6 +37,7 @@ HEIGHT = 2048
 
 @pytest.fixture(scope="module")
 def adef():
+    """Get AreaDefinition for tests."""
     return AreaDefinition('eurol',
                           'description',
                           '',
@@ -51,23 +53,26 @@ def adef():
 
 @pytest.fixture(scope="module")
 def lons():
+    """Get longitudes for tests."""
     return da.from_array(np.array([[25., 25.], [25., 25.]]), chunks=CHUNKS)
 
 
 @pytest.fixture(scope="module")
 def lats():
+    """Get latitudes for tests."""
     return da.from_array(np.array([[60., 60.00001], [60.2, 60.3]]), chunks=CHUNKS)
 
 
 @pytest.fixture(scope="module")
 def resampler(adef, lons, lats):
+    """Get initialised resampler for tests."""
     return bucket.BucketResampler(adef, lons, lats)
 
 
 @patch('pyresample.bucket.Proj')
 @patch('pyresample.bucket.BucketResampler._get_indices')
 def test_init(get_indices, prj, adef, lons, lats):
-    """Test the init method of the BucketResampler"""
+    """Test the init method of the BucketResampler."""
     resampler = bucket.BucketResampler(adef, lons, lats)
 
     get_indices.assert_called_once()


### PR DESCRIPTION
This PR adds support for `fill_value` and `set_empty_bucket_to` in BucketResampler `get_sum`. This is a nice feature, but most importantly it fixes the satpy `bucket_sum` interface.

Closes https://github.com/pytroll/satpy/issues/2805, closes https://github.com/pytroll/satpy/issues/1746, closes https://github.com/pytroll/pyresample/issues/354

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
