### PR TITLE
Fix test failure with PROJ 9.8.0.

### DIFF
--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -1088,7 +1088,7 @@ class TestAreaDefinition:
     def test_from_epsg(self, area_class):
         """Test the from_epsg class method."""
         sweref = area_class.from_epsg('3006', 2000)
-        assert sweref.description == 'SWEREF99 TM'
+        assert sweref.description in ['SWEREF99 TM', 'ETRS89-SWE [SWEREF 99 TM]']
         with ignore_pyproj_proj_warnings():
             assert sweref.proj_dict == {'ellps': 'GRS80', 'no_defs': None,
                                         'proj': 'utm', 'type': 'crs', 'units': 'm',


### PR DESCRIPTION
Fixes test failures with [PROJ 9.8.0](https://github.com/OSGeo/PROJ/blob/master/NEWS.md#980) by allowing both descriptions:
```
=================================== FAILURES ===================================
______________ TestAreaDefinition.test_from_epsg[AreaDefinition] _______________

self = <pyresample.test.test_geometry.test_area.TestAreaDefinition object at 0x7fb1f1246580>
area_class = <class 'pyresample.future.geometry.area.AreaDefinition'>

    def test_from_epsg(self, area_class):
        """Test the from_epsg class method."""
        sweref = area_class.from_epsg('3006', 2000)
>       assert sweref.description == 'SWEREF99 TM'
E       AssertionError: assert 'ETRS89-SWE [SWEREF 99 TM]' == 'SWEREF99 TM'
E         
E         - SWEREF99 TM
E         + ETRS89-SWE [SWEREF 99 TM]

pyresample/test/test_geometry/test_area.py:1091: AssertionError
------------------------------ Captured log call -------------------------------
WARNING  pyresample.area_config:area_config.py:767 shape found from radius and resolution does not contain only integers: (793.915117526711, 452.20830661668975)
Rounding shape to (794, 453) and resolution from (2000.0, 2000.0) meters to (1996.5046649743479, 1999.7861902436046) meters
___________ TestAreaDefinition.test_from_epsg[LegacyAreaDefinition] ____________

self = <pyresample.test.test_geometry.test_area.TestAreaDefinition object at 0x7fb1f12464e0>
area_class = <class 'pyresample.geometry.AreaDefinition'>

    def test_from_epsg(self, area_class):
        """Test the from_epsg class method."""
        sweref = area_class.from_epsg('3006', 2000)
>       assert sweref.description == 'SWEREF99 TM'
E       AssertionError: assert 'ETRS89-SWE [SWEREF 99 TM]' == 'SWEREF99 TM'
E         
E         - SWEREF99 TM
E         + ETRS89-SWE [SWEREF 99 TM]

pyresample/test/test_geometry/test_area.py:1091: AssertionError
------------------------------ Captured log call -------------------------------
```

 - [X] Tests passed <!-- for all non-documentation changes -->