### PR TITLE
Remove unused dependency importlib_metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ requirements = ['pyproj>=3.0', 'configobj',
                 "shapely", "donfig", "platformdirs",
                 ]
 
-if sys.version_info < (3, 10):
-    requirements.append('importlib_metadata')
 
 test_requires = ['rasterio', 'dask', 'xarray', 'cartopy>=0.20.0', 'pillow', 'matplotlib', 'scipy', 'zarr',
                  'pytest-lazy-fixtures', 'shapely', 'odc-geo']


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the dependency `importlib_metadata` is specified as a requirement in the `setup.py` file, when in reality it is not needed.

This PR removes it from `setup.py`, which helps keeping the dependency list clean.
Hope this is helpful!

Best regards

