### PR TITLE
Fix dynamic area freezing not preserving epsg code

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -22,6 +22,7 @@ import hashlib
 import math
 import warnings
 from collections import OrderedDict
+from contextlib import suppress
 from functools import partial, wraps
 from logging import getLogger
 from pathlib import Path
@@ -66,6 +67,7 @@ except ModuleNotFoundError:
 
 from pyproj import CRS
 from pyproj.enums import TransformDirection
+from pyproj.exceptions import CRSError
 
 logger = getLogger(__name__)
 
@@ -1284,6 +1286,8 @@ class DynamicAreaDefinition(object):
         area_extent = self.area_extent
         if not area_extent or not width or not height:
             projection, corners = self._compute_bound_centers(proj_dict, lonslats, antimeridian_mode=antimeridian_mode)
+            with suppress(CRSError):
+                projection = CRS(CRS(projection).to_epsg())
             area_extent, width, height = self.compute_domain(corners, resolution, shape, projection)
         return AreaDefinition(self.area_id, self.description, '',
                               projection, width, height,

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1763,3 +1763,12 @@ def test_dynamic_area_can_use_bounding_box_attribute():
     swath_def_to_freeze_on = SwathDefinition(None, None, attrs=dict(bounding_box=[[0, 20, 20, 0], [55, 55, 45, 45]]))
     res_area = area_def.freeze(swath_def_to_freeze_on)
     assert res_area.area_extent == (3533500, 2484500, 5108500, 3588500)
+    assert res_area.crs == CRS("epsg:3035")
+
+
+def test_dynamic_area_preserves_epsg_code():
+    """Test that area freezing preserves epsg code."""
+    area_def = DynamicAreaDefinition("test_area", "", "epsg:3035", resolution=500)
+    swath_def_to_freeze_on = SwathDefinition(None, None, attrs=dict(bounding_box=[[0, 20, 20, 0], [55, 55, 45, 45]]))
+    res_area = area_def.freeze(swath_def_to_freeze_on)
+    assert res_area.crs == CRS("epsg:3035")


### PR DESCRIPTION
This PR fixes dynamic areas not preserving epsg code when freezing.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
