### PR TITLE
Decode CF metadata for pre-opened datasets

### DIFF
--- a/pyresample/utils/cf.py
+++ b/pyresample/utils/cf.py
@@ -473,6 +473,6 @@ def _open_nc_file(nc_file: str | Path | xr.Dataset) -> xr.Dataset:
     if xr is None:
         raise ImportError("Xarray (pip install xarray) is required to load geometries from a NetCDF file.")
     if isinstance(nc_file, xr.Dataset):
-        return nc_file
+        return xr.decode_cf(nc_file)
 
     return xr.open_dataset(nc_file)


### PR DESCRIPTION
Inspired by https://github.com/pytroll/pyresample/pull/702, _open_nc_file would fail to decode types when xr.Dataset was passed.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
