### PR TITLE
Fix boundaries losing precision for accurate polygon calculations

### DIFF
--- a/pyresample/boundary/legacy_boundary.py
+++ b/pyresample/boundary/legacy_boundary.py
@@ -45,8 +45,9 @@ class Boundary(object):
     def contour_poly(self):
         """Get the Spherical polygon corresponding to the Boundary."""
         if self._contour_poly is None:
+            # force 64-bit for more accuracy
             self._contour_poly = SphPolygon(
-                np.deg2rad(np.vstack(self.contour()).T))
+                np.deg2rad(np.vstack(self.contour()).T, dtype=np.float64))
         return self._contour_poly
 
     def draw(self, mapper, options, **more_options):

--- a/pyresample/test/test_boundary/test_legacy_boundary.py
+++ b/pyresample/test/test_boundary/test_legacy_boundary.py
@@ -108,3 +108,25 @@ class TestAreaBoundary(unittest.TestCase):
         lons, lats = boundary.contour()
         assert np.allclose(lons, np.array([1., 1.5, 2., 3., 3.5, 4.]))
         assert np.allclose(lats, np.array([6., 6.5, 7., 8., 8.5, 9.]))
+
+    def test_countour_poly_north_pole(self):
+        """Test that a polygon can be made with 32-bit north pole coordinates.
+
+        In a real world case, 32-bit geolocation including a point at exactly the
+        north pole lead to a validity check failure because the radians value for
+        90N was just barely above pi / 2.
+
+        """
+        list_sides = [
+            (np.array([1., 1.5, 2.], dtype=np.float32), np.array([87.0, 87.5, 88.0], dtype=np.float32)),
+            (np.array([2., 3.], dtype=np.float32), np.array([88.0, 89.0], dtype=np.float32)),
+            (np.array([3., 3.5, 4.], dtype=np.float32), np.array([89., 89.5, 90.0], dtype=np.float32)),
+            (np.array([4., 1.], dtype=np.float32), np.array([90.0, 87.0], dtype=np.float32)),
+        ]
+        boundary = AreaBoundary(*list_sides)
+        poly = boundary.contour_poly
+        # validity checks happen here:
+        aedges = list(poly.aedges())
+        # ensure 90 degree latitude coordinate is retained
+        np.testing.assert_allclose(aedges[4].end.lat, np.radians(90.0))
+        np.testing.assert_allclose(aedges[5].start.lat, np.radians(90.0))


### PR DESCRIPTION
In a real world case identified by @spruceboy, if a 32-bit coordinate is given to `AreaBoundary` (or any boundary class) that is exactly at 90 degrees north, the conversion to radians and then validity checks in the spherical polygon class will raise an error.

```python
  File "/opt/cspp/polar2grid_v_3_1/libexec/python_runtime/lib/python3.11/site-packages/pyresample/spherical.py", line 571, in aedges
    yield Arc(SCoordinate(lon_start, lat_start),
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/cspp/polar2grid_v_3_1/libexec/python_runtime/lib/python3.11/site-packages/pyresample/spherical.py", line 131, in __init__
    lon, lat = _check_lon_lat(lon, lat)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/cspp/polar2grid_v_3_1/libexec/python_runtime/lib/python3.11/site-packages/pyresample/spherical.py", line 119, in _check_lon_lat
    _check_lat_validity(lat)
  File "/opt/cspp/polar2grid_v_3_1/libexec/python_runtime/lib/python3.11/site-packages/pyresample/spherical.py", line 111, in _check_lat_validity
    raise ValueError("Latitude values must range between [-pi/2, pi/2].")
```

What I discovered is that due to precision issues you end up with the input coordinate being `4.371139006309477e-08` greater than `np.pi / 2` and failing the validity check. See https://github.com/ssec/polar2grid/issues/766 for more info. 

The alternative solution could be allowing an epsilon greater/less than 90/-90 in the validity check but then the question becomes how to handle that coordinate? Should it be clipped? Should it be left alone and hope that the math is "good enough". Maybe it is just better to be more accurate with this PR's fix.

CC @ghiggi

@spruceboy, feel free to hack your Polar2Grid installation and add the `dtype=np.float64` shown in the changes here for `pyresample/boundary/legacy_boundary.py`.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
