### PR TITLE
use vertices_per_side argument rather than frequency which is deprecated

### DIFF
--- a/pyresample/future/geometry/_subset.py
+++ b/pyresample/future/geometry/_subset.py
@@ -100,7 +100,7 @@ def _get_area_boundary(area_to_cover: AreaDefinition) -> Boundary:
         if area_to_cover.is_geostationary:
             return Boundary(*get_geostationary_bounding_box_in_lonlats(area_to_cover))
         boundary_shape = max(max(*area_to_cover.shape) // 100 + 1, 3)
-        return area_to_cover.boundary(frequency=boundary_shape, force_clockwise=True)
+        return area_to_cover.boundary(vertices_per_side=boundary_shape, force_clockwise=True)
     except ValueError as err:
         raise NotImplementedError("Can't determine boundary of area to cover") from err
 

--- a/pyresample/slicer.py
+++ b/pyresample/slicer.py
@@ -170,7 +170,7 @@ class AreaSlicer(Slicer):
         from shapely.geometry import Polygon
 
         try:
-            x, y = self.area_to_contain.get_edge_bbox_in_projection_coordinates(frequency=10)
+            x, y = self.area_to_contain.get_edge_bbox_in_projection_coordinates(vertices_per_side=10)
         except AttributeError:
             x, y = self.area_to_contain.get_edge_lonlats(vertices_per_side=10)
         if self.area_to_crop.is_geostationary:

--- a/pyresample/slicer.py
+++ b/pyresample/slicer.py
@@ -202,7 +202,7 @@ class AreaSlicer(Slicer):
         from shapely.geometry import Polygon
 
         poly_to_crop = Polygon(zip(
-            *self.area_to_crop.get_edge_bbox_in_projection_coordinates(frequency=10),
+            *self.area_to_crop.get_edge_bbox_in_projection_coordinates(vertices_per_side=10),
             strict=True))
         if not poly_to_crop.intersects(buffered_poly):
             raise IncompatibleAreas("Areas not overlapping.")


### PR DESCRIPTION
`get_polygon_to_contain` used the deprecated frequency argument:

The `get_polygon_to_contain` function and call to `get_edge_bbox_in_projection_coordinates`:

https://github.com/pytroll/pyresample/blob/60e6132d934491c1aa12ccd7382c3246f9d1eb5e/pyresample/slicer.py#L173

And the "PendingDeprecationWarning" in `get_edge_bbox_in_projection_coordinates`:

https://github.com/pytroll/pyresample/blob/60e6132d934491c1aa12ccd7382c3246f9d1eb5e/pyresample/geometry.py#L1681

 - [x] Closes #711 
 - [x] Tests passed <!-- for all non-documentation changes -->