### PR TITLE
Drop support for Python <3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         experimental: [false]
         include:
-          - python-version: "3.12"
+          - python-version: "3.13"
             os: "ubuntu-latest"
             experimental: true
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Download wheels artifact
         uses: actions/download-artifact@v4
         with:
-          name: wheels-*
+          pattern: wheels-*
           merge-multiple: true
           path: dist
       - name: Publish package to PyPI
@@ -111,7 +111,7 @@ jobs:
       - name: Download wheels artifact
         uses: actions/download-artifact@v4
         with:
-          name: wheels-*
+          pattern: wheels-*
           merge-multiple: true
           path: dist
       - name: Publish package to PyPI

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,7 +65,7 @@ jobs:
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* pp* *i686 *-musllinux*"
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           CIBW_TEST_COMMAND: "python -c \"import pyresample; assert 'unknown' not in pyresample.__version__, 'incorrect version found'\""
-          CIBW_TEST_SKIP: "*-win_arm64 *-macosx_arm64"
+          CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Upload wheel(s) as build artifacts

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,41 +42,36 @@ jobs:
       matrix:
         include:
           - os: windows-2019
-            cibw_archs: "AMD64 ARM64"
-            artifact_name: "win"
-          - os: macos-12
-            cibw_archs: "x86_64 arm64"
-            artifact_name: "mac"
-          - os: "ubuntu-20.04"
-            cibw_archs: "aarch64"
-            artifact_name: "ubuntu-aarch"
-          - os: "ubuntu-20.04"
+            cibw_archs: "AMD64"
+          - os: windows-2019
+            cibw_archs: "ARM64"
+          - os: macos-13
             cibw_archs: "x86_64"
-            artifact_name: "ubuntu-x86_64"
+          - os: macos-14
+            cibw_archs: "arm64"
+          - os: "ubuntu-24.04-arm"
+            cibw_archs: "aarch64"
+          - os: "ubuntu-22.04"
+            cibw_archs: "x86_64"
 
     steps:
       - uses: actions/checkout@v4
       - run: |
           git fetch --prune --unshallow
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:
-          CIBW_SKIP: "cp36-* cp37-* cp38-* cp313-* pp* *i686 *-musllinux*"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* pp* *i686 *-musllinux*"
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           CIBW_TEST_COMMAND: "python -c \"import pyresample; assert 'unknown' not in pyresample.__version__, 'incorrect version found'\""
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
+          CIBW_TEST_SKIP: "*-win_arm64"
+          CIBW_BUILD_VERBOSITY: 1
 
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.artifact_name }}
+          name: "wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}"
           path: ./wheelhouse/*.whl
 
   upload_test_pypi:
@@ -90,25 +85,11 @@ jobs:
         with:
           name: sdist
           path: dist
-      - name: Download wheels artifact - win
+      - name: Download wheels artifact
         uses: actions/download-artifact@v4
         with:
-          name: wheels-win
-          path: dist
-      - name: Download wheels artifact - mac
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-mac
-          path: dist
-      - name: Download wheels artifact - ubuntu aarch
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-ubuntu-aarch
-          path: dist
-      - name: Download wheels artifact - ubuntu x86_64
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-ubuntu-x86_64
+          name: wheels-*
+          merge-multiple: true
           path: dist
       - name: Publish package to PyPI
         if: github.event.action != 'published'
@@ -127,25 +108,11 @@ jobs:
         with:
           name: sdist
           path: dist
-      - name: Download wheels artifact - win
+      - name: Download wheels artifact
         uses: actions/download-artifact@v4
         with:
-          name: wheels-win
-          path: dist
-      - name: Download wheels artifact - mac
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-mac
-          path: dist
-      - name: Download wheels artifact - ubuntu aarch
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-ubuntu-aarch
-          path: dist
-      - name: Download wheels artifact - ubuntu x86_64
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-ubuntu-x86_64
+          name: wheels-*
+          merge-multiple: true
           path: dist
       - name: Publish package to PyPI
         if: github.event.action == 'published'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,7 +65,7 @@ jobs:
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* pp* *i686 *-musllinux*"
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           CIBW_TEST_COMMAND: "python -c \"import pyresample; assert 'unknown' not in pyresample.__version__, 'incorrect version found'\""
-          CIBW_TEST_SKIP: "*-win_arm64"
+          CIBW_TEST_SKIP: "*-win_arm64 *-macosx_arm64"
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Upload wheel(s) as build artifacts

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-latest"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -25,6 +25,5 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-lazy-fixtures
-  - importlib-metadata
   - sphinx-reredirects
   - odc-geo

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: readthedocs
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.12
   - pip
   - xarray
   - zarr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ convention = "google"
 max-complexity = 10
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.12"
 # See https://github.com/python/mypy/issues/12286 for automatic multi-platform support
 platform = "linux"
 # platform = win32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ convention = "google"
 max-complexity = 10
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.11"
 # See https://github.com/python/mypy/issues/12286 for automatic multi-platform support
 platform = "linux"
 # platform = win32

--- a/pyresample/_compat.py
+++ b/pyresample/_compat.py
@@ -17,15 +17,4 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Backports and compatibility fixes for pyresample."""
 
-import sys
-
-if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points  # noqa
-else:
-    from importlib.metadata import entry_points  # noqa
-
-try:
-    from numpy.typing import ArrayLike  # noqa
-except ImportError:
-    # numpy <1.20
-    from numpy import ndarray as ArrayLike  # noqa
+from importlib.metadata import entry_points  # noqa

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2126,8 +2126,8 @@ class AreaDefinition(_ProjectionDefinition):
         if existing_hash is None:
             existing_hash = hashlib.sha1()  # nosec: B324
         existing_hash.update(self.crs_wkt.encode('utf-8'))
-        existing_hash.update(np.array(self.shape))
-        existing_hash.update(np.array(self.area_extent))
+        existing_hash.update(np.array(self.shape))  # type: ignore[arg-type]
+        existing_hash.update(np.array(self.area_extent))  # type: ignore[arg-type]
         return existing_hash
 
     @daskify_2in_2out

--- a/pyresample/utils/__init__.py
+++ b/pyresample/utils/__init__.py
@@ -16,12 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Miscellaneous utility functions for pyresample."""
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
-
 import warnings
+from collections.abc import Mapping
 
 import numpy as np
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
           packages=find_packages(),
           package_data={'pyresample.test': ['test_files/*']},
           include_package_data=True,
-          python_requires='>=3.10',
+          python_requires='>=3.11',
           setup_requires=['setuptools>=3.2'],
           install_requires=requirements,
           extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
           packages=find_packages(),
           package_data={'pyresample.test': ['test_files/*']},
           include_package_data=True,
-          python_requires='>=3.9',
+          python_requires='>=3.10',
           setup_requires=['setuptools>=3.2'],
           install_requires=requirements,
           extras_require=extras_require,


### PR DESCRIPTION
This PR adds support for python 3.13. This was triggered by the rebuild of pyresample for 3.13 in conda forge.