### PR TITLE
Add workaround for autodocs failing to handle DataArray

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,6 +80,7 @@ autodoc_type_aliases = {
 }
 autodoc_default_options = {
     "special-members": "__init__, __reduce_ex__",
+    "exclude-members": "DataArray",
 }
 nitpick_ignore_regex: list[tuple[str, str]] = []
 autoclass_content = "both"  # append class __init__ docstring to the class docstring


### PR DESCRIPTION
Sphinx-autodoc-typehints has trouble when parsing the `DataArray` import. It issues a warning about the optional xarray dependency "iris" not being available. I could have installed iris, but Claude identified this simpler workaround.

Upstream issue: https://github.com/tox-dev/sphinx-autodoc-typehints/issues/768

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
