### PR TITLE
Move setuptools to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import find_packages, setup
 
 import versioneer
 
-requirements = ['setuptools>=3.2', 'pyproj>=3.0', 'configobj',
+requirements = ['pyproj>=3.0', 'configobj',
                 'pykdtree>=1.3.1', 'pyyaml', 'numpy>=1.21.0',
                 "shapely", "donfig", "platformdirs",
                 ]
@@ -103,6 +103,7 @@ if __name__ == "__main__":
           package_data={'pyresample.test': ['test_files/*']},
           include_package_data=True,
           python_requires='>=3.9',
+          setup_requires=['setuptools>=3.2'],
           install_requires=requirements,
           extras_require=extras_require,
           ext_modules=extensions,


### PR DESCRIPTION
Apparently `setuptools` is not required at runtime

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
