### PR TITLE
Fix dtype for swath -> area resampling with gradient search

### DIFF
--- a/pyresample/gradient/__init__.py
+++ b/pyresample/gradient/__init__.py
@@ -421,6 +421,7 @@ def parallel_gradient_search(data, src_x, src_y, dst_x, dst_y,
                 dst_x[i], dst_y[i],
                 method=method)
             res = da.from_delayed(res, (num_bands, ) + dst_x[i].shape,
+                                  meta=np.array((), dtype=dtype),
                                   dtype=arr.dtype)
         if dst_mosaic_locations[i] in chunks:
             if not is_pad:

--- a/pyresample/gradient/__init__.py
+++ b/pyresample/gradient/__init__.py
@@ -421,7 +421,7 @@ def parallel_gradient_search(data, src_x, src_y, dst_x, dst_y,
                 dst_x[i], dst_y[i],
                 method=method)
             res = da.from_delayed(res, (num_bands, ) + dst_x[i].shape,
-                                  meta=np.array((), dtype=dtype),
+                                  meta=np.array((), dtype=arr.dtype),
                                   dtype=arr.dtype)
         if dst_mosaic_locations[i] in chunks:
             if not is_pad:

--- a/pyresample/gradient/__init__.py
+++ b/pyresample/gradient/__init__.py
@@ -414,14 +414,14 @@ def parallel_gradient_search(data, src_x, src_y, dst_x, dst_y,
         else:
             is_pad = False
             res = dask.delayed(_gradient_resample_data)(
-                arr.astype(np.float64),
+                arr,
                 src_x[i], src_y[i],
                 src_gradient_xl[i], src_gradient_xp[i],
                 src_gradient_yl[i], src_gradient_yp[i],
                 dst_x[i], dst_y[i],
                 method=method)
             res = da.from_delayed(res, (num_bands, ) + dst_x[i].shape,
-                                  dtype=np.float64).astype(arr.dtype)
+                                  dtype=arr.dtype)
         if dst_mosaic_locations[i] in chunks:
             if not is_pad:
                 chunks[dst_mosaic_locations[i]].append(res)

--- a/pyresample/gradient/__init__.py
+++ b/pyresample/gradient/__init__.py
@@ -421,7 +421,7 @@ def parallel_gradient_search(data, src_x, src_y, dst_x, dst_y,
                 dst_x[i], dst_y[i],
                 method=method)
             res = da.from_delayed(res, (num_bands, ) + dst_x[i].shape,
-                                  dtype=np.float64)
+                                  dtype=np.float64).astype(arr.dtype)
         if dst_mosaic_locations[i] in chunks:
             if not is_pad:
                 chunks[dst_mosaic_locations[i]].append(res)

--- a/pyresample/gradient/_gradient_search.pyx
+++ b/pyresample/gradient/_gradient_search.pyx
@@ -28,8 +28,8 @@ cimport numpy as np
 from libc.math cimport fabs, isinf
 
 ctypedef fused data_type:
-    double
-    float
+    np.float64_t
+    np.float32_t
 
 ctypedef np.float64_t float_index
 float_index_dtype = np.float64

--- a/pyresample/gradient/_gradient_search.pyx
+++ b/pyresample/gradient/_gradient_search.pyx
@@ -31,7 +31,7 @@ ctypedef fused data_type:
     double
     float
 
-ctypedef double float_index
+ctypedef np.float64_t float_index
 float_index_dtype = np.float64
 
 np.import_array()

--- a/pyresample/gradient/_gradient_search.pyx
+++ b/pyresample/gradient/_gradient_search.pyx
@@ -31,9 +31,8 @@ ctypedef fused data_type:
     double
     float
 
-ctypedef fused float_index:
-    double
-    float
+ctypedef double float_index
+float_index_dtype = np.float64
 
 np.import_array()
 
@@ -252,23 +251,18 @@ cpdef one_step_gradient_indices(float_index [:, :] src_x,
     cdef size_t x_size = dst_x.shape[1]
 
 
-    if float_index is double:
-        dtype = np.float64
-    else:
-        dtype = np.float32
-
     # output indices arrays --> needs to be (lines, pixels) --> y,x
-    indices = np.full([2, y_size, x_size], np.nan, dtype=dtype)
+    indices = np.full([2, y_size, x_size], np.nan, dtype=float_index_dtype)
     cdef float_index [:, :, :] indices_view_result = indices
 
     # fake_data is not going to be used anyway as we just fill in the indices
-    cdef float_index [:, :, :] fake_data = np.full([1, 1, 1], np.nan, dtype=dtype)
+    cdef float_index [:, :, :] fake_data = np.full([1, 1, 1], np.nan, dtype=float_index_dtype)
 
     with nogil:
-        one_step_gradient_search_no_gil[float_index, float_index](fake_data,
-                                                                  src_x, src_y,
-                                                                  xl, xp, yl, yp,
-                                                                  dst_x, dst_y,
-                                                                  x_size, y_size,
-                                                                  indices_xy, indices_view_result)
+        one_step_gradient_search_no_gil[float_index](fake_data,
+                                                     src_x, src_y,
+                                                     xl, xp, yl, yp,
+                                                     dst_x, dst_y,
+                                                     x_size, y_size,
+                                                     indices_xy, indices_view_result)
     return indices

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -273,7 +273,7 @@ class TestOGradientResampler:
             res = self.swath_resampler.compute(
                 data, method='bil').compute(scheduler='single-threaded')
         assert res.dtype == data.dtype
-        assert res.values.dytpe == data.dtype
+        assert res.values.dtype == data.dtype
         assert res.shape == (3, ) + self.dst_area.shape
         for i in range(res.shape[0]):
             arr = np.ravel(res[i, :, :])

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -255,13 +255,15 @@ class TestOGradientResampler:
         data = xr.DataArray(da.ones(self.src_swath.shape, dtype=input_dtype),
                             dims=['y', 'x'])
         with np.errstate(invalid="ignore"):  # 'inf' space pixels cause runtime warnings
-            res_dask = self.swath_resampler.compute(data, method='bil')
-            res_np = res_dask.compute(scheduler='single-threaded')
+            res_xr = self.swath_resampler.compute(data, method='bil')
+            res_np = res_xr.compute(scheduler='single-threaded')
 
-        assert res_dask.dtype == data.dtype
+        assert res_xr.dtype == data.dtype
         assert res_np.dtype == data.dtype
-        assert res_dask.shape == self.dst_area.shape
+        assert res_xr.shape == self.dst_area.shape
         assert res_np.shape == self.dst_area.shape
+        assert type(res_xr) is type(data)
+        assert type(res_xr.data) is type(data.data)
         assert not np.all(np.isnan(res_np))
 
     @pytest.mark.parametrize("input_dtype", (np.float32, np.float64))
@@ -272,13 +274,15 @@ class TestOGradientResampler:
                             np.array([1, 2, 3])[:, np.newaxis, np.newaxis],
                             dims=['bands', 'y', 'x'])
         with np.errstate(invalid="ignore"):  # 'inf' space pixels cause runtime warnings
-            res_dask = self.swath_resampler.compute(data, method='bil')
-            res_np = res_dask.compute(scheduler='single-threaded')
+            res_xr = self.swath_resampler.compute(data, method='bil')
+            res_np = res_xr.compute(scheduler='single-threaded')
 
-        assert res_dask.dtype == data.dtype
+        assert res_xr.dtype == data.dtype
         assert res_np.dtype == data.dtype
-        assert res_dask.shape == (3, ) + self.dst_area.shape
+        assert res_xr.shape == (3, ) + self.dst_area.shape
         assert res_np.shape == (3, ) + self.dst_area.shape
+        assert type(res_xr) is type(data)
+        assert type(res_xr.data) is type(data.data)
         for i in range(res_np.shape[0]):
             arr = np.ravel(res_np[i, :, :])
             assert np.allclose(arr[np.isfinite(arr)], float(i + 1))

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -255,12 +255,14 @@ class TestOGradientResampler:
         data = xr.DataArray(da.ones(self.src_swath.shape, dtype=input_dtype),
                             dims=['y', 'x'])
         with np.errstate(invalid="ignore"):  # 'inf' space pixels cause runtime warnings
-            res = self.swath_resampler.compute(
-                data, method='bil').compute(scheduler='single-threaded')
-        assert res.dtype == data.dtype
-        assert res.values.dtype == data.dtype
-        assert res.shape == self.dst_area.shape
-        assert not np.all(np.isnan(res))
+            res_dask = self.swath_resampler.compute(data, method='bil')
+            res_np = res_dask.compute(scheduler='single-threaded')
+
+        assert res_dask.dtype == data.dtype
+        assert res_np.dtype == data.dtype
+        assert res_dask.shape == self.dst_area.shape
+        assert res_np.shape == self.dst_area.shape
+        assert not np.all(np.isnan(res_np))
 
     @pytest.mark.parametrize("input_dtype", (np.float32, np.float64))
     def test_resample_swath_to_area_3d(self, input_dtype):
@@ -270,13 +272,15 @@ class TestOGradientResampler:
                             np.array([1, 2, 3])[:, np.newaxis, np.newaxis],
                             dims=['bands', 'y', 'x'])
         with np.errstate(invalid="ignore"):  # 'inf' space pixels cause runtime warnings
-            res = self.swath_resampler.compute(
-                data, method='bil').compute(scheduler='single-threaded')
-        assert res.dtype == data.dtype
-        assert res.values.dtype == data.dtype
-        assert res.shape == (3, ) + self.dst_area.shape
-        for i in range(res.shape[0]):
-            arr = np.ravel(res[i, :, :])
+            res_dask = self.swath_resampler.compute(data, method='bil')
+            res_np = res_dask.compute(scheduler='single-threaded')
+
+        assert res_dask.dtype == data.dtype
+        assert res_np.dtype == data.dtype
+        assert res_dask.shape == (3, ) + self.dst_area.shape
+        assert res_np.shape == (3, ) + self.dst_area.shape
+        for i in range(res_np.shape[0]):
+            arr = np.ravel(res_np[i, :, :])
             assert np.allclose(arr[np.isfinite(arr)], float(i + 1))
 
 

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -496,7 +496,7 @@ class TestRBGradientSearchResamplerArea2Area:
 
 
 class TestRBGradientSearchResamplerArea2Swath:
-    """Test RBGradientSearchResampler for the Swath to Area case."""
+    """Test RBGradientSearchResampler for the Area to Swath case."""
 
     def setup_method(self):
         """Set up the test case."""

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -258,6 +258,7 @@ class TestOGradientResampler:
             res = self.swath_resampler.compute(
                 data, method='bil').compute(scheduler='single-threaded')
         assert res.dtype == data.dtype
+        assert res.values.dtype == data.dtype
         assert res.shape == self.dst_area.shape
         assert not np.all(np.isnan(res))
 
@@ -272,6 +273,7 @@ class TestOGradientResampler:
             res = self.swath_resampler.compute(
                 data, method='bil').compute(scheduler='single-threaded')
         assert res.dtype == data.dtype
+        assert res.values.dytpe == data.dtype
         assert res.shape == (3, ) + self.dst_area.shape
         for i in range(res.shape[0]):
             arr = np.ravel(res[i, :, :])

--- a/pyresample/test/test_gradient.py
+++ b/pyresample/test/test_gradient.py
@@ -249,25 +249,29 @@ class TestOGradientResampler:
         assert res.shape == (1, ) + self.dst_area.shape
         assert np.allclose(res[0, :, :], 1.0)
 
-    def test_resample_swath_to_area_2d(self):
+    @pytest.mark.parametrize("input_dtype", (np.float32, np.float64))
+    def test_resample_swath_to_area_2d(self, input_dtype):
         """Resample swath to area, 2d."""
-        data = xr.DataArray(da.ones(self.src_swath.shape, dtype=np.float64),
+        data = xr.DataArray(da.ones(self.src_swath.shape, dtype=input_dtype),
                             dims=['y', 'x'])
         with np.errstate(invalid="ignore"):  # 'inf' space pixels cause runtime warnings
             res = self.swath_resampler.compute(
                 data, method='bil').compute(scheduler='single-threaded')
+        assert res.dtype == data.dtype
         assert res.shape == self.dst_area.shape
         assert not np.all(np.isnan(res))
 
-    def test_resample_swath_to_area_3d(self):
+    @pytest.mark.parametrize("input_dtype", (np.float32, np.float64))
+    def test_resample_swath_to_area_3d(self, input_dtype):
         """Resample area to area, 3d."""
         data = xr.DataArray(da.ones((3, ) + self.src_swath.shape,
-                                    dtype=np.float64) *
+                                    dtype=input_dtype) *
                             np.array([1, 2, 3])[:, np.newaxis, np.newaxis],
                             dims=['bands', 'y', 'x'])
         with np.errstate(invalid="ignore"):  # 'inf' space pixels cause runtime warnings
             res = self.swath_resampler.compute(
                 data, method='bil').compute(scheduler='single-threaded')
+        assert res.dtype == data.dtype
         assert res.shape == (3, ) + self.dst_area.shape
         for i in range(res.shape[0]):
             arr = np.ravel(res[i, :, :])


### PR DESCRIPTION
Resampling `float32` swath data resulted in `float64` output. This is a simple fix for this data type promotion.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
