### PR TITLE
Fix geocentric_resolution compatibility with numpy 2.1.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,4 @@
  - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
  - [ ] Tests added <!-- for all bug fixes or enhancements -->
  - [ ] Tests passed <!-- for all non-documentation changes -->
- - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
  - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2121,8 +2121,8 @@ class AreaDefinition(_ProjectionDefinition):
         if existing_hash is None:
             existing_hash = hashlib.sha1()  # nosec: B324
         existing_hash.update(self.crs_wkt.encode('utf-8'))
-        existing_hash.update(np.array(self.shape))
-        existing_hash.update(np.array(self.area_extent))
+        existing_hash.update(np.array(self.shape))  # type: ignore[arg-type]
+        existing_hash.update(np.array(self.area_extent))  # type: ignore[arg-type]
         return existing_hash
 
     @daskify_2in_2out

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2121,8 +2121,8 @@ class AreaDefinition(_ProjectionDefinition):
         if existing_hash is None:
             existing_hash = hashlib.sha1()  # nosec: B324
         existing_hash.update(self.crs_wkt.encode('utf-8'))
-        existing_hash.update(np.array(self.shape))  # type: ignore[arg-type]
-        existing_hash.update(np.array(self.area_extent))  # type: ignore[arg-type]
+        existing_hash.update(np.array(self.shape))
+        existing_hash.update(np.array(self.area_extent))
         return existing_hash
 
     @daskify_2in_2out
@@ -2696,6 +2696,15 @@ class AreaDefinition(_ProjectionDefinition):
            edge averages.
 
         """
+        def _safe_bin_edges(arr):
+            try:
+                return np.histogram_bin_edges(arr, bins=10)[:2]
+            except ValueError:
+                # numpy 2.1.0+ produces a ValueError if it can't fill
+                # all bins due to a small data range
+                # we just arbitrarily use the first 2 elements as all elements
+                # should be within floating point precision for our use case
+                return arr[:2]
         from pyproj.transformer import Transformer
         rows, cols = self.shape
         mid_row = rows // 2
@@ -2726,9 +2735,9 @@ class AreaDefinition(_ProjectionDefinition):
         # Very useful near edge of disk geostationary areas.
         hor_res = vert_res = 0
         if hor_dist.size:
-            hor_res = np.mean(np.histogram_bin_edges(hor_dist)[:2])
+            hor_res = np.mean(_safe_bin_edges(hor_dist))
         if vert_dist.size:
-            vert_res = np.mean(np.histogram_bin_edges(vert_dist)[:2])
+            vert_res = np.mean(_safe_bin_edges(vert_dist))
         # Use the maximum distance between the two midlines instead of
         # binning both of them together. If we binned them together then
         # we are highly dependent on the shape of the area (more rows in

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1062,6 +1062,21 @@ class TestAreaDefinition:
         geo_res = area_def.geocentric_resolution()
         np.testing.assert_allclose(298.647232, geo_res, atol=1e-1)
 
+    def test_area_def_geocentric_resolution_close_dist(self, create_test_area):
+        """Test geocentric resolution when distance range isn't big enough for histogram bins.
+
+        The method currently uses `np.histogram_bin_edges`. Starting in numpy
+        2.1.0, if the number of bins requested (10 in this default case) can't
+        be created because the range of the data is too small, it will raise an
+        exception. This test makes sure that geocentric_resolution doesn't
+        error out when this case is encountered.
+
+        """
+        # this area is known to produce horizontal distances of ~999.9999989758
+        # and trigger the error in numpy 2.1.0
+        ar = create_test_area(4087, 5, 5, (-2500.0, -2500.0, 2500.0, 2500.0))
+        np.testing.assert_allclose(ar.geocentric_resolution(), 999.999999, atol=1e-2)
+
     def test_area_def_geocentric_resolution_latlong(self, create_test_area):
         """Test the AreaDefinition.geocentric_resolution method on a latlong projection."""
         area_extent = (-110.0, 45.0, -95.0, 55.0)


### PR DESCRIPTION
Satpy unstable environment started failing and regular environments will start failing too when conda-forge has numpy 2.1.0 available.

Starting with numpy 2.1.0 the numpy function `histogram_bin_edges` will raise a `ValueError` if the array you give it can't be split into the number of buckets you request (default 10). This happens when the elements of an array are so close together (near floating point precision) that numpy can't possibly split things into N buckets. There error you get is:

```
E               ValueError: Too many bins for data range. Cannot create 10 finite-sized bins.
```

This PR works around this by adding a try/except to the call and just returning the two elements of the input array. As far as I can tell this is basically equivalent.


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files  -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
