### PR TITLE
fix(area): complete area definitions with explicit b parameter

### DIFF
--- a/docs/areas.cfg
+++ b/docs/areas.cfg
@@ -237,7 +237,7 @@ REGION: euro_north {
 REGION: ease_sh {
        NAME:           Antarctic EASE grid
        PCS_ID:         ease_sh
-       PCS_DEF:        proj=laea, lat_0=-90, lon_0=0, a=6371228.0, units=m
+       PCS_DEF:        proj=laea, lat_0=-90, lon_0=0, a=6371228.0, b=6371228.0, units=m
        XSIZE:          425
        YSIZE:          425
        AREA_EXTENT:    (-5326849.0625,-5326849.0625,5326849.0625,5326849.0625)
@@ -246,7 +246,7 @@ REGION: ease_sh {
 REGION: ease_nh {
        NAME:           Arctic EASE grid
        PCS_ID:         ease_nh
-       PCS_DEF:        proj=laea, lat_0=90, lon_0=0, a=6371228.0, units=m
+       PCS_DEF:        proj=laea, lat_0=90, lon_0=0, a=6371228.0, b=6371228.0, units=m
        XSIZE:          425
        YSIZE:          425
        AREA_EXTENT:    (-5326849.0625,-5326849.0625,5326849.0625,5326849.0625)

--- a/docs/source/howtos/geo_def.rst
+++ b/docs/source/howtos/geo_def.rst
@@ -61,7 +61,7 @@ Example:
  >>> area_id = 'ease_sh'
  >>> description = 'Antarctic EASE grid'
  >>> proj_id = 'ease_sh'
- >>> projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
+ >>> projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'}
  >>> width = 425
  >>> height = 425
  >>> area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
@@ -76,11 +76,15 @@ Example:
  Number of rows: 425
  Area extent: (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
 
+When specifying a custom ellipsoid, always define both ``a`` and ``b``
+(``b = a`` for a sphere). Projections that only define ``a`` are
+rejected by some stricter tools such as GDAL when writing geotiffs.
+
 You can also specify the projection using a PROJ.4 string
 
 .. doctest::
 
- >>> projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+ >>> projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +b=6371228.0 +units=m'
  >>> area_def = AreaDefinition(area_id, description, proj_id, projection,
  ...                           width, height, area_extent)
 
@@ -178,7 +182,7 @@ Get longitude and latitude arrays:
  >>> area_id = 'ease_sh'
  >>> description = 'Antarctic EASE grid'
  >>> proj_id = 'ease_sh'
- >>> projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+ >>> projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +b=6371228.0 +units=m'
  >>> width = 425
  >>> height = 425
  >>> area_extent = (-5326849.0625,-5326849.0625,5326849.0625,5326849.0625)

--- a/docs/source/howtos/geometry_utils.rst
+++ b/docs/source/howtos/geometry_utils.rst
@@ -49,7 +49,7 @@ and optional arguments:
 
  >>> from pyresample import create_area_def
  >>> area_id = 'ease_sh'
- >>> proj_dict = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
+ >>> proj_dict = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'}
  >>> center = (0, 0)
  >>> radius = (5326849.0625, 5326849.0625)
  >>> resolution = (25067.525, 25067.525)
@@ -75,7 +75,7 @@ keyword arguments can be specified with one value if ``dx == dy``:
 
 .. doctest::
 
- >>> proj_string = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+ >>> proj_string = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +b=6371228.0 +units=m'
  >>> area_def = create_area_def(area_id, proj_string, center=center,
  ...                              radius=5326849.0625, resolution=25067.525)
  >>> print(area_def)
@@ -161,7 +161,7 @@ from_extent
 
  >>> from pyresample.geometry import AreaDefinition
  >>> area_id = 'ease_sh'
- >>> proj_string = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+ >>> proj_string = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +b=6371228.0 +units=m'
  >>> area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
  >>> shape = (425, 425)
  >>> area_def = AreaDefinition.from_extent(area_id, proj_string, shape, area_extent)
@@ -180,7 +180,7 @@ from_circle
 
 .. doctest::
 
- >>> proj_dict = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
+ >>> proj_dict = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'}
  >>> center = (0, 0)
  >>> radius = 5326849.0625
  >>> area_def = AreaDefinition.from_circle(area_id, proj_dict, center, radius, shape=shape)
@@ -257,6 +257,7 @@ an area might be specified.
      lat_0: -90
      lon_0: 0
      a: 6371228.0
+     b: 6371228.0
      units: m
    shape: [425, 425]
    area_extent: [-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625]
@@ -269,6 +270,7 @@ an area might be specified.
      lat_0: -90
      lon_0: 0
      a: 6371228.0
+     b: 6371228.0
      units: m
    shape:
      height: 425
@@ -284,6 +286,7 @@ an area might be specified.
      lat_0: -90
      lon_0: 0
      a: 6371228.0
+     b: 6371228.0
      units: m
    shape: [425, 425]
    upper_left_extent: [-5326849.0625, 5326849.0625]
@@ -298,6 +301,7 @@ an area might be specified.
      lat_0: -90
      lon_0: 0
      a: 6371228.0
+     b: 6371228.0
      units: m
    shape: [425, 425]
    upper_left_extent:
@@ -315,6 +319,7 @@ an area might be specified.
      lat_0: -90
      lon_0: 0
      a: 6371228.0
+     b: 6371228.0
      units: m
    center: [0, 0]
    resolution: [25067.525, 25067.525]
@@ -328,6 +333,7 @@ an area might be specified.
      lat_0: -90
      lon_0: 0
      a: 6371228.0
+     b: 6371228.0
      units: m
    center:
      x: 0
@@ -348,6 +354,7 @@ an area might be specified.
      lat_0: -90
      lon_0: 0
      a: 6371228.0
+     b: 6371228.0
      units: m
    shape: [425, 425]
    center: [0, 0]
@@ -361,6 +368,7 @@ an area might be specified.
      lat_0: -90
      lon_0: 0
      a: 6371228.0
+     b: 6371228.0
      units: m
    shape: [425, 425]
    center:
@@ -441,7 +449,7 @@ Assuming the file **areas.cfg** exists with the following content
  REGION: ease_sh {
     NAME:           Antarctic EASE grid
     PCS_ID:         ease_sh
-        PCS_DEF:        proj=laea, lat_0=-90, lon_0=0, a=6371228.0, units=m
+        PCS_DEF:        proj=laea, lat_0=-90, lon_0=0, a=6371228.0, b=6371228.0, units=m
         XSIZE:          425
         YSIZE:          425
         AREA_EXTENT:    (-5326849.0625,-5326849.0625,5326849.0625,5326849.0625)
@@ -450,7 +458,7 @@ Assuming the file **areas.cfg** exists with the following content
  REGION: ease_nh {
         NAME:           Arctic EASE grid
         PCS_ID:         ease_nh
-        PCS_DEF:        proj=laea, lat_0=90, lon_0=0, a=6371228.0, units=m
+        PCS_DEF:        proj=laea, lat_0=90, lon_0=0, a=6371228.0, b=6371228.0, units=m
         XSIZE:          425
         YSIZE:          425
         AREA_EXTENT:    (-5326849.0625,-5326849.0625,5326849.0625,5326849.0625)

--- a/docs/source/howtos/plot.rst
+++ b/docs/source/howtos/plot.rst
@@ -39,7 +39,7 @@ set the three arrays :code:`lons`, :code:`lats` and :code:`tb37v` accordingly, e
    >>> area_id = 'ease_sh'
    >>> description = 'Antarctic EASE grid'
    >>> proj_id = 'ease_sh'
-   >>> projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
+   >>> projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'}
    >>> width = 425
    >>> height = 425
    >>> area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)

--- a/docs/source/howtos/plot_cartopy_basemap.rst
+++ b/docs/source/howtos/plot_cartopy_basemap.rst
@@ -72,7 +72,7 @@ AreaDefinition using the :func:`area_def2basemap <pyresample.plot.area_def2basem
    >>> area_id = 'ease_sh'
    >>> description = 'Antarctic EASE grid'
    >>> proj_id = 'ease_sh'
-   >>> projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
+   >>> projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'}
    >>> width = 425
    >>> height = 425
    >>> area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)

--- a/docs/source/howtos/plot_projections.rst
+++ b/docs/source/howtos/plot_projections.rst
@@ -5,7 +5,7 @@
    area_id = 'ease_sh'
    description = 'Antarctic EASE grid'
    proj_id = 'ease_sh'
-   projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'}
+   projection = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'}
    width = 425
    height = 425
    area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
@@ -96,6 +96,7 @@ should also work with these projections. Again assuming the area-config file
       lon_0: 40.
       lat_0: -40.
       a: 6370997.0
+      b: 6370997.0
     shape:
       height: 480
       width: 640
@@ -116,6 +117,7 @@ should also work with these projections. Again assuming the area-config file
        lon_0: 40.
        lat_0: -40.
        a: 6370997.0
+       b: 6370997.0
      shape:
        height: 480
        width: 640

--- a/docs/source/howtos/spherical_geometry.rst
+++ b/docs/source/howtos/spherical_geometry.rst
@@ -22,7 +22,7 @@ Geometries can be checked for overlap:
  >>> area_id = 'ease_sh'
  >>> description = 'Antarctic EASE grid'
  >>> proj_id = 'ease_sh'
- >>> projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+ >>> projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +b=6371228.0 +units=m'
  >>> width = 425
  >>> height = 425
  >>> area_extent = (-5326849.0625,-5326849.0625,5326849.0625,5326849.0625)

--- a/pyresample/test/test_files/areas.yaml
+++ b/pyresample/test/test_files/areas.yaml
@@ -6,6 +6,7 @@ boundary:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape: [425, 425]
   area_extent: [-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625]
@@ -18,6 +19,7 @@ boundary_2:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape:
     height: 425
@@ -33,6 +35,7 @@ corner:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape: [425, 425]
   upper_left_extent: [-5326849.0625, 5326849.0625]
@@ -47,6 +50,7 @@ corner_2:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape: [425, 425]
   upper_left_extent:
@@ -64,6 +68,7 @@ circle:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   center: [0, 0]
   resolution: [25067.525, 25067.525]
@@ -77,6 +82,7 @@ circle_2:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   center:
     x: 0
@@ -97,6 +103,7 @@ area_of_interest:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape: [425, 425]
   center: [0, 0]
@@ -110,6 +117,7 @@ area_of_interest_2:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape: [425, 425]
   center:
@@ -126,6 +134,7 @@ test_meters:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape: [425, 850]
   upper_left_extent:
@@ -148,6 +157,7 @@ test_degrees:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   area_extent:
     lower_left_xy: [-135.0, -17.516001139327766]
@@ -177,6 +187,7 @@ ease_sh:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape:
     height: 425
@@ -193,6 +204,7 @@ ease_nh:
     lat_0: -90
     lon_0: 0
     a: 6371228.0
+    b: 6371228.0
     units: m
   shape:
     height: 425
@@ -271,6 +283,7 @@ ortho:
     lon_0: 40.
     lat_0: -40.
     a: 6370997.0
+    b: 6370997.0
   shape:
     height: 480
     width: 640

--- a/pyresample/test/test_geometry/test_area.py
+++ b/pyresample/test/test_geometry/test_area.py
@@ -713,7 +713,7 @@ class TestAreaDefinition:
         proj_dict = {"proj": 'laea',
                      'lat_0': '50',
                      'lon_0': '0',
-                     'a': '6371228.0', 'units': 'm'}
+                     'a': '6371228.0', 'b': '6371228.0', 'units': 'm'}
         area_def = create_test_area(proj_dict, x_size, y_size, area_extent)
         lat1, lon1 = 48.832222, 2.355556  # Paris, 13th arrondissement, France
         lat2, lon2 = 58.6, 16.2  # Norrköping, Sweden
@@ -737,7 +737,7 @@ class TestAreaDefinition:
         proj_dict = {"proj": 'laea',
                      'lat_0': '50',
                      'lon_0': '0',
-                     'a': '6371228.0', 'units': 'm'}
+                     'a': '6371228.0', 'b': '6371228.0', 'units': 'm'}
         area_def = create_test_area(proj_dict, x_size, y_size, area_extent)
         lons, lats = area_def.get_lonlats()
         x, y = np.meshgrid(np.arange(x_size), np.arange(y_size))
@@ -747,7 +747,7 @@ class TestAreaDefinition:
 
     def test_area_corners_around_south_pole(self, create_test_area):
         """Test corner values for the ease-sh area."""
-        projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+        projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +b=6371228.0 +units=m'
         width = 425
         height = 425
         area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
@@ -829,7 +829,7 @@ class TestAreaDefinition:
         proj_dict = {"proj": 'laea',
                      'lat_0': '60',
                      'lon_0': '0',
-                     'a': '6371228.0', 'units': 'm'}
+                     'a': '6371228.0', 'b': '6371228.0', 'units': 'm'}
         area_def = create_test_area(proj_dict, x_size, y_size, area_extent)
         p__ = Proj(proj_dict)
         lon_ul, lat_ul = p__(1000000, 50000, inverse=True)
@@ -1311,8 +1311,8 @@ class TestCreateAreaDef:
     @pytest.mark.parametrize(
         'projection',
         [
-            {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'},
-            '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m',
+            {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'},
+            '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +b=6371228.0 +units=m',
             '+init=EPSG:3409',
             'EPSG:3409',
         ])
@@ -1334,7 +1334,7 @@ class TestCreateAreaDef:
         shape = (425, 850)
         area_extent = (-5326849.0625, -5326849.0625, 5326849.0625, 5326849.0625)
         base_def = create_test_area(
-            {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'},
+            {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'},
             shape[1], shape[0], area_extent,
         )
 
@@ -1381,7 +1381,7 @@ class TestCreateAreaDef:
         """Test extra combinations of create_area_def parameters."""
         from pyresample import create_area_def as cad
 
-        projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +units=m'
+        projection = '+proj=laea +lat_0=-90 +lon_0=0 +a=6371228.0 +b=6371228.0 +units=m'
         area_id = 'ease_sh'
         shape = (425, 850)
         upper_left_extent = (-5326849.0625, 5326849.0625)
@@ -1389,7 +1389,7 @@ class TestCreateAreaDef:
         resolution = (12533.7625, 25067.525)
         radius = [5326849.0625, 5326849.0625]
         base_def = create_test_area(
-            {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'units': 'm'},
+            {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0, 'b': 6371228.0, 'units': 'm'},
             shape[1], shape[0], area_extent)
 
         # Tests that specifying units through xarrays works.
@@ -1438,7 +1438,7 @@ class TestCreateAreaDef:
         """Test that a non-pole center can be used."""
         from pyresample import create_area_def as cad
         from pyresample.geometry import AreaDefinition
-        area_def = cad('ease_sh', '+a=6371228.0 +units=m +lon_0=0 +proj=merc +lat_0=0',
+        area_def = cad('ease_sh', '+a=6371228.0 +b=6371228.0 +units=m +lon_0=0 +proj=merc +lat_0=0',
                        center=(0, 0), radius=45,
                        resolution=(1, 0.9999291722135637),
                        units='degrees')
@@ -1478,7 +1478,7 @@ def test_enclose_areas(create_test_area):
                  'x_0': 0, 'y_0': 0, 'ellps': 'GRS80', 'units': 'm',
                  'no_defs': None, 'type': 'crs'}
     proj_dict_alt = {'proj': 'laea', 'lat_0': -90, 'lon_0': 0, 'a': 6371228.0,
-                     'units': 'm'}
+                     'b': 6371228.0, 'units': 'm'}
 
     ar1 = create_test_area(
         proj_dict,


### PR DESCRIPTION
## What

Completes all incomplete area definitions in the repository. Several example projections (test fixtures and documentation) only define the equatorial radius `a`; while PROJ accepts this and treats the ellipsoid as a sphere, stricter tools such as **GDAL reject these definitions when writing geotiffs** (reported in #200, encountered by Satpy users).

## Change

Add `b = a` to every projection that only defined `a`:

- `pyresample/test/test_files/areas.yaml` — 13 area definitions
- `pyresample/test/test_geometry/test_area.py` — projection dicts and PROJ.4 strings used as test fixtures
- Docs: `docs/areas.cfg`, and howto examples in `geo_def.rst`, `geometry_utils.rst`, `plot.rst`, `plot_cartopy_basemap.rst`, `plot_projections.rst`, `spherical_geometry.rst` (dict, PROJ.4 string, YAML and `.cfg` forms)
- Added a note in `geo_def.rst` documenting that both `a` and `b` should always be defined

## Why it's safe

`a`-only and `a+b` (with `b = a`) definitions normalize to the **identical** CRS in pyproj (`+R=6371228` sphere form, `CRS.equals()` → `True`), so no coordinate behavior changes — this only removes the GDAL incompatibility.

## Tests

- `python -m pytest pyresample/test/test_area_config.py pyresample/test/test_geometry/test_area.py` → **221 passed** (same as before the change)
- All `.. doctest::` blocks in the edited howtos still pass unchanged (verified expected outputs are byte-identical)
- All YAML code blocks in edited docs parse with `yaml.safe_load`
- `ruff check` clean on the modified test file
