### PR TITLE
Update EWA pyproj Proj usage to Transformer

### DIFF
--- a/pyresample/ewa/ewa.py
+++ b/pyresample/ewa/ewa.py
@@ -76,7 +76,7 @@ def ll2cr(swath_def, area_def, fill=np.nan, copy=True):
     ox = area_def.area_extent[0] + cw / 2.
     oy = area_def.area_extent[3] + ch / 2.
     swath_points_in_grid = _ll2cr.ll2cr_static(lons, lats, fill,
-                                               p, cw, ch, w, h, ox, oy)
+                                               swath_def.crs, area_def.crs, cw, ch, w, h, ox, oy)
     return swath_points_in_grid, lons, lats
 
 

--- a/pyresample/test/test_ewa_ll2cr.py
+++ b/pyresample/test/test_ewa_ll2cr.py
@@ -21,6 +21,7 @@ import logging
 import unittest
 
 import numpy as np
+from pyproj import CRS
 
 from pyresample.test.utils import create_test_latitude, create_test_longitude
 
@@ -70,14 +71,15 @@ class TestLL2CRStatic(unittest.TestCase):
         lat_arr = create_test_latitude(18.0, 40.0, (50, 100), dtype=np.float64)
         grid_info = static_lcc.copy()
         fill_in = np.nan
-        proj_str = grid_info["proj4_definition"]
+        src_crs = CRS.from_epsg(4326)
+        dst_crs = CRS.from_proj4(grid_info["proj4_definition"])
         cw = grid_info["cell_width"]
         ch = grid_info["cell_height"]
         ox = grid_info["origin_x"]
         oy = grid_info["origin_y"]
         w = grid_info["width"]
         h = grid_info["height"]
-        points_in_grid = _ll2cr.ll2cr_static(lon_arr, lat_arr, fill_in, proj_str,
+        points_in_grid = _ll2cr.ll2cr_static(lon_arr, lat_arr, fill_in, src_crs, dst_crs,
                                              cw, ch, w, h, ox, oy)
         self.assertEqual(points_in_grid, lon_arr.size, "all these test points should fall in this grid")
 
@@ -92,14 +94,15 @@ class TestLL2CRStatic(unittest.TestCase):
 
         grid_info = static_geo_whole_earth.copy()
         fill_in = np.nan
-        proj_str = grid_info['proj4_definition']
+        src_crs = CRS.from_epsg(4326)
+        dst_crs = CRS.from_proj4(grid_info["proj4_definition"])
         cw = grid_info['cell_width']
         ch = grid_info['cell_height']
         ox = grid_info['origin_x']
         oy = grid_info['origin_y']
         w = grid_info['width']
         h = grid_info['height']
-        points_in_grid = _ll2cr.ll2cr_static(lon_arr, lat_arr, fill_in, proj_str,
+        points_in_grid = _ll2cr.ll2cr_static(lon_arr, lat_arr, fill_in, src_crs, dst_crs,
                                              cw, ch, w, h, ox, oy)
         self.assertEqual(points_in_grid, lon_arr.size,
                          'all these test points should fall in this grid')
@@ -110,14 +113,15 @@ class TestLL2CRStatic(unittest.TestCase):
         lat_arr = create_test_latitude(18.0, 40.0, (50, 100), dtype=np.float64)
         grid_info = static_lcc.copy()
         fill_in = np.nan
-        proj_str = grid_info["proj4_definition"]
+        src_crs = CRS.from_epsg(4326)
+        dst_crs = CRS.from_proj4(grid_info["proj4_definition"])
         cw = grid_info["cell_width"]
         ch = grid_info["cell_height"]
         ox = grid_info["origin_x"]
         oy = grid_info["origin_y"]
         w = grid_info["width"]
         h = grid_info["height"]
-        points_in_grid = _ll2cr.ll2cr_static(lon_arr, lat_arr, fill_in, proj_str,
+        points_in_grid = _ll2cr.ll2cr_static(lon_arr, lat_arr, fill_in, src_crs, dst_crs,
                                              cw, ch, w, h, ox, oy)
         self.assertEqual(points_in_grid, 0, "none of these test points should fall in this grid")
 
@@ -131,14 +135,16 @@ class TestLL2CRDynamic(unittest.TestCase):
         lat_arr = create_test_latitude(15.0, 30.0, (50, 100), dtype=np.float64)
         grid_info = dynamic_wgs84.copy()
         fill_in = np.nan
-        proj_str = grid_info["proj4_definition"]
+        src_crs = CRS.from_epsg(4326)
+        dst_crs = CRS.from_proj4(grid_info["proj4_definition"])
         cw = grid_info["cell_width"]
         ch = grid_info["cell_height"]
         ox = grid_info["origin_x"]
         oy = grid_info["origin_y"]
         w = grid_info["width"]
         h = grid_info["height"]
-        points_in_grid, lon_res, lat_res, ox, oy, w, h = _ll2cr.ll2cr_dynamic(lon_arr, lat_arr, fill_in, proj_str,
+        points_in_grid, lon_res, lat_res, ox, oy, w, h = _ll2cr.ll2cr_dynamic(lon_arr, lat_arr, fill_in,
+                                                                              src_crs, dst_crs,
                                                                               cw, ch, w, h, ox, oy)
         self.assertEqual(points_in_grid, lon_arr.size, "all points should be contained in a dynamic grid")
         self.assertIs(lon_arr, lon_res)
@@ -152,14 +158,16 @@ class TestLL2CRDynamic(unittest.TestCase):
         lat_arr = create_test_latitude(15.0, 30.0, (50, 100), twist_factor=-0.1, dtype=np.float64)
         grid_info = dynamic_wgs84.copy()
         fill_in = np.nan
-        proj_str = grid_info["proj4_definition"]
+        src_crs = CRS.from_epsg(4326)
+        dst_crs = CRS.from_proj4(grid_info["proj4_definition"])
         cw = grid_info["cell_width"]
         ch = grid_info["cell_height"]
         ox = grid_info["origin_x"]
         oy = grid_info["origin_y"]
         w = grid_info["width"]
         h = grid_info["height"]
-        points_in_grid, lon_res, lat_res, ox, oy, w, h = _ll2cr.ll2cr_dynamic(lon_arr, lat_arr, fill_in, proj_str,
+        points_in_grid, lon_res, lat_res, ox, oy, w, h = _ll2cr.ll2cr_dynamic(lon_arr, lat_arr, fill_in,
+                                                                              src_crs, dst_crs,
                                                                               cw, ch, w, h, ox, oy)
         self.assertEqual(points_in_grid, lon_arr.size, "all points should be contained in a dynamic grid")
         self.assertIs(lon_arr, lon_res)
@@ -173,14 +181,16 @@ class TestLL2CRDynamic(unittest.TestCase):
         lat_arr = create_test_latitude(15.0, 30.0, (50, 100), twist_factor=-0.1, dtype=np.float64)
         grid_info = dynamic_wgs84.copy()
         fill_in = np.nan
-        proj_str = grid_info["proj4_definition"]
+        src_crs = CRS.from_epsg(4326)
+        dst_crs = CRS.from_proj4(grid_info["proj4_definition"])
         cw = grid_info["cell_width"]
         ch = grid_info["cell_height"]
         ox = grid_info["origin_x"]
         oy = grid_info["origin_y"]
         w = grid_info["width"]
         h = grid_info["height"]
-        points_in_grid, lon_res, lat_res, ox, oy, w, h = _ll2cr.ll2cr_dynamic(lon_arr, lat_arr, fill_in, proj_str,
+        points_in_grid, lon_res, lat_res, ox, oy, w, h = _ll2cr.ll2cr_dynamic(lon_arr, lat_arr, fill_in,
+                                                                              src_crs, dst_crs,
                                                                               cw, ch, w, h, ox, oy)
         self.assertEqual(points_in_grid, lon_arr.size, "all points should be contained in a dynamic grid")
         self.assertIs(lon_arr, lon_res)

--- a/versioneer.py
+++ b/versioneer.py
@@ -1993,7 +1993,7 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
     cmds["build_ext"] = cmd_build_ext
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
-        from cx_Freeze.dist import build_exe as _build_exe
+        from cx_Freeze.dist import build_exe as _build_exe  # type: ignore
 
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
@@ -2027,9 +2027,9 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
 
     if 'py2exe' in sys.modules:  # py2exe enabled?
         try:
-            from py2exe.setuptools_buildexe import py2exe as _py2exe
+            from py2exe.setuptools_buildexe import py2exe as _py2exe  # type: ignore
         except ImportError:
-            from py2exe.distutils_buildexe import py2exe as _py2exe
+            from py2exe.distutils_buildexe import py2exe as _py2exe  # type: ignore
 
         class cmd_py2exe(_py2exe):
             def run(self) -> None:

--- a/versioneer.py
+++ b/versioneer.py
@@ -1898,7 +1898,7 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
 
     class cmd_version(Command):
         description = "report generated version string"
-        user_options: List[Tuple[str, str, str]] = []
+        user_options: List[Tuple[str, str, str]] = []  # type: ignore
         boolean_options: List[str] = []
 
         def initialize_options(self) -> None:
@@ -1993,7 +1993,7 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
     cmds["build_ext"] = cmd_build_ext
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
-        from cx_Freeze.dist import build_exe as _build_exe  # type: ignore
+        from cx_Freeze.dist import build_exe as _build_exe
 
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
@@ -2027,9 +2027,9 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
 
     if 'py2exe' in sys.modules:  # py2exe enabled?
         try:
-            from py2exe.setuptools_buildexe import py2exe as _py2exe  # type: ignore
+            from py2exe.setuptools_buildexe import py2exe as _py2exe
         except ImportError:
-            from py2exe.distutils_buildexe import py2exe as _py2exe  # type: ignore
+            from py2exe.distutils_buildexe import py2exe as _py2exe
 
         class cmd_py2exe(_py2exe):
             def run(self) -> None:


### PR DESCRIPTION
The pyproj `Proj` object is deprecated and is not as accurate/explicit as the `Transformer` interface. I did some of these changes in my #645 branch, but decided that these changes should be their own PR. Unfortunately this also meant that I changed the low-level interfaces of ll2cr to accept a source CRS and a target CRS instead of just the target projection information.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
