### PR TITLE
Fix user fill value not being used in EWA

### DIFF
--- a/pyresample/ewa/ewa.py
+++ b/pyresample/ewa/ewa.py
@@ -167,7 +167,7 @@ def fornav(cols, rows, area_def, data_in,
     rows_per_scan = rows_per_scan or data_in[0].shape[0]
 
     results = _fornav.fornav_wrapper(cols, rows, data_in, out,
-                                     np.nan, np.nan, rows_per_scan,
+                                     fill, fill, rows_per_scan,
                                      weight_count=weight_count,
                                      weight_min=weight_min,
                                      weight_distance_max=weight_distance_max,

--- a/pyresample/test/test_ewa_fornav.py
+++ b/pyresample/test/test_ewa_fornav.py
@@ -191,3 +191,40 @@ class TestFornavWrapper(unittest.TestCase):
         # output except outside the swath
         self.assertTrue(((out == 1) | np.isnan(out)).all(),
                         msg="Unexpected interpolation values were returned")
+
+    def test_fornav_integer_swath_with_fill(self):
+        """Integer swath data resamples when a fill value is given (#689)."""
+        from pyresample.ewa import fornav
+        rows = np.empty((1600, 3200), dtype=np.float32)
+        rows[:] = np.linspace(-500, 2500, 1600)[:, None]
+        cols = np.empty((1600, 3200), dtype=np.float32)
+        cols[:] = np.linspace(-2500, 500, 3200)
+        data = np.ones((1600, 3200), dtype=np.int8)
+        out = np.empty((1000, 1000), dtype=np.int8)
+
+        grid_points_covered, out_res = fornav(cols, rows, None, data,
+                                              rows_per_scan=16, fill=0, out=out)
+
+        self.assertIs(out, out_res)
+        self.assertGreater(grid_points_covered, 0)
+        self.assertTrue(((out == 1) | (out == 0)).all(),
+                        msg="Integer output should only contain data and fill values")
+        self.assertGreater((out == 0).sum(), 0,
+                           msg="Uncovered pixels should contain the fill value")
+
+    def test_fornav_fill_value_used_in_output(self):
+        """A user-supplied fill value is written to uncovered pixels (#689)."""
+        from pyresample.ewa import fornav
+        rows = np.empty((1600, 3200), dtype=np.float32)
+        rows[:] = np.linspace(-500, 2500, 1600)[:, None]
+        cols = np.empty((1600, 3200), dtype=np.float32)
+        cols[:] = np.linspace(-2500, 500, 3200)
+        data = np.ones((1600, 3200), dtype=np.float32)
+        out = np.empty((1000, 1000), dtype=np.float32)
+
+        _, out_res = fornav(cols, rows, None, data,
+                            rows_per_scan=16, fill=0.0, out=out)
+
+        self.assertFalse(np.isnan(out).any(),
+                         msg="Uncovered pixels should contain the fill value, not NaN")
+        self.assertTrue(((out == 1) | (out == 0)).all())


### PR DESCRIPTION
## What

`fornav()` resolves a fill value from the input data (NaN for floats, -999 for integers, or the caller's `fill` argument) but then passed hardcoded `np.nan` as both the input and output fill to the C resampler (`_fornav.fornav_wrapper`). Two consequences (reported in #689):

- Integer swath data cannot be resampled — NaN cannot be written into an integer output array.
- A user-specified `fill` (e.g. `fill=0`) was ignored for float data: uncovered pixels still got NaN.

## Change

Pass the resolved `fill` value as both input and output fill to `fornav_wrapper`. Default behavior is unchanged (float data with `fill=None` still gets NaN, matching the documented default); only `fill`-specified and integer paths change. The dask EWA resampler already forwarded its fill value and is unaffected.

## Tests

- New `test_fornav_integer_swath_with_fill`: int8 swath + `fill=0` resamples without error; output contains only data and fill values.
- New `test_fornav_fill_value_used_in_output`: float32 swath + `fill=0` — uncovered pixels are 0, no NaN anywhere.
- Both tests fail on the previous implementation (verified) and pass with the fix.
- `pytest test_ewa_fornav.py test_dask_ewa.py` → 89 passed, 20 skipped (pre-existing skips). ruff clean.