### PR TITLE
Revert change of map_blocks name= kwarg in favor of token=

### DIFF
--- a/pyresample/utils/proj4.py
+++ b/pyresample/utils/proj4.py
@@ -150,7 +150,7 @@ class DaskFriendlyTransformer:
                                crs_from.to_wkt(), crs_to.to_wkt(),
                                dtype=np.float64, chunks=x.chunks + ((num_results,),),
                                meta=np.array((), dtype=np.float64),
-                               name="transform_coords",
+                               token="transform_coords",  # nosec: B106
                                kwargs=self.kwargs,
                                transform_kwargs=kwargs,
                                new_axis=x.ndim)


### PR DESCRIPTION
See https://github.com/dask/dask/pull/11952

I used `name=` because `token=` was deprecated. This has been reverted in dask now and the desired behavior of defining a task name prefix is through the `token` kwarg to `map_blocks`.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
