### PR TITLE
Add resample `force` kwarg

### DIFF
--- a/pyresample/resampler.py
+++ b/pyresample/resampler.py
@@ -95,7 +95,7 @@ class BaseResampler:
         """
         raise NotImplementedError
 
-    def resample(self, data, cache_dir=None, mask_area=None, **kwargs):
+    def resample(self, data, cache_dir=None, mask_area=None, force=False,**kwargs):
         """Resample `data` by calling `precompute` and `compute` methods.
 
         Only certain resampling classes may use `cache_dir` and the `mask`
@@ -112,13 +112,16 @@ class BaseResampler:
             mask_area (bool): Mask geolocation data where data values are
                               invalid. This should be used when data values
                               may affect what neighbors are considered valid.
+            force (bool): Force resampling by skipping the check for source
+                          and target geometries equality. Can be useful e.g. for
+                          gapfilling data.
             kwargs: Keyword arguments to pass to both the ``precompute`` and
                 ``compute`` stages of the resampler.
 
         Returns (xarray.DataArray): Data resampled to the target area
 
         """
-        if self._geometries_are_the_same():
+        if not force and self._geometries_are_the_same():
             return data
         # default is to mask areas for SwathDefinitions
         if mask_area is None and isinstance(

--- a/pyresample/resampler.py
+++ b/pyresample/resampler.py
@@ -95,7 +95,7 @@ class BaseResampler:
         """
         raise NotImplementedError
 
-    def resample(self, data, cache_dir=None, mask_area=None, force=False,**kwargs):
+    def resample(self, data, cache_dir=None, mask_area=None, force=False, **kwargs):
         """Resample `data` by calling `precompute` and `compute` methods.
 
         Only certain resampling classes may use `cache_dir` and the `mask`

--- a/pyresample/test/test_resamplers/test_resampler.py
+++ b/pyresample/test/test_resamplers/test_resampler.py
@@ -86,8 +86,9 @@ def test_resampler(src, dst):
         (True, "dask"),  # same dask tasks are equal
         (True, "swath_def"),  # same underlying arrays are equal
     ])
-def test_base_resampler_does_nothing_when_src_and_dst_areas_are_equal(_geos_area, use_swaths, copy_dst_swath):
-    """Test that the BaseResampler does nothing when the source and target areas are the same."""
+@pytest.mark.parametrize("force", [False, True])
+def test_base_resampler_does_nothing_when_src_and_dst_areas_are_equal(_geos_area, use_swaths, copy_dst_swath, force):
+    """Test that the BaseResampler does nothing when the source and target areas are the same, unless forced."""
     src_geom = _geos_area if not use_swaths else _xarray_swath_def_from_area(_geos_area)
     dst_geom = src_geom
     if copy_dst_swath == "dask":
@@ -97,7 +98,12 @@ def test_base_resampler_does_nothing_when_src_and_dst_areas_are_equal(_geos_area
 
     resampler = BaseResampler(src_geom, dst_geom)
     some_data = xr.DataArray(da.zeros(src_geom.shape, dtype=np.float64), dims=('y', 'x'))
-    assert resampler.resample(some_data) is some_data
+
+    if not force:
+        assert resampler.resample(some_data, force=force) is some_data
+    else:
+        with pytest.raises(NotImplementedError):
+            resampler.resample(some_data, force=force)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds a `force` kwarg to the `resampler.resample` call. When set to `True`, it bypasses the area equality checks that skip the resampling if the geometries are the same. This is useful e.g. when data has NaN gaps (for example after a parallax correction) and one wants to gapfill it, e.g. with nearest neighbour.

 - [x] Closes #660 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
