### PR TITLE
Make use of bounding_box for area freezing when available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,13 +35,12 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           mamba-version: "1.5.10"
           python-version: ${{ matrix.python-version }}
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
+          channels: conda-forge
 
       - name: Install unstable dependencies
         if: matrix.experimental == true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
+          mamba-version: "1.5.10"
           python-version: ${{ matrix.python-version }}
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ nosetests.xml
 pyresample/ewa/_fornav.cpp
 pyresample/ewa/_ll2cr.c
 pyresample/gradient/_gradient_search.c
+
+# don't include doctest files
+docs/doctest/.doctrees/*

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1317,7 +1317,10 @@ class DynamicAreaDefinition(object):
         try:
             lons, lats = lonslats
         except (TypeError, ValueError):
-            lons, lats = lonslats.get_lonlats()
+            try:
+                lons, lats = lonslats.attrs["bounding_box"]
+            except (AttributeError, KeyError):
+                lons, lats = lonslats.get_lonlats()
         return lons, lats
 
     def _compute_new_x_corners_for_antimeridian(self, xarr, antimeridian_mode):

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -1228,6 +1228,8 @@ class DynamicAreaDefinition(object):
         lonlats : SwathDefinition or tuple
           The geographical coordinates to contain in the resulting area.
           A tuple should be ``(lons, lats)``.
+          If a SwathDefinition is provided, and it has a "bounding_box" attribute, it will be used instead of the full
+          longitude and latitude to avoid potentially slow computations.
         resolution:
           the resolution of the resulting area.
         shape:

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -30,6 +30,7 @@ from pyresample.future.geometry import AreaDefinition, SwathDefinition
 from pyresample.future.geometry.area import ignore_pyproj_proj_warnings
 from pyresample.future.geometry.base import get_array_hashable
 from pyresample.geometry import AreaDefinition as LegacyAreaDefinition
+from pyresample.geometry import DynamicAreaDefinition
 from pyresample.test.utils import assert_future_geometry
 
 
@@ -1754,3 +1755,11 @@ def test_non2d_shape_error(shape):
     """Test that non-2D shapes fail."""
     with pytest.raises(NotImplementedError):
         AreaDefinition("EPSG:4326", shape, (-1000.0, -1000.0, 1000.0, 1000.0))
+
+
+def test_dynamic_area_can_use_bounding_box_attribute():
+    """Test that area freezing can use bounding box info."""
+    area_def = DynamicAreaDefinition("test_area", "", "epsg:3035", resolution=500)
+    swath_def_to_freeze_on = SwathDefinition(None, None, attrs=dict(bounding_box=[[0, 20, 20, 0], [55, 55, 45, 45]]))
+    res_area = area_def.freeze(swath_def_to_freeze_on)
+    assert res_area.area_extent == (3533500, 2484500, 5108500, 3588500)


### PR DESCRIPTION
This PR adds the possibility to use the bounding box attribute of the swathdefinition to freeze a dynamic area definition.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
