### PR TITLE
Deprecate 'get_area_extent_for_subset' and fix incorrect return value

### DIFF
--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -192,34 +192,6 @@ class BaseDefinition:
         """Test for approximate inequality."""
         return not self.__eq__(other)
 
-    def get_area_extent_for_subset(self, row_LR, col_LR, row_UL, col_UL):
-        """Calculate extent for a subdomain of this area.
-
-        Rows are counted from upper left to lower left and columns are
-        counted from upper left to upper right.
-
-        Args:
-            row_LR (int): row of the lower right pixel
-            col_LR (int): col of the lower right pixel
-            row_UL (int): row of the upper left pixel
-            col_UL (int): col of the upper left pixel
-
-        Returns:
-            area_extent (tuple):
-                Area extent (LL_x, LL_y, UR_x, UR_y) of the subset
-
-        Author:
-            Ulrich Hamann
-        """
-        (a, b) = self.get_proj_coords(data_slice=(row_LR, col_LR))
-        a = a - 0.5 * self.pixel_size_x
-        b = b - 0.5 * self.pixel_size_y
-        (c, d) = self.get_proj_coords(data_slice=(row_UL, col_UL))
-        c = c + 0.5 * self.pixel_size_x
-        d = d + 0.5 * self.pixel_size_y
-
-        return a, b, c, d
-
     def get_lonlat(self, row, col):
         """Retrieve lon and lat of single pixel.
 
@@ -1371,9 +1343,14 @@ def _generate_2d_coords(pixel_size_x, pixel_size_y, pixel_upper_left_x, pixel_up
     return res
 
 
-def _generate_1d_proj_vectors(col_range, row_range,
-                              pixel_size_xy, offset_xy,
-                              dtype, chunks=None):
+def _generate_1d_proj_vectors(
+        col_range: tuple[float | int, float | int],
+        row_range: tuple[float | int, float | int],
+        pixel_size_xy: tuple[float, float],
+        offset_xy: tuple[float, float],
+        dtype: np.dtype,
+        chunks: tuple | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
     x_kwargs, y_kwargs, arange = _get_vector_arange_args(dtype, chunks)
     x = arange(*col_range, **x_kwargs) * pixel_size_xy[0] + offset_xy[0]
     y = arange(*row_range, **y_kwargs) * -pixel_size_xy[1] + offset_xy[1]
@@ -2379,6 +2356,43 @@ class AreaDefinition(_ProjectionDefinition):
                       stacklevel=2)
 
         return self.get_array_indices_from_projection_coordinates(self, xm, ym)
+
+    def get_area_extent_for_subset(
+            self,
+            row_LR: int,
+            col_LR: int,
+            row_UL: int,
+            col_UL: int,
+    ) -> tuple[float, float, float, float]:
+        """Calculate extent for a subdomain of this area.
+
+        Rows are counted from upper left to lower left and columns are
+        counted from upper left to upper right.
+
+        .. deprecated:: 1.36.0
+
+            This method will be removed in Pyresample 2.0. Slice the area
+            definition and use its ``area_extent`` instead::
+
+                area_def[row_UL:row_LR + 1, col_UL:col_LR + 1].area_extent
+
+        Args:
+            row_LR: row of the lower right pixel
+            col_LR: col of the lower right pixel
+            row_UL: row of the upper left pixel
+            col_UL: col of the upper left pixel
+
+        Returns:
+            Area extent (LL_x, LL_y, UR_x, UR_y) of the subset
+
+        """
+        warnings.warn(
+            "'get_area_extent_for_subset' is deprecated and will be removed in Pyresample 2.0. "
+            "Use 'area_def[row_UL:row_LR + 1, col_UL:col_LR + 1].area_extent' instead.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return self[row_UL:row_LR + 1, col_UL:col_LR + 1].area_extent
 
     def get_lonlat(self, row, col):
         """Retrieve lon and lat values of single point in area grid.

--- a/pyresample/geometry.py
+++ b/pyresample/geometry.py
@@ -2359,10 +2359,10 @@ class AreaDefinition(_ProjectionDefinition):
 
     def get_area_extent_for_subset(
             self,
-            row_LR: int,
-            col_LR: int,
-            row_UL: int,
-            col_UL: int,
+            row_lr: int,
+            col_lr: int,
+            row_ul: int,
+            col_ul: int,
     ) -> tuple[float, float, float, float]:
         """Calculate extent for a subdomain of this area.
 
@@ -2374,13 +2374,13 @@ class AreaDefinition(_ProjectionDefinition):
             This method will be removed in Pyresample 2.0. Slice the area
             definition and use its ``area_extent`` instead::
 
-                area_def[row_UL:row_LR + 1, col_UL:col_LR + 1].area_extent
+                area_def[row_ul:row_lr + 1, col_ul:col_lr + 1].area_extent
 
         Args:
-            row_LR: row of the lower right pixel
-            col_LR: col of the lower right pixel
-            row_UL: row of the upper left pixel
-            col_UL: col of the upper left pixel
+            row_lr: row of the lower right pixel
+            col_lr: col of the lower right pixel
+            row_ul: row of the upper left pixel
+            col_ul: col of the upper left pixel
 
         Returns:
             Area extent (LL_x, LL_y, UR_x, UR_y) of the subset
@@ -2388,11 +2388,11 @@ class AreaDefinition(_ProjectionDefinition):
         """
         warnings.warn(
             "'get_area_extent_for_subset' is deprecated and will be removed in Pyresample 2.0. "
-            "Use 'area_def[row_UL:row_LR + 1, col_UL:col_LR + 1].area_extent' instead.",
+            "Use 'area_def[row_ul:row_lr + 1, col_ul:col_lr + 1].area_extent' instead.",
             UserWarning,
             stacklevel=2,
         )
-        return self[row_UL:row_LR + 1, col_UL:col_LR + 1].area_extent
+        return self[row_ul:row_lr + 1, col_ul:col_lr + 1].area_extent
 
     def get_lonlat(self, row, col):
         """Retrieve lon and lat values of single point in area grid.

--- a/pyresample/utils/__init__.py
+++ b/pyresample/utils/__init__.py
@@ -199,16 +199,16 @@ def wrap_longitudes(lons):
     return (lons + 180) % 360 - 180
 
 
-def check_and_wrap(lons, lats):
+def check_and_wrap(lons: np.ndarray, lats: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Wrap longitude to [-180:+180[ and check latitude for validity.
 
     Args:
-        lons (ndarray): Longitude degrees
-        lats (ndarray): Latitude degrees
+        lons: Longitude degrees
+        lats: Latitude degrees
 
     Returns:
-        lons, lats: Longitude degrees in the range [-180:180[ and the original
-                    latitude array
+        ``(lons, lats)`` with longitude degrees wrapped to the range
+        [-180, 180) and the original latitude array
 
     Raises:
         ValueError: If latitude array is not between -90 and 90


### PR DESCRIPTION
Sphinx was complaining about bad type definitions in the docstring of 'get_area_extent_for_subset'. I decided to move the types to normal type annotations since we use that elsewhere. This revealed that this method hasn't returned a tuple of scalars since 2018. This method was added in 2018 in #44 and then later we changed how the `get_proj_*` methods work and dropped this scalar use case. Since no tests were ever added for this method the breakage was never caught. In this PR I fix the type annotations and deprecate the method in favor of the slicing logic available for `AreaDefinition` to create a subset area and then get the area extent. Oh yeah, Claude pointed out that this method was on the `BaseDefinition` but was using methods that only existed on the `AreaDefinition`.

I also added type annotations to a helper function when I was confused about how I wanted to replace the internals of this method.

Bottom line: This method has been broken for years, it is being removed.

CC @meteoswiss-mdr who originally added in in #44 (Ulrich)

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
