### PR TITLE
Allow overriding area repr map section HTML

### DIFF
--- a/pyresample/_formatting_html.py
+++ b/pyresample/_formatting_html.py
@@ -68,7 +68,7 @@ def _icon(icon_name):
 
 def plot_area_def(area: Union['geom.AreaDefinition', 'geom.SwathDefinition'], # noqa F821
                   fmt: Optional[Literal["svg", "png", None]] = None,
-                  features: Iterable[str] = ("ocean", "land", "coastline", "borders"),
+                  features: Optional[Iterable[str]] = None,
                   ) -> Union[str, None]:
     """Plot area.
 
@@ -80,7 +80,8 @@ def plot_area_def(area: Union['geom.AreaDefinition', 'geom.SwathDefinition'], # 
         features: Series of string names of cartopy features to add to the plot.
             Can be lowercase or uppercase names of the features, for example,
             "land", "coastline", "borders", or any other feature available from
-            ``cartopy.feature``.
+            ``cartopy.feature``. If None (default), then land, coastline, borders,
+            and ocean are used.
 
     Returns:
         svg or png image as string.
@@ -107,6 +108,9 @@ def plot_area_def(area: Union['geom.AreaDefinition', 'geom.SwathDefinition'], # 
         ax.set_extent([bounds[0], bounds[2], bounds[1], bounds[3]], crs=cartopy.crs.CRS(area.crs))
     else:
         raise NotImplementedError("Only AreaDefinition and SwathDefinition objects can be plotted")
+
+    if features is None:
+        features = ("ocean", "land", "coastline", "borders")
 
     for feat_name in features:
         feat_obj = getattr(cartopy.feature, feat_name.upper())

--- a/pyresample/_formatting_html.py
+++ b/pyresample/_formatting_html.py
@@ -161,28 +161,6 @@ def collapsible_section(name: str, inline_details: Optional[str] = "", details: 
             )
 
 
-def map_section(area: Union['geom.AreaDefinition', 'geom.SwathDefinition']) -> str: # noqa F821
-    """Create html for map section.
-
-    Args:
-        area : AreaDefinition or SwathDefinition.
-
-    Returns:
-        Html with collapsible section with a cartopy plot.
-
-    """
-    map_icon = _icon("icon-globe")
-
-    if cartopy:
-        coll = collapsible_section("Map", details=plot_area_def(area, fmt="svg"), collapsed=True, icon=map_icon)
-    else:
-        coll = collapsible_section("Map",
-                                   details="Note: If cartopy is installed a display of the area can be seen here",
-                                   collapsed=True, icon=map_icon)
-
-    return f"{coll}"
-
-
 def proj_area_attrs_section(area: 'geom.AreaDefinition') -> str: # noqa F821
     """Create html for attribute section based on an area Area.
 
@@ -308,7 +286,9 @@ def swath_area_attrs_section(area: 'geom.SwathDefinition') -> str: # noqa F821
 
 def area_repr(area: Union['geom.AreaDefinition', 'geom.SwathDefinition'],
               include_header: bool = True,
-              include_static_files: bool = True):
+              include_static_files: bool = True,
+              map_content: str | None = None,
+              ):
     """Return html repr of an AreaDefinition.
 
     Args:
@@ -318,6 +298,8 @@ def area_repr(area: Union['geom.AreaDefinition', 'geom.SwathDefinition'],
             display in the overview of area definitions for the Satpy documentation this
             should be set to false.
         include_static_files : Load and include css and html needed for representation.
+        map_content : Optionally override the map section contents. Can be any string
+            that is valid HTML between a "<div></div>" tag.
 
     Returns:
         Html.
@@ -347,7 +329,18 @@ def area_repr(area: Union['geom.AreaDefinition', 'geom.SwathDefinition'],
     html += "<div class='pyresample-area-sections'>"
     if isinstance(area, geom.AreaDefinition):
         html += proj_area_attrs_section(area)
-        html += map_section(area)
+        map_icon = _icon("icon-globe")
+        if map_content is None:
+            if cartopy:
+                map_content = plot_area_def(area, fmt="svg")
+            else:
+                map_content = "Note: If cartopy is installed a display of the area can be seen here"
+        coll = collapsible_section("Map",
+                                   details=map_content,
+                                   collapsed=True,
+                                   icon=map_icon)
+
+        html += str(coll)
     elif isinstance(area, geom.SwathDefinition):
         html += swath_area_attrs_section(area)
 

--- a/pyresample/_formatting_html.py
+++ b/pyresample/_formatting_html.py
@@ -79,12 +79,14 @@ def plot_area_def(area: Union['geom.AreaDefinition', 'geom.SwathDefinition'], # 
             If None (default) plot is just shown.
         features: Series of string names of cartopy features to add to the plot.
             Can be lowercase or uppercase names of the features, for example,
-            "land", "coastline", "borders", or any other feature available from
-            ``cartopy.feature``. If None (default), then land, coastline, borders,
-            and ocean are used.
+            "land", "coastline", "borders", "ocean", or any other feature
+            available from ``cartopy.feature``. If None (default), then land,
+            coastline, and borders are used.
 
     Returns:
-        svg or png image as string.
+        svg or png image as string or ``None`` when no format is provided
+        in which case the plot is shown interactively.
+
     """
     import base64
     from io import BytesIO, StringIO
@@ -110,7 +112,7 @@ def plot_area_def(area: Union['geom.AreaDefinition', 'geom.SwathDefinition'], # 
         raise NotImplementedError("Only AreaDefinition and SwathDefinition objects can be plotted")
 
     if features is None:
-        features = ("ocean", "land", "coastline", "borders")
+        features = ("land", "coastline", "borders")
 
     for feat_name in features:
         feat_obj = getattr(cartopy.feature, feat_name.upper())

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2121,8 +2121,8 @@ class AreaDefinition(_ProjectionDefinition):
         if existing_hash is None:
             existing_hash = hashlib.sha1()  # nosec: B324
         existing_hash.update(self.crs_wkt.encode('utf-8'))
-        existing_hash.update(np.array(self.shape))  # type: ignore[arg-type]
-        existing_hash.update(np.array(self.area_extent))  # type: ignore[arg-type]
+        existing_hash.update(np.array(self.shape))
+        existing_hash.update(np.array(self.area_extent))
         return existing_hash
 
     @daskify_2in_2out


### PR DESCRIPTION
These changes help control how AreaDefinitions and others are represented when plotted for sphinx documentation (specifically Satpy). See https://github.com/pytroll/satpy/issues/2864 for more information. No TDD on this one.

CC @BENR0 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
