### PR TITLE
Fix bug that would add spurious nan lines in gradient search

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,12 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          mamba-version: "1.5.10"
           python-version: ${{ matrix.python-version }}
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
           channels: conda-forge
+          conda-remove-defaults: true
+          channel-priority: strict
 
       - name: Install unstable dependencies
         if: matrix.experimental == true

--- a/pyresample/gradient/__init__.py
+++ b/pyresample/gradient/__init__.py
@@ -309,7 +309,7 @@ def gradient_resampler(data, source_area, target_area, method='bilinear'):
                                    method=method)
 
 
-def gradient_resampler_indices_block(block_info=None, **kwargs):
+def gradient_resampler_indices_block(block_info, **kwargs):
     """Do the gradient search resampling using block_info for areas, returning the resulting indices."""
     source_area = block_info[0]["area"]
     target_area = block_info[None]["area"]

--- a/pyresample/gradient/_gradient_search.pyx
+++ b/pyresample/gradient/_gradient_search.pyx
@@ -187,6 +187,7 @@ cdef void one_step_gradient_search_no_gil(const data_type[:, :, :] data,
 
         for _ in range(x_size):
             if isinf(dst_x[i, j]):
+                j += col_step
                 continue
             cnt = 0
             while True:


### PR DESCRIPTION
This PR fixes #642.

The symptom was that every other line, or all lines, of chunks that were on the edges of a geos disc would be nans. That was because the cursor in the gradient search algorithm was not moved along x when a pixel was skipped because of invalid target coordinates.

 - [x] Closes #642  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
