### PR TITLE
Support for zarr 3.1+

### DIFF
--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -210,7 +210,7 @@ class XArrayBilinearResampler(BilinearBase):
     def load_resampling_info(self, filename):
         """Load bilinear resampling look-up tables and initialize the resampler."""
         try:
-            fid = zarr.open(filename, 'r')
+            fid = zarr.open(filename, mode='r')
             for val in BIL_COORDINATES:
                 cache = da.array(fid[val])
                 setattr(self, val, cache)


### PR DESCRIPTION
> Removes support for passing keyword-only arguments positionally to the following functions and methods: save_array, open, group, open_group, create, get_basic_selection, set_basic_selection, get_orthogonal_selection, set_orthogonal_selection, get_mask_selection, set_mask_selection, get_coordinate_selection, set_coordinate_selection, get_block_selection, set_block_selection, Group.create_array, Group.empty, Group.zeroes, Group.ones, Group.empty_like, Group.full, Group.zeros_like, Group.ones_like, Group.full_like, Group.array. Prior to this change, passing a keyword-only argument positionally to one of these functions or methods would raise a deprecation warning. That warning is now gone. Passing keyword-only arguments to these functions and methods positionally is now an error.

 - [x] Tests passed