### PR TITLE
Add meson-python dep to unstable CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          python -m pip install hatchling hatch-vcs hatch-cython Cython setuptools versioneer editables configobj pkgconfig;
+          python -m pip install hatchling hatch-vcs hatch-cython Cython setuptools versioneer editables configobj pkgconfig meson-python;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --no-deps --pre --upgrade \


### PR DESCRIPTION
CI is failing in the unstable environment. I think it just needs this missing dependency (meson-python) for the mesonpy build backend.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
