### PR TITLE
Fix BucketResampler using area's proj_dict instead crs

### DIFF
--- a/pyresample/bucket/__init__.py
+++ b/pyresample/bucket/__init__.py
@@ -145,7 +145,7 @@ class BucketResampler(object):
         self.target_area = target_area
         self.source_lons = source_lons
         self.source_lats = source_lats
-        self.prj = Proj(self.target_area.proj_dict)
+        self.prj = Proj(self.target_area.crs)
         self.x_idxs = None
         self.y_idxs = None
         self.idxs = None


### PR DESCRIPTION
This is causing pyproj warnings about loss of precision in Satpy tests.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
