### PR TITLE
Fix SwathDefinition html representation error when lons/lats 1D

### DIFF
--- a/pyresample/_formatting_html.py
+++ b/pyresample/_formatting_html.py
@@ -246,25 +246,25 @@ def swath_area_attrs_section(area: 'geom.SwathDefinition') -> str: # noqa F821
     """
     if np.ndim(area.lons) == 1:
         area_name = "1D Swath"
-        resolution_str = "{resolution}/{resolution}".format(resolution="Na")
-        height, width = "Na", "Na"
+        resolution_str = "NA/NA"
+        height, width = "NA", "NA"
         area_units = "m"
     else:
-        if isinstance(area.lons, np.ndarray) & isinstance(area.lats, np.ndarray):
+        if isinstance(area.lons, np.ndarray) and isinstance(area.lats, np.ndarray):
             # Calculate and estimated resolution from lats/lons in meter
             area_name = "Arbitrary Swath"
             resolution_y = np.mean(area.lats[0:-1, :] - area.lats[1::, :])
             resolution_x = np.mean(area.lons[:, 1::] - area.lons[:, 0:-1])
             resolution = np.mean(np.array([resolution_x, resolution_y]))
             resolution = np.round(40075000 * resolution / 360, 1)
-            resolution_str = f"{resolution}/{resolution}"
+            resolution_str = f"{resolution}x{resolution}"
         else:
             lon_attrs = area.lons.attrs
             lat_attrs = area.lats.attrs
 
             # use resolution from lat/lons dataarray attributes -> are these always set? -> Maybe try/except?
             area_name = f"{lon_attrs.get('sensor')} Swath"
-            resolution_str = "/".join([str(round(x.get("resolution"), 1)) for x in [lat_attrs, lon_attrs]])
+            resolution_str = "x".join([str(round(x.get("resolution"), 1)) for x in [lat_attrs, lon_attrs]])
 
         area_units = "m"
         height, width = area.lons.shape
@@ -275,7 +275,7 @@ def swath_area_attrs_section(area: 'geom.SwathDefinition') -> str: # noqa F821
                   # f"<dt>Area name</dt><dd>{area_name}</dd>"
                   f"<dt>Description</dt><dd>{area_name}</dd>"
                   f"<dt>Width/Height</dt><dd>{width}/{height} Pixel</dd>"
-                  f"<dt>Resolution x/y (SSP)</dt><dd>{resolution_str} {area_units}</dd>"
+                  f"<dt>Resolution XxY (SSP)</dt><dd>{resolution_str} {area_units}</dd>"
                   "</dl>"
                   )
 

--- a/pyresample/_formatting_html.py
+++ b/pyresample/_formatting_html.py
@@ -244,25 +244,30 @@ def swath_area_attrs_section(area: 'geom.SwathDefinition') -> str: # noqa F821
         - Improve resolution estimation from lat/lon arrays. Maybe use CoordinateDefinition.geocentric_resolution?
 
     """
-    if isinstance(area.lons, np.ndarray) & isinstance(area.lats, np.ndarray):
-        # Calculate and estimated resolution from lats/lons in meter
-        area_name = "Arbitrary Swath"
-        resolution_y = np.mean(area.lats[0:-1, :] - area.lats[1::, :])
-        resolution_x = np.mean(area.lons[:, 1::] - area.lons[:, 0:-1])
-        resolution = np.mean(np.array([resolution_x, resolution_y]))
-        resolution = np.round(40075000 * resolution / 360, 1)
-        resolution_str = f"{resolution}/{resolution}"
-        area_units = "m"
+    if np.ndim(area.lons) == 1:
+        area_name = "1D Swath"
+        resolution_str = "{resolution}/{resolution}".format(resolution="Na")
+        height, width = "Na", "Na"
+        area_units = "Na"
     else:
-        lon_attrs = area.lons.attrs
-        lat_attrs = area.lats.attrs
+        if isinstance(area.lons, np.ndarray) & isinstance(area.lats, np.ndarray):
+            # Calculate and estimated resolution from lats/lons in meter
+            area_name = "Arbitrary Swath"
+            resolution_y = np.mean(area.lats[0:-1, :] - area.lats[1::, :])
+            resolution_x = np.mean(area.lons[:, 1::] - area.lons[:, 0:-1])
+            resolution = np.mean(np.array([resolution_x, resolution_y]))
+            resolution = np.round(40075000 * resolution / 360, 1)
+            resolution_str = f"{resolution}/{resolution}"
+        else:
+            lon_attrs = area.lons.attrs
+            lat_attrs = area.lats.attrs
 
-        # use resolution from lat/lons dataarray attributes -> are these always set? -> Maybe try/except?
-        area_name = f"{lon_attrs.get('sensor')} swath"
-        resolution_str = "/".join([str(round(x.get("resolution"), 1)) for x in [lat_attrs, lon_attrs]])
+            # use resolution from lat/lons dataarray attributes -> are these always set? -> Maybe try/except?
+            area_name = f"{lon_attrs.get('sensor')} Swath"
+            resolution_str = "/".join([str(round(x.get("resolution"), 1)) for x in [lat_attrs, lon_attrs]])
+
         area_units = "m"
-
-    height, width = area.lons.shape
+        height, width = area.lons.shape
 
     attrs_icon = _icon("icon-file-text2")
 

--- a/pyresample/_formatting_html.py
+++ b/pyresample/_formatting_html.py
@@ -246,7 +246,7 @@ def swath_area_attrs_section(area: 'geom.SwathDefinition') -> str: # noqa F821
     """
     if np.ndim(area.lons) == 1:
         area_name = "1D Swath"
-        resolution_str = "NA/NA"
+        resolution_str = "NAxNA"
         height, width = "NA", "NA"
         area_units = "m"
     else:

--- a/pyresample/_formatting_html.py
+++ b/pyresample/_formatting_html.py
@@ -248,7 +248,7 @@ def swath_area_attrs_section(area: 'geom.SwathDefinition') -> str: # noqa F821
         area_name = "1D Swath"
         resolution_str = "{resolution}/{resolution}".format(resolution="Na")
         height, width = "Na", "Na"
-        area_units = "Na"
+        area_units = "m"
     else:
         if isinstance(area.lons, np.ndarray) & isinstance(area.lats, np.ndarray):
             # Calculate and estimated resolution from lats/lons in meter

--- a/pyresample/static/css/style.css
+++ b/pyresample/static/css/style.css
@@ -29,7 +29,7 @@ body.vscode-dark {
 .pyresample-wrap {
   display: block !important;
   min-width: 700px;
-  max-width: 900px;
+  max-width: 1050px;
 }
 
 .pyresample-text-repr-fallback {

--- a/pyresample/static/css/style.css
+++ b/pyresample/static/css/style.css
@@ -90,19 +90,6 @@ body.vscode-dark {
   margin-right: 0.5em;
 }
 
-/* und noch der Doppelpunkt */
-.pyresample-area-section-details dt:after {
-  content: ": ";
-}
-
-/* ein Clearfix für Folge-dd-Elemente */
-.pyresample-area-section-details dd:after {
-  clear: left;
-  content: " ";
-  display: block;
-}
-/* end attribute list formatting */
-
 .pyresample-area-sections {
   display: grid;
   grid-template-columns: auto;


### PR DESCRIPTION
This is a quick fix for #609. It just sets things like resolution and width/height to Na in the case of 1D lat/lon arrays so the html representation does not break.
It also does some quick fixing of formatting issues I noticed.

 - [x] Closes #609 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->

