### PR TITLE
Flatten Boundary coordinates before sampling

### DIFF
--- a/pyresample/boundary/legacy_boundary.py
+++ b/pyresample/boundary/legacy_boundary.py
@@ -33,9 +33,9 @@ class Boundary(object):
     def __init__(self, lons=None, lats=None, frequency=1):
         self._contour_poly = None
         if lons is not None:
-            self.lons = lons[::frequency]
+            self.lons = np.ravel(lons)[::frequency]
         if lats is not None:
-            self.lats = lats[::frequency]
+            self.lats = np.ravel(lats)[::frequency]
 
     def contour(self):
         """Get lon/lats of the contour."""

--- a/pyresample/test/test_boundary/test_legacy_boundary.py
+++ b/pyresample/test/test_boundary/test_legacy_boundary.py
@@ -22,7 +22,18 @@ import unittest
 import numpy as np
 import pytest
 
-from pyresample.boundary import AreaBoundary
+from pyresample.boundary import AreaBoundary, Boundary
+
+
+def test_boundary_flattens_coordinates_before_decimation():
+    """Test 2D coordinates are flattened before frequency sampling."""
+    lons = np.arange(6).reshape(2, 3)
+    lats = lons + 10
+
+    contour_lons, contour_lats = Boundary(lons, lats, frequency=2).contour()
+
+    np.testing.assert_array_equal(contour_lons, [0, 2, 4])
+    np.testing.assert_array_equal(contour_lats, [10, 12, 14])
 
 
 class TestAreaBoundary(unittest.TestCase):


### PR DESCRIPTION
## Summary

- flatten `Boundary` longitude and latitude arrays before applying `frequency`
- preserve the existing C-order sampling semantics for one-dimensional inputs
- add one focused regression test for two-dimensional coordinates

Closes #333

## Testing

- `pytest pyresample/test/test_boundary/test_legacy_boundary.py -q` (`7 passed`)
- adjacent boundary/spherical tests (`70 passed`)
- `pytest pyresample/test -q` (`1157 passed, 24 skipped`)
- Ruff, trailing-whitespace, EOF, Bandit, isort, and `git diff --check` passed
- The pre-commit Mypy hook fails identically on unchanged `main` before checking project files because its unpinned NumPy 2.5.1 stubs use Python 3.12 type syntax while this repository configures Mypy for Python 3.11

## Checklist

- [x] Closes #333
- [x] Tests added
- [x] Tests passed

No documentation change is needed because this fixes the existing `Boundary` contract without adding or changing a public API.

## Automation disclosure

This patch, its tests, and this pull request description were prepared and validated with OpenAI Codex automation under the contributor's authorization. This disclosure is included for reviewer context.
