### PR TITLE
Pin setuptools to avoid compilation problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools!=74.0.0", "wheel", "numpy>=2.0.0rc1,<2.3", "Cython>=3", "versioneer"]
+requires = ["setuptools!=74.0.0", "wheel", "numpy>=2.0.0rc1,<2.3", "Cython>=3", "versioneer[toml]"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
@@ -36,3 +36,10 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true
 warn_unused_configs = true
+
+[tool.versioneer]
+VCS = "git"
+style = "pep440"
+versionfile_source = "pyresample/version.py"
+versionfile_build = "pyresample/version.py"
+tag_prefix = "v"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=2.0.0rc1,<2.3", "Cython>=3", "versioneer"]
+requires = ["setuptools!=74.0.0", "wheel", "numpy>=2.0.0rc1,<2.3", "Cython>=3", "versioneer"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,6 @@ ignore = D107,W504
 per-file-ignores =
     pyresample/test/*.py:D102
 
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = pyresample/version.py
-versionfile_build = pyresample/version.py
-tag_prefix = v
-
 [coverage:run]
 relative_files = True
 omit =


### PR DESCRIPTION
This is to solve compilation problems on windows arm64.

Also attempts to port setup.cfg to pyproject.toml

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
