### PR TITLE
Fix bilinear cache type decoding

### DIFF
--- a/pyresample/bilinear/xarr.py
+++ b/pyresample/bilinear/xarr.py
@@ -28,10 +28,9 @@ import warnings
 
 import dask.array as da
 import numpy as np
-import zarr
 from dask import delayed
 from pyproj import Proj
-from xarray import DataArray, Dataset
+from xarray import DataArray, Dataset, open_zarr
 
 from pyresample import CHUNK_SIZE
 from pyresample.bilinear._base import (
@@ -210,11 +209,11 @@ class XArrayBilinearResampler(BilinearBase):
     def load_resampling_info(self, filename):
         """Load bilinear resampling look-up tables and initialize the resampler."""
         try:
-            fid = zarr.open(filename, mode='r')
+            fid = open_zarr(filename, chunks="auto")
             for val in BIL_COORDINATES:
-                cache = da.array(fid[val])
+                cache = fid[val].data
                 setattr(self, val, cache)
-        except ValueError as err:
+        except (FileNotFoundError, KeyError, OSError, ValueError) as err:
             raise IOError("Invalid information loaded from resampling cache") from err
 
 

--- a/pyresample/test/test_bilinear.py
+++ b/pyresample/test/test_bilinear.py
@@ -1206,6 +1206,7 @@ class TestXarrayBilinear(unittest.TestCase):
             new_resampler = XArrayBilinearResampler(self.source_def, self.target_def,
                                                     self.radius)
             new_resampler.load_resampling_info(filename)
+            self.assertEqual(new_resampler.mask_slices.dtype, bool)
 
             for attr in CACHE_INDICES:
                 orig = getattr(resampler, attr)


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

Fixes bilinear cache type decoding:

mask_slices are boolean mask, and are stored as int8 via zarr.

boolean information is part of xarray metadata, so when skipping it we get back int8.

now mask_slices is not a mask but rather an array of 0, 1 indices making the mask useless.

---

I opted into chunks=auto automatic rechunking so Dask can pick the optimal chunk size, which gave a small performance boost on my data when using the cache:

```
  - raw zarr + astype(bool): load avg 0.006923s, compute avg 0.020060s
  - xarray open_zarr(chunks='auto'): load avg 0.004082s, compute avg 0.019647s
```

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->

